### PR TITLE
Restore link_all_deplibs on Debian/Ubuntu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -399,6 +399,9 @@ AC_CONFIG_FILES([Makefile src/Makefile test/Makefile doxygen/Makefile
 # Must still call AC_OUTPUT() after generating all the files
 AC_OUTPUT()
 
+dnl Hackish fix for Ubuntu/Debian libtool
+perl -pi -e 's/link_all_deplibs=no/link_all_deplibs=yes/' libtool
+
 dnl------------------------------
 dnl Final summary
 dnl------------------------------


### PR DESCRIPTION
Pro: this patch fixes #4, so can we work out of the box with Debian/Ubuntu libtool now.

Con: this patch makes bile rise up in the back of my throat.

I tried setting link_all_deplibs in a few places, but nothing propagated through to the generated libtool copy, so I'm resorting to a perl search-and-replace right after libtool is output.

It might be more portable to use sed here, but we're already using perl in update_license.pl anyway.
