### PR TITLE
Fixes for make dist.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,8 @@ EXTRA_DIST       = README.md CHANGES LICENSE COPYING docs contrib
 aclocaldir = $(prefix)/share/aclocal
 aclocal_DATA = $(top_srcdir)/share/aclocal/*
 
+EXTRA_DIST += $(aclocal_DATA)
+
 #doxygendir = $(prefix)/doxygen
 #doxygen_DATA = $(top_srcdir)/docs/doxygen/GRINS.tag
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -54,6 +54,8 @@ toyprob_DATA = $(top_srcdir)/examples/toyprob/toy.in
 toy_SOURCES = $(top_srcdir)/examples/toyprob/toy.C
 toy_LDADD = $(LIBGRINS_LIBS)
 
+EXTRA_DIST += $(toyprob_DATA)
+
 #=======================================================================
 # Cavity Benchmark
 #=======================================================================
@@ -132,6 +134,8 @@ rlmnsex_DATA += $(top_srcdir)/examples/reacting_flow/air_2sp.xml
 rlmns_SOURCES = $(top_srcdir)/examples/reacting_flow/rlmns.C
 rlmns_LDADD = $(LIBGRINS_LIBS)
 
+EXTRA_DIST += $(rlmnsex_DATA)
+
 #=======================================================================
 # Vortex Example
 #=======================================================================
@@ -151,6 +155,11 @@ laminarflame_PROGRAMS = bunsen
 laminarflame_DATA  = $(top_srcdir)/examples/laminar_flame/bunsen.in
 laminarflame_DATA += $(top_srcdir)/examples/laminar_flame/elements.xml
 laminarflame_DATA += $(top_srcdir)/examples/laminar_flame/bunsen.xml
+laminarflame_DATA += $(top_srcdir)/examples/laminar_flame/ignite_initial_guess.h
+laminarflame_DATA += $(top_srcdir)/examples/laminar_flame/constant_with_exp_layer.h 
+laminarflame_DATA += $(top_srcdir)/examples/laminar_flame/bunsen_source.h 
+
+EXTRA_DIST += $(laminarflame_DATA)
 
 bunsen_SOURCES  = $(top_srcdir)/examples/laminar_flame/bunsen.C
 bunsen_SOURCES += $(top_srcdir)/examples/laminar_flame/constant_with_exp_layer.C

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -134,7 +134,16 @@ libgrins_la_SOURCES += $(top_srcdir)/src/visualization/src/postprocessing_factor
 # This is for installing .C files that are needed for instantiating
 # with different template parameters in user code
 sfilesdir = $(prefix)/src
-sfiles_DATA = $(top_srcdir)/src/physics/src/axisym_heat_transfer.C
+sfiles_DATA  = $(top_srcdir)/src/physics/src/axisym_heat_transfer.C
+sfiles_DATA += $(top_srcdir)/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
+sfiles_DATA += $(top_srcdir)/src/boundary_conditions/src/catalytic_wall.C
+sfiles_DATA += $(top_srcdir)/src/physics/src/reacting_low_mach_navier_stokes_base.C
+sfiles_DATA += $(top_srcdir)/src/physics/src/reacting_low_mach_navier_stokes.C
+sfiles_DATA += $(top_srcdir)/src/properties/src/antioch_evaluator.C
+sfiles_DATA += $(top_srcdir)/src/properties/src/antioch_wilke_transport_mixture.C
+sfiles_DATA += $(top_srcdir)/src/properties/src/antioch_wilke_transport_evaluator.C
+sfiles_DATA += $(top_srcdir)/src/properties/src/antioch_constant_transport_mixture.C
+sfiles_DATA += $(top_srcdir)/src/properties/src/antioch_constant_transport_evaluator.C
 
 #----------------------------
 #INCLUDES we want distributed
@@ -369,7 +378,8 @@ STAMPED_FILES += $(top_srcdir)/src/apps/cantera_kinetic_rates.C
 	$(top_srcdir)/src/common/lic_utils/update_license.pl $(top_srcdir)/LICENSE $(STAMPED_FILES)
 	echo 'updated source license headers' >$@
 
-EXTRA_DIST = common
+EXTRA_DIST  = common
+EXTRA_DIST += $(sfiles_DATA)
 
 # Required for AX_AM_MACROS
 ###@INC_AMINCLUDE@


### PR DESCRIPTION
Hadn't done make dist for awhile and it got stale. Main thing here is to note that for templated classes that I've either needed to extend or anticipate user extension, we do two things: 1. We only build an "something_instantiate.C" file that #include file.C (I've opted for this over putting everything in the header in these complex classes). This prevents compiling the same file multiple times, but we have to be sure to... 2. Install and EXTRA_DIST the appropriate file.C files needed to extend the templated classes.

Note that make distcheck isn't working for me, but manually testing works. Opening a different issue for that.
