### PR TITLE
Sort out LDFLAGS/LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,36 +193,39 @@ if test "$enable_cantera" != no; then
 
    ac_cantera_save_CPPFLAGS="$CPPFLAGS"
    ac_cantera_save_LDFLAGS="$LDFLAGS"
+   ac_cantera_save_LIBS="$LIBS"
 
    CANTERA_PREFIX=$with_cantera
 
    CPPFLAGS="-I$CANTERA_PREFIX/include"
    # v2.0.x with scons
-   LDFLAGS="-L$CANTERA_PREFIX/lib -lcantera_shared"
+   LDFLAGS="-L$CANTERA_PREFIX/lib"
+   LIBS="-lcantera_shared"
    
    if (test -f $CANTERA_PREFIX/lib/libcvode_shared*); then
-      LDFLAGS="$LDFLAGS -lcvode_shared"
+      LIBS="$LIBS -lcvode_shared"
    fi
    if (test -f $CANTERA_PREFIX/lib/libctmath_shared*); then
-      LDFLAGS="$LDFLAGS -lctmath_shared"
+      LIBS="$LIBS -lctmath_shared"
    fi
    if (test -f $CANTERA_PREFIX/lib/libctf2c_shared*); then
-      LDFLAGS="$LDFLAGS -lctf2c_shared"
+      LIBS="$LIBS -lctf2c_shared"
    fi
    if (test -f $CANTERA_PREFIX/lib/libexecstream_shared*); then
-      LDFLAGS="$LDFLAGS -lexecstream_shared"
+      LIBS="$LIBS -lexecstream_shared"
    fi
 
    CANTERA_CPPFLAGS="${CPPFLAGS}"
    CANTERA_LDFLAGS="${LDFLAGS}"
+   CANTERA_LIBS="${LIBS}"
 
    dnl We don't want these in the final link line since we'll already have BLAS
    dnl from PETSC etc., but these are needed for the test to pass.
    if (test -f $CANTERA_PREFIX/lib/libctblas_shared*); then
-      LDFLAGS="$LDFLAGS -lctblas_shared"
+      LIBS="$LIBS -lctblas_shared"
    fi
    if (test -f $CANTERA_PREFIX/lib/libctlapack_shared*); then
-      LDFLAGS="$LDFLAGS -lctlapack_shared"
+      LIBS="$LIBS -lctlapack_shared"
    fi
 
    #--------------------------------------------------------------
@@ -241,17 +244,20 @@ if test "$enable_cantera" != no; then
 
    CPPFLAGS="$ac_cantera_save_CPPFLAGS"
    LDFLAGS="$ac_cantera_save_LDFLAGS"
+   LIBS="$ac_cantera_save_LIBS"
 
    if test "x${found_cantera_library}" = "xyes" ; then
       HAVE_CANTERA=1
       AC_DEFINE(HAVE_CANTERA, 1, [Flag indicating support for Cantera chemistry])
       AC_SUBST(CANTERA_CPPFLAGS)
       AC_SUBST(CANTERA_LDFLAGS)
+      AC_SUBST(CANTERA_LIBS)
       AC_SUBST(CANTERA_PREFIX)
    else
       AC_MSG_NOTICE([Disabling optional Cantera chemistry support])
       CANTERA_CPPFLAGS=""
       CANTERA_LDFLAGS=""
+      CANTERA_LIBS=""
    fi
 fi
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -23,6 +23,7 @@ AM_LDFLAGS =
 if CANTERA_ENABLED
    AM_CPPFLAGS += $(CANTERA_CPPFLAGS)
    AM_LDFLAGS  += $(CANTERA_LDFLAGS)
+   LIBGRINS_LIBS += $(CANTERA_LIBS)
 endif
 
 #----------------
@@ -30,7 +31,7 @@ endif
 #----------------
 if ANTIOCH_ENABLED
    AM_CPPFLAGS += $(ANTIOCH_CPPFLAGS)
-   AM_LDFLAGS  += $(ANTIOCH_PREFIX)/lib/libantioch.la
+   LIBGRINS_LIBS += $(ANTIOCH_PREFIX)/lib/libantioch.la
 endif
 
 #=======================================================================

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -324,12 +324,15 @@ AM_CPPFLAGS += $(BOOST_CPPFLAGS)
 AM_CPPFLAGS += $(LIBMESH_CPPFLAGS)
 AM_CPPFLAGS += $(GRVY_CFLAGS)
 
+AM_LDFLAGS =
+
 #----------------
 # Cantera support
 #----------------
 if CANTERA_ENABLED
    AM_CPPFLAGS += $(CANTERA_CPPFLAGS)
-   libgrins_la_LIBADD  += $(CANTERA_LDFLAGS)
+   AM_LDFLAGS += $(CANTERA_LDFLAGS)
+   libgrins_la_LIBADD  += $(CANTERA_LIBS)
 endif
 
 #----------------
@@ -345,7 +348,7 @@ endif
 #-------------
 if MASA_ENABLED
   AM_CPPFLAGS += $(MASA_CXXFLAGS)
-  AM_LDFLAGS  = $(MASA_LIBS)
+  libgrins_la_LIBADD += $(MASA_LIBS)
 endif
 
 #--------------

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -38,8 +38,10 @@ AM_CPPFLAGS += $(BOOST_CPPFLAGS)
 AM_CPPFLAGS += $(LIBMESH_CPPFLAGS)
 AM_CPPFLAGS += $(GRVY_CFLAGS)
 
+LIBS =
+LIBS += $(LIBGRINS_LIBS)
+
 AM_LDFLAGS = 
-AM_LDFLAGS += $(LIBGRINS_LIBS)
 
 #----------------
 # Cantera support
@@ -47,6 +49,7 @@ AM_LDFLAGS += $(LIBGRINS_LIBS)
 if CANTERA_ENABLED
    AM_CPPFLAGS += $(CANTERA_CPPFLAGS)
    AM_LDFLAGS += $(CANTERA_LDFLAGS)
+   LIBS += $(CANTERA_LIBS)
 endif
 
 #----------------
@@ -54,7 +57,7 @@ endif
 #----------------
 if ANTIOCH_ENABLED
    AM_CPPFLAGS += $(ANTIOCH_CPPFLAGS)
-   AM_LDFLAGS  += $(ANTIOCH_PREFIX)/lib/libantioch.la
+   LIBS += $(ANTIOCH_PREFIX)/lib/libantioch.la
 endif
 
 #--------------
@@ -62,7 +65,7 @@ endif
 #--------------
 if MASA_ENABLED
   AM_CPPFLAGS += $(MASA_CXXFLAGS)
-  AM_LDFLAGS += $(MASA_LIBS)
+  LIBS += $(MASA_LIBS)
 endif
 
 # Sources for these tests


### PR DESCRIPTION
This fixes compilation with Cantera on Linux for me.  It needs to be
tested on OSX before being committed just in case I regressed
something there.
