### PR TITLE
Fixes for various gcc 4.8 compiler warnings

### DIFF
--- a/src/physics/src/heat_transfer.C
+++ b/src/physics/src/heat_transfer.C
@@ -129,18 +129,16 @@ namespace GRINS
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	// Compute the solution & its gradient at the old Newton iterate.
-	libMesh::Number u, v, w;
+	libMesh::Number u, v;
 	u = context.interior_value(_u_var, qp);
 	v = context.interior_value(_v_var, qp);
-	if (_dim == 3)
-	  w = context.interior_value(_w_var, qp);
 
 	libMesh::Gradient grad_T;
 	grad_T = context.interior_gradient(_T_var, qp);
 
 	libMesh::NumberVectorValue U (u,v);
 	if (_dim == 3)
-	  U(2) = w;
+	  U(2) = context.interior_value(_w_var, qp);
 
         const libMesh::Number r = u_qpoint[qp](0);
 

--- a/src/physics/src/inc_navier_stokes.C
+++ b/src/physics/src/inc_navier_stokes.C
@@ -342,12 +342,6 @@ namespace GRINS
     unsigned int n_qpoints = context.element_qrule->n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-        libMesh::Number u;
-        if( _is_axisymmetric )
-          { 
-            u = context.interior_value( _u_var, qp );
-          }
-        
 	// Compute the velocity gradient at the old Newton iterate.
 	libMesh::Gradient grad_u, grad_v, grad_w;
 	grad_u = context.interior_gradient(_u_var, qp);
@@ -365,6 +359,7 @@ namespace GRINS
 
         if( _is_axisymmetric )
           {
+            libMesh::Number u = context.interior_value( _u_var, qp );
             divU += u/r;
             jac *= r;
           }

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -182,30 +182,27 @@ namespace GRINS
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Number u, v, w, T;
+	libMesh::Number u, v, T;
 	u = cache.get_cached_values(Cache::X_VELOCITY)[qp];
 	v = cache.get_cached_values(Cache::Y_VELOCITY)[qp];
-	if (this->_dim == 3)
-	  w = cache.get_cached_values(Cache::Z_VELOCITY)[qp];
 
 	T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
 
 	libMesh::Gradient grad_u = cache.get_cached_gradient_values(Cache::X_VELOCITY_GRAD)[qp];
 	libMesh::Gradient grad_v = cache.get_cached_gradient_values(Cache::Y_VELOCITY_GRAD)[qp];
 
-	libMesh::Gradient grad_w;
-	if (this->_dim == 3)
-	  grad_w = cache.get_cached_gradient_values(Cache::Z_VELOCITY_GRAD)[qp];
-
 	libMesh::Gradient grad_T = cache.get_cached_gradient_values(Cache::TEMPERATURE_GRAD)[qp];
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = w;
+	  U(2) = cache.get_cached_values(Cache::Z_VELOCITY)[qp]; // w
 
 	libMesh::Number divU = grad_u(0) + grad_v(1);
 	if (this->_dim == 3)
-	  divU += grad_w(2);
+          {
+	    libMesh::Gradient grad_w = cache.get_cached_gradient_values(Cache::Z_VELOCITY_GRAD)[qp];
+	    divU += grad_w(2);
+          }
 
 	// Now a loop over the pressure degrees of freedom.  This
 	// computes the contributions of the continuity equation.
@@ -250,11 +247,9 @@ namespace GRINS
     unsigned int n_qpoints = context.element_qrule->n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Number u, v, w, p, p0, T;
+	libMesh::Number u, v, p, p0, T;
 	u = cache.get_cached_values(Cache::X_VELOCITY)[qp];
 	v = cache.get_cached_values(Cache::Y_VELOCITY)[qp];
-	if (this->_dim == 3)
-	  w = cache.get_cached_values(Cache::Z_VELOCITY)[qp];
 
 	T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
 	p = cache.get_cached_values(Cache::PRESSURE)[qp];
@@ -279,7 +274,7 @@ namespace GRINS
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = w;
+	  U(2) = cache.get_cached_values(Cache::Z_VELOCITY)[qp]; // w
 
 	libMesh::Number divU = grad_u(0) + grad_v(1);
 	if (this->_dim == 3)
@@ -404,12 +399,9 @@ namespace GRINS
     unsigned int n_qpoints = context.element_qrule->n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Number u, v, w, T, p0;
+	libMesh::Number u, v, T, p0;
 	u = cache.get_cached_values(Cache::X_VELOCITY)[qp];
 	v = cache.get_cached_values(Cache::Y_VELOCITY)[qp];
-	if (this->_dim == 3)
-	  w = cache.get_cached_values(Cache::Z_VELOCITY)[qp];
-
 	T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
 	p0 = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
 
@@ -417,7 +409,7 @@ namespace GRINS
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = w;
+	  U(2) = cache.get_cached_values(Cache::Z_VELOCITY)[qp]; // w
 
 	libMesh::Number k = this->_k(T);
 	libMesh::Number cp = this->_cp(T);

--- a/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
@@ -242,17 +242,15 @@ namespace GRINS
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Number u, v, w;
+	libMesh::Number u, v;
 	u = context.interior_value(this->_u_var, qp);
 	v = context.interior_value(this->_v_var, qp);
-	if (this->_dim == 3)
-	  w = context.interior_value(this->_w_var, qp);
 
 	libMesh::Gradient grad_T = context.interior_gradient(this->_T_var, qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = w;
+	  U(2) = context.interior_value(this->_w_var, qp); // w
 
 	libMesh::Real T = context.interior_value( this->_T_var, qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -174,17 +174,15 @@ namespace GRINS
 
     libMesh::DenseSubVector<libMesh::Number>& Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
 
-    libMesh::Number u, v, w, T;
+    libMesh::Number u, v, T;
     u = cache.get_cached_values(Cache::X_VELOCITY)[qp];
     v = cache.get_cached_values(Cache::Y_VELOCITY)[qp];
-    if (this->_dim == 3)
-      w = cache.get_cached_values(Cache::Z_VELOCITY)[qp];
     
     T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
 
     libMesh::NumberVectorValue U(u,v);
     if (this->_dim == 3)
-      U(2) = w;
+      U(2) = cache.get_cached_values(Cache::Z_VELOCITY)[qp]; // w
 
     libMesh::Gradient grad_u = cache.get_cached_gradient_values(Cache::X_VELOCITY_GRAD)[qp];
     libMesh::Gradient grad_v = cache.get_cached_gradient_values(Cache::Y_VELOCITY_GRAD)[qp];


### PR DESCRIPTION
This fixes a bunch of "potentially uninitialized variable" warnings with gcc 4.8, greatly improving compiler output clarity, but its effect on code clarity is more debatable.
