### PR TITLE
Fixes for make distcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,18 +43,18 @@ AUX_DIST        += build-aux/depcomp
 AUX_DIST        += build-aux/ltmain.sh
 
 # Additional files to be deleted by 'make distclean'
-DISTCLEANFILES = _configs.sed
+DISTCLEANFILES  = _configs.sed
+DISTCLEANFILES += config.log
+DISTCLEANFILES += grins_config.h
 
 # Files to be deleted by 'make maintainer-clean'
 MAINTAINERCLEANFILES = aclocal.m4                               \
                        aminclude.am                             \
                        autom4te.cache/*                         \
                        $(AUX_DIST)                              \
-                       config.log                               \
                        config.status                            \
                        config.sub                               \
                        configure                                \
-                       grins_config.h                           \
                        grins_config.h.tmp.in                    \
                        grins_config.h.tmp.in~                   \
                        Makefile.in                              \

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,4 +1,7 @@
 BUILT_SOURCES   = .license.stamp
+
+CLEANFILES = .license.stamp
+
 EXTRA_DIST =
 
 AM_CPPFLAGS = 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,7 @@
 BUILT_SOURCES   = .license.stamp
 
+CLEANFILES = .license.stamp
+
 #----------------------------------------
 # Programs and libraries we want to build
 #----------------------------------------
@@ -365,7 +367,7 @@ endif
 # Code coverage
 #--------------
 if CODE_COVERAGE_ENABLED
-  CLEANFILES = *.gcda *.gcno
+  CLEANFILES += *.gcda *.gcno
 endif
 
 #---------------------------------

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,7 @@
 BUILT_SOURCES   = .license.stamp
 
+CLEANFILES = .license.stamp
+
 check_PROGRAMS =
 check_PROGRAMS += test_ns_couette_flow_2d_x
 check_PROGRAMS += test_ns_couette_flow_2d_y
@@ -190,7 +192,7 @@ shellfiles_src += reacting_low_mach_antioch_statmech_blottner_eucken_lewis_catal
 EXTRA_DIST = $(shellfiles_src) input_files test_data grids
 
 if CODE_COVERAGE_ENABLED
-  CLEANFILES = *.gcda *.gcno
+  CLEANFILES += *.gcda *.gcno
 endif
 
 .license.stamp: $(top_srcdir)/LICENSE


### PR DESCRIPTION
make distcheck now finishes successfully for me _if_ I have LIBMESH_DIR set. This is a separate issue that I will deal with later (basically --with-libmesh needs to be passed to DISTCHECK_CONFIGURE_FLAGS, but need to play with/decide on whether to go the boost.m4 route and put it directly in there or do AM_DISTCHECK_CONFIGURE_FLAGS in the Makefile.am)
