### PR TITLE
Automated API update, libMesh master compatibility

### DIFF
--- a/examples/laminar_flame/bunsen_source.C
+++ b/examples/laminar_flame/bunsen_source.C
@@ -83,21 +83,21 @@ namespace Bunsen
 #endif
   
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_T_var]->get_JxW();
+      context.get_element_fe(_T_var)->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.element_fe_var[_T_var]->get_phi();
+      context.get_element_fe(_T_var)->get_phi();
 
     // Locations of quadrature points
-    const std::vector<libMesh::Point>& x_qp = context.element_fe_var[_T_var]->get_xyz();
+    const std::vector<libMesh::Point>& x_qp = context.get_element_fe(_T_var)->get_xyz();
 
     // Get residuals
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(_T_var); // R_{T}
 
     // Now we will build the element Jacobian and residual.
     // Constructing the residual requires the solution and its
@@ -105,7 +105,7 @@ namespace Bunsen
     // calculated at each quadrature point by summing the
     // solution degree-of-freedom values by the appropriate
     // weight functions.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
     
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {

--- a/src/boundary_conditions/src/boundary_conditions.C
+++ b/src/boundary_conditions/src/boundary_conditions.C
@@ -59,20 +59,20 @@ namespace GRINS
 					  const libMesh::Point& value ) const
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_var_dofs = context.dof_indices_var[var].size();
+    const unsigned int n_var_dofs = context.get_dof_indices(var).size();
 
     // Element Jacobian * quadrature weight for side integration.
-    const std::vector<libMesh::Real> &JxW_side = context.side_fe_var[var]->get_JxW();
+    const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(var)->get_JxW();
 
     // The var shape functions at side quadrature points.
     const std::vector<std::vector<libMesh::Real> >& var_phi_side =
-      context.side_fe_var[var]->get_phi();
+      context.get_side_fe(var)->get_phi();
 
-    const std::vector<libMesh::Point> &normals = context.side_fe_var[var]->get_normals();
+    const std::vector<libMesh::Point> &normals = context.get_side_fe(var)->get_normals();
 
-    libMesh::DenseSubVector<libMesh::Number> &F_var = *context.elem_subresiduals[var]; // residual
+    libMesh::DenseSubVector<libMesh::Number> &F_var = context.get_elem_residual(var); // residual
 
-    unsigned int n_qpoints = context.side_qrule->n_points();
+    unsigned int n_qpoints = context.get_side_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	for (unsigned int i=0; i != n_var_dofs; i++)
@@ -90,18 +90,18 @@ namespace GRINS
 							libMesh::Real value ) const
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_var_dofs = context.dof_indices_var[var].size();
+    const unsigned int n_var_dofs = context.get_dof_indices(var).size();
 
     // Element Jacobian * quadrature weight for side integration.
-    const std::vector<libMesh::Real> &JxW_side = context.side_fe_var[var]->get_JxW();
+    const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(var)->get_JxW();
 
     // The var shape functions at side quadrature points.
     const std::vector<std::vector<libMesh::Real> >& var_phi_side =
-      context.side_fe_var[var]->get_phi();
+      context.get_side_fe(var)->get_phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &F_var = *context.elem_subresiduals[var]; // residual
+    libMesh::DenseSubVector<libMesh::Number> &F_var = context.get_elem_residual(var); // residual
 
-    unsigned int n_qpoints = context.side_qrule->n_points();
+    unsigned int n_qpoints = context.get_side_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	for (unsigned int i=0; i != n_var_dofs; i++)
@@ -119,22 +119,22 @@ namespace GRINS
                                                                      libMesh::Real value ) const
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_var_dofs = context.dof_indices_var[var].size();
+    const unsigned int n_var_dofs = context.get_dof_indices(var).size();
 
     // Element Jacobian * quadrature weight for side integration.
-    const std::vector<libMesh::Real> &JxW_side = context.side_fe_var[var]->get_JxW();
+    const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(var)->get_JxW();
 
     // The var shape functions at side quadrature points.
     const std::vector<std::vector<libMesh::Real> >& var_phi_side =
-      context.side_fe_var[var]->get_phi();
+      context.get_side_fe(var)->get_phi();
 
     // Physical location of the quadrature points
     const std::vector<libMesh::Point>& var_qpoint =
-      context.side_fe_var[var]->get_xyz();
+      context.get_side_fe(var)->get_xyz();
 
-    libMesh::DenseSubVector<libMesh::Number> &F_var = *context.elem_subresiduals[var]; // residual
+    libMesh::DenseSubVector<libMesh::Number> &F_var = context.get_elem_residual(var); // residual
 
-    unsigned int n_qpoints = context.side_qrule->n_points();
+    unsigned int n_qpoints = context.get_side_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
         const libMesh::Number r = var_qpoint[qp](0);
@@ -155,24 +155,24 @@ namespace GRINS
 						       const libMesh::Point& value ) const
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_var_dofs = context.dof_indices_var[var].size();
+    const unsigned int n_var_dofs = context.get_dof_indices(var).size();
 
     // Element Jacobian * quadrature weight for side integration.
-    const std::vector<libMesh::Real> &JxW_side = context.side_fe_var[var]->get_JxW();
+    const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(var)->get_JxW();
 
     // The var shape functions at side quadrature points.
     const std::vector<std::vector<libMesh::Real> >& var_phi_side =
-      context.side_fe_var[var]->get_phi();
+      context.get_side_fe(var)->get_phi();
 
     // Physical location of the quadrature points
     const std::vector<libMesh::Point>& var_qpoint =
-      context.side_fe_var[var]->get_xyz();
+      context.get_side_fe(var)->get_xyz();
 
-    const std::vector<libMesh::Point> &normals = context.side_fe_var[var]->get_normals();
+    const std::vector<libMesh::Point> &normals = context.get_side_fe(var)->get_normals();
 
-    libMesh::DenseSubVector<libMesh::Number> &F_var = *context.elem_subresiduals[var]; // residual
+    libMesh::DenseSubVector<libMesh::Number> &F_var = context.get_elem_residual(var); // residual
 
-    unsigned int n_qpoints = context.side_qrule->n_points();
+    unsigned int n_qpoints = context.get_side_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	const libMesh::Number r = var_qpoint[qp](0);
@@ -194,21 +194,21 @@ namespace GRINS
 					  const std::tr1::shared_ptr<NeumannFuncObj> neumann_func ) const
   {
     // The number of local degrees of freedom
-    const unsigned int n_var_dofs = context.dof_indices_var[var].size();
+    const unsigned int n_var_dofs = context.get_dof_indices(var).size();
   
     // Element Jacobian * quadrature weight for side integration.
-    const std::vector<libMesh::Real> &JxW_side = context.side_fe_var[var]->get_JxW();
+    const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(var)->get_JxW();
 
     // The var shape functions at side quadrature points.
     const std::vector<std::vector<libMesh::Real> >& var_phi_side =
-      context.side_fe_var[var]->get_phi();
+      context.get_side_fe(var)->get_phi();
 
-    const std::vector<libMesh::Point> &normals = context.side_fe_var[var]->get_normals();
+    const std::vector<libMesh::Point> &normals = context.get_side_fe(var)->get_normals();
 
-    libMesh::DenseSubVector<libMesh::Number> &F_var = *context.elem_subresiduals[var]; // residual
-    libMesh::DenseSubMatrix<libMesh::Number> &K_var = *context.elem_subjacobians[var][var]; // jacobian
+    libMesh::DenseSubVector<libMesh::Number> &F_var = context.get_elem_residual(var); // residual
+    libMesh::DenseSubMatrix<libMesh::Number> &K_var = context.get_elem_jacobian(var, var); // jacobian
 
-    unsigned int n_qpoints = context.side_qrule->n_points();
+    unsigned int n_qpoints = context.get_side_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -240,11 +240,11 @@ namespace GRINS
 	     var2 != other_jac_vars.end();
 	     var2++ )
 	  {
-            libMesh::DenseSubMatrix<libMesh::Number> &K_var2 = *context.elem_subjacobians[var][*var2]; // jacobian
+            libMesh::DenseSubMatrix<libMesh::Number> &K_var2 = context.get_elem_jacobian(var, *var2); // jacobian
 
-	    const unsigned int n_var2_dofs = context.dof_indices_var[*var2].size();
+	    const unsigned int n_var2_dofs = context.get_dof_indices(*var2).size();
 	    const std::vector<std::vector<libMesh::Real> >& var2_phi_side =
-	      context.side_fe_var[*var2]->get_phi();
+	      context.get_side_fe(*var2)->get_phi();
 
 	    for (unsigned int qp=0; qp != n_qpoints; qp++)
 	      {
@@ -272,19 +272,19 @@ namespace GRINS
 							const std::tr1::shared_ptr<GRINS::NeumannFuncObj> neumann_func ) const
   {
     // The number of local degrees of freedom
-    const unsigned int n_var_dofs = context.dof_indices_var[var].size();
+    const unsigned int n_var_dofs = context.get_dof_indices(var).size();
   
     // Element Jacobian * quadrature weight for side integration.
-    const std::vector<libMesh::Real> &JxW_side = context.side_fe_var[var]->get_JxW();
+    const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(var)->get_JxW();
 
     // The var shape functions at side quadrature points.
     const std::vector<std::vector<libMesh::Real> >& var_phi_side =
-      context.side_fe_var[var]->get_phi();
+      context.get_side_fe(var)->get_phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &F_var = *context.elem_subresiduals[var]; // residual
-    libMesh::DenseSubMatrix<libMesh::Number> &K_var = *context.elem_subjacobians[var][var]; // jacobian
+    libMesh::DenseSubVector<libMesh::Number> &F_var = context.get_elem_residual(var); // residual
+    libMesh::DenseSubMatrix<libMesh::Number> &K_var = context.get_elem_jacobian(var, var); // jacobian
 
-    unsigned int n_qpoints = context.side_qrule->n_points();
+    unsigned int n_qpoints = context.get_side_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -316,11 +316,11 @@ namespace GRINS
 	     var2 != other_jac_vars.end();
 	     var2++ )
 	  {
-            libMesh::DenseSubMatrix<libMesh::Number> &K_var2 = *context.elem_subjacobians[var][*var2]; // jacobian
+            libMesh::DenseSubMatrix<libMesh::Number> &K_var2 = context.get_elem_jacobian(var, *var2); // jacobian
             
-	    const unsigned int n_var2_dofs = context.dof_indices_var[*var2].size();
+	    const unsigned int n_var2_dofs = context.get_dof_indices(*var2).size();
 	    const std::vector<std::vector<libMesh::Real> >& var2_phi_side =
-	      context.side_fe_var[*var2]->get_phi();
+	      context.get_side_fe(*var2)->get_phi();
 
 	    for (unsigned int qp=0; qp != n_qpoints; qp++)
 	      {
@@ -348,23 +348,23 @@ namespace GRINS
                                                                      const std::tr1::shared_ptr<GRINS::NeumannFuncObj> neumann_func ) const
   {
     // The number of local degrees of freedom
-    const unsigned int n_var_dofs = context.dof_indices_var[var].size();
+    const unsigned int n_var_dofs = context.get_dof_indices(var).size();
   
     // Element Jacobian * quadrature weight for side integration.
-    const std::vector<libMesh::Real> &JxW_side = context.side_fe_var[var]->get_JxW();
+    const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(var)->get_JxW();
 
     // The var shape functions at side quadrature points.
     const std::vector<std::vector<libMesh::Real> >& var_phi_side =
-      context.side_fe_var[var]->get_phi();
+      context.get_side_fe(var)->get_phi();
 
     // Physical location of the quadrature points
     const std::vector<libMesh::Point>& var_qpoint =
-      context.side_fe_var[var]->get_xyz();
+      context.get_side_fe(var)->get_xyz();
     
-    libMesh::DenseSubVector<libMesh::Number> &F_var = *context.elem_subresiduals[var]; // residual
-    libMesh::DenseSubMatrix<libMesh::Number> &K_var = *context.elem_subjacobians[var][var]; // jacobian
+    libMesh::DenseSubVector<libMesh::Number> &F_var = context.get_elem_residual(var); // residual
+    libMesh::DenseSubMatrix<libMesh::Number> &K_var = context.get_elem_jacobian(var, var); // jacobian
 
-    unsigned int n_qpoints = context.side_qrule->n_points();
+    unsigned int n_qpoints = context.get_side_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -398,11 +398,11 @@ namespace GRINS
 	     var2 != other_jac_vars.end();
 	     var2++ )
 	  {
-            libMesh::DenseSubMatrix<libMesh::Number> &K_var2 = *context.elem_subjacobians[var][*var2]; // jacobian
+            libMesh::DenseSubMatrix<libMesh::Number> &K_var2 = context.get_elem_jacobian(var, *var2); // jacobian
 
-	    const unsigned int n_var2_dofs = context.dof_indices_var[*var2].size();
+	    const unsigned int n_var2_dofs = context.get_dof_indices(*var2).size();
 	    const std::vector<std::vector<libMesh::Real> >& var2_phi_side =
-	      context.side_fe_var[*var2]->get_phi();
+	      context.get_side_fe(*var2)->get_phi();
 
 	    for (unsigned int qp=0; qp != n_qpoints; qp++)
 	      {
@@ -434,25 +434,25 @@ namespace GRINS
 							      std::tr1::shared_ptr<GRINS::NeumannFuncObj> neumann_func ) const
   {
     // The number of local degrees of freedom
-    const unsigned int n_var_dofs = context.dof_indices_var[var].size();
+    const unsigned int n_var_dofs = context.get_dof_indices(var).size();
   
     // Element Jacobian * quadrature weight for side integration.
-    const std::vector<libMesh::Real> &JxW_side = context.side_fe_var[var]->get_JxW();
+    const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(var)->get_JxW();
 
     // The var shape functions at side quadrature points.
     const std::vector<std::vector<libMesh::Real> >& var_phi_side =
-      context.side_fe_var[var]->get_phi();
+      context.get_side_fe(var)->get_phi();
 
     // Physical location of the quadrature points
     const std::vector<libMesh::Point>& var_qpoint =
-      context.side_fe_var[var]->get_xyz();
+      context.get_side_fe(var)->get_xyz();
 
-    const std::vector<libMesh::Point> &normals = context.side_fe_var[var]->get_normals();
+    const std::vector<libMesh::Point> &normals = context.get_side_fe(var)->get_normals();
 
-    libMesh::DenseSubVector<libMesh::Number> &F_var = *context.elem_subresiduals[var]; // residual
-    libMesh::DenseSubMatrix<libMesh::Number> &K_var = *context.elem_subjacobians[var][var]; // jacobian
+    libMesh::DenseSubVector<libMesh::Number> &F_var = context.get_elem_residual(var); // residual
+    libMesh::DenseSubMatrix<libMesh::Number> &K_var = context.get_elem_jacobian(var, var); // jacobian
 
-    unsigned int n_qpoints = context.side_qrule->n_points();
+    unsigned int n_qpoints = context.get_side_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -486,11 +486,11 @@ namespace GRINS
 	     var2 != other_jac_vars.end();
 	     var2++ )
 	  {
-            libMesh::DenseSubMatrix<libMesh::Number> &K_var2 = *context.elem_subjacobians[var][*var2]; // jacobian
+            libMesh::DenseSubMatrix<libMesh::Number> &K_var2 = context.get_elem_jacobian(var, *var2); // jacobian
 
-	    const unsigned int n_var2_dofs = context.dof_indices_var[*var2].size();
+	    const unsigned int n_var2_dofs = context.get_dof_indices(*var2).size();
 	    const std::vector<std::vector<libMesh::Real> >& var2_phi_side =
-	      context.side_fe_var[*var2]->get_phi();
+	      context.get_side_fe(*var2)->get_phi();
 
 	    for (unsigned int qp=0; qp != n_qpoints; qp++)
 	      {
@@ -520,35 +520,35 @@ namespace GRINS
 				      const libMesh::Point& pin_location, 
 				      const double penalty )
   {
-    if (context.elem->contains_point(pin_location))
+    if (context.get_elem().contains_point(pin_location))
       {
-	libMesh::DenseSubVector<libMesh::Number> &F_var = *context.elem_subresiduals[var]; // residual
-	libMesh::DenseSubMatrix<libMesh::Number> &K_var = *context.elem_subjacobians[var][var]; // jacobian
+	libMesh::DenseSubVector<libMesh::Number> &F_var = context.get_elem_residual(var); // residual
+	libMesh::DenseSubMatrix<libMesh::Number> &K_var = context.get_elem_jacobian(var, var); // jacobian
 
 	// The number of local degrees of freedom in p variable.
-	const unsigned int n_var_dofs = context.dof_indices_var[var].size();
+	const unsigned int n_var_dofs = context.get_dof_indices(var).size();
 
 	libMesh::Number var_value = context.point_value(var, pin_location);
 
-	libMesh::FEType fe_type = context.element_fe_var[var]->get_fe_type();
+	libMesh::FEType fe_type = context.get_element_fe(var)->get_fe_type();
       
 	libMesh::Point point_loc_in_masterelem = 
-	  libMesh::FEInterface::inverse_map(context.dim, fe_type, context.elem, pin_location);
+	  libMesh::FEInterface::inverse_map(context.get_dim(), fe_type, &context.get_elem(), pin_location);
 
 	std::vector<libMesh::Real> phi(n_var_dofs);
 
 	for (unsigned int i=0; i != n_var_dofs; i++)
-	  phi[i] = libMesh::FEInterface::shape( context.dim, fe_type, context.elem, i, 
+	  phi[i] = libMesh::FEInterface::shape( context.get_dim(), fe_type, &context.get_elem(), i, 
 						point_loc_in_masterelem );
       
 	for (unsigned int i=0; i != n_var_dofs; i++)
 	  {
 	    F_var(i) += penalty*(var_value - pin_value)*phi[i];
 	  
-	    /** \todo What the hell is the context.elem_solution_derivative all about? */
-	    if (request_jacobian && context.elem_solution_derivative)
+	    /** \todo What the hell is the context.get_elem_solution_derivative() all about? */
+	    if (request_jacobian && context.get_elem_solution_derivative())
 	      {
-		libmesh_assert (context.elem_solution_derivative == 1.0);
+		libmesh_assert (context.get_elem_solution_derivative() == 1.0);
 	      
 		for (unsigned int j=0; j != n_var_dofs; j++)
 		  K_var(i,j) += penalty*phi[i]*phi[j];

--- a/src/boundary_conditions/src/pressure_pinning.C
+++ b/src/boundary_conditions/src/pressure_pinning.C
@@ -75,35 +75,35 @@ namespace GRINS
     /** \todo pin_location needs to be const. Currently a libMesh restriction. */
     libMesh::FEMContext &c = libMesh::libmesh_cast_ref<libMesh::FEMContext&>(context);
 
-    if (c.elem->contains_point(_pin_location))
+    if (c.get_elem().contains_point(_pin_location))
       {
-	libMesh::DenseSubVector<libMesh::Number> &F_var = *c.elem_subresiduals[var]; // residual
-	libMesh::DenseSubMatrix<libMesh::Number> &K_var = *c.elem_subjacobians[var][var]; // jacobian
+	libMesh::DenseSubVector<libMesh::Number> &F_var = c.get_elem_residual(var); // residual
+	libMesh::DenseSubMatrix<libMesh::Number> &K_var = c.get_elem_jacobian(var, var); // jacobian
 
 	// The number of local degrees of freedom in p variable.
-	const unsigned int n_var_dofs = c.dof_indices_var[var].size();
+	const unsigned int n_var_dofs = c.get_dof_indices(var).size();
 
 	libMesh::Number var_value = c.point_value(var, _pin_location);
 
-	libMesh::FEType fe_type = c.element_fe_var[var]->get_fe_type();
+	libMesh::FEType fe_type = c.get_element_fe(var)->get_fe_type();
       
 	libMesh::Point point_loc_in_masterelem = 
-	  libMesh::FEInterface::inverse_map(c.dim, fe_type, c.elem, _pin_location);
+	  libMesh::FEInterface::inverse_map(c.get_dim(), fe_type, &c.get_elem(), _pin_location);
 
 	std::vector<libMesh::Real> phi(n_var_dofs);
 
 	for (unsigned int i=0; i != n_var_dofs; i++)
-	  phi[i] = libMesh::FEInterface::shape( c.dim, fe_type, c.elem, i, 
+	  phi[i] = libMesh::FEInterface::shape( c.get_dim(), fe_type, &c.get_elem(), i, 
 						point_loc_in_masterelem );
       
 	for (unsigned int i=0; i != n_var_dofs; i++)
 	  {
 	    F_var(i) += penalty*(var_value - _pin_value)*phi[i];
 	  
-	    /** \todo What the hell is the c.elem_solution_derivative all about? */
-	    if (request_jacobian && c.elem_solution_derivative)
+	    /** \todo What the hell is the c.get_elem_solution_derivative() all about? */
+	    if (request_jacobian && c.get_elem_solution_derivative())
 	      {
-		libmesh_assert (c.elem_solution_derivative == 1.0);
+		libmesh_assert (c.get_elem_solution_derivative() == 1.0);
 	      
 		for (unsigned int j=0; j != n_var_dofs; j++)
 		  K_var(i,j) += penalty*phi[i]*phi[j];

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -100,32 +100,32 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[_u_r_var].size();
-    const unsigned int n_T_dofs = context.dof_indices_var[_T_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(_u_r_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_u_r_var]->get_JxW();
+      context.get_element_fe(_u_r_var)->get_JxW();
 
     // The velocity shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& vel_phi =
-      context.element_fe_var[_u_r_var]->get_phi();
+      context.get_element_fe(_u_r_var)->get_phi();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.element_fe_var[_T_var]->get_phi();
+      context.get_element_fe(_T_var)->get_phi();
 
     // Physical location of the quadrature points
     const std::vector<libMesh::Point>& u_qpoint =
-      context.element_fe_var[_u_r_var]->get_xyz();
+      context.get_element_fe(_u_r_var)->get_xyz();
 
     // Get residuals
-    libMesh::DenseSubVector<Number> &Fr = *context.elem_subresiduals[_u_r_var]; // R_{r}
-    libMesh::DenseSubVector<Number> &Fz = *context.elem_subresiduals[_u_z_var]; // R_{z}
+    libMesh::DenseSubVector<Number> &Fr = context.get_elem_residual(_u_r_var); // R_{r}
+    libMesh::DenseSubVector<Number> &Fz = context.get_elem_residual(_u_z_var); // R_{z}
 
     // Get Jacobians
-    libMesh::DenseSubMatrix<Number> &KrT = *context.elem_subjacobians[_u_r_var][_T_var]; // R_{r},{T}
-    libMesh::DenseSubMatrix<Number> &KzT = *context.elem_subjacobians[_u_z_var][_T_var]; // R_{z},{T}
+    libMesh::DenseSubMatrix<Number> &KrT = context.get_elem_jacobian(_u_r_var, _T_var); // R_{r},{T}
+    libMesh::DenseSubMatrix<Number> &KzT = context.get_elem_jacobian(_u_z_var, _T_var); // R_{z},{T}
 
     // Now we will build the element Jacobian and residual.
     // Constructing the residual requires the solution and its
@@ -133,7 +133,7 @@ namespace GRINS
     // calculated at each quadrature point by summing the
     // solution degree-of-freedom values by the appropriate
     // weight functions.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -151,9 +151,9 @@ namespace GRINS
 	    Fr(i) += -_rho_ref*_beta_T*(T - _T_ref)*_g(0)*vel_phi[i][qp]*r*JxW[qp];
 	    Fz(i) += -_rho_ref*_beta_T*(T - _T_ref)*_g(1)*vel_phi[i][qp]*r*JxW[qp];
 
-	    if (compute_jacobian && context.elem_solution_derivative)
+	    if (compute_jacobian && context.get_elem_solution_derivative())
 	      {
-		libmesh_assert (context.elem_solution_derivative == 1.0);
+		libmesh_assert (context.get_elem_solution_derivative() == 1.0);
 		for (unsigned int j=0; j != n_T_dofs; j++)
 		  {
 		    KrT(i,j) += -_rho_ref*_beta_T*_g(0)*vel_phi[i][qp]*T_phi[j][qp]*r*JxW[qp];

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -120,15 +120,15 @@ namespace GRINS
     // We should prerequest all the data
     // we will need to build the linear system
     // or evaluate a quantity of interest.
-    context.element_fe_var[_T_var]->get_JxW();
-    context.element_fe_var[_T_var]->get_phi();
-    context.element_fe_var[_T_var]->get_dphi();
-    context.element_fe_var[_T_var]->get_xyz();
+    context.get_element_fe(_T_var)->get_JxW();
+    context.get_element_fe(_T_var)->get_phi();
+    context.get_element_fe(_T_var)->get_dphi();
+    context.get_element_fe(_T_var)->get_xyz();
 
-    context.side_fe_var[_T_var]->get_JxW();
-    context.side_fe_var[_T_var]->get_phi();
-    context.side_fe_var[_T_var]->get_dphi();
-    context.side_fe_var[_T_var]->get_xyz();
+    context.get_side_fe(_T_var)->get_JxW();
+    context.get_side_fe(_T_var)->get_phi();
+    context.get_side_fe(_T_var)->get_dphi();
+    context.get_side_fe(_T_var)->get_xyz();
 
     // _u_var is registered so can we assume things related to _u_var
     // are available in FEMContext
@@ -146,8 +146,8 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[_T_var].size();
-    const unsigned int n_u_dofs = context.dof_indices_var[_u_r_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(_T_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(_u_r_var).size();
 
     //TODO: check n_T_dofs is same as n_u_dofs, n_v_dofs, n_w_dofs
 
@@ -156,32 +156,32 @@ namespace GRINS
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_T_var]->get_JxW();
+      context.get_element_fe(_T_var)->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.element_fe_var[_T_var]->get_phi();
+      context.get_element_fe(_T_var)->get_phi();
 
     // The velocity shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& vel_phi =
-      context.element_fe_var[_u_r_var]->get_phi();
+      context.get_element_fe(_u_r_var)->get_phi();
 
     // The temperature shape function gradients (in global coords.)
     // at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[_T_var]->get_dphi();
+      context.get_element_fe(_T_var)->get_dphi();
 
     // Physical location of the quadrature points
     const std::vector<libMesh::Point>& u_qpoint =
-      context.element_fe_var[_u_r_var]->get_xyz();
+      context.get_element_fe(_u_r_var)->get_xyz();
 
     // The subvectors and submatrices we need to fill:
-    libMesh::DenseSubVector<Number> &FT = *context.elem_subresiduals[_T_var]; // R_{T}
+    libMesh::DenseSubVector<Number> &FT = context.get_elem_residual(_T_var); // R_{T}
 
-    libMesh::DenseSubMatrix<Number> &KTT = *context.elem_subjacobians[_T_var][_T_var]; // R_{T},{T}
+    libMesh::DenseSubMatrix<Number> &KTT = context.get_elem_jacobian(_T_var, _T_var); // R_{T},{T}
 
-    libMesh::DenseSubMatrix<Number> &KTr = *context.elem_subjacobians[_T_var][_u_r_var]; // R_{T},{r}
-    libMesh::DenseSubMatrix<Number> &KTz = *context.elem_subjacobians[_T_var][_u_z_var]; // R_{T},{z}
+    libMesh::DenseSubMatrix<Number> &KTr = context.get_elem_jacobian(_T_var, _u_r_var); // R_{T},{r}
+    libMesh::DenseSubMatrix<Number> &KTz = context.get_elem_jacobian(_T_var, _u_z_var); // R_{T},{z}
 
 
     // Now we will build the element Jacobian and residual.
@@ -190,7 +190,7 @@ namespace GRINS
     // calculated at each quadrature point by summing the
     // solution degree-of-freedom values by the appropriate
     // weight functions.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -217,9 +217,9 @@ namespace GRINS
 	      (-_rho*_Cp*T_phi[i][qp]*(U*grad_T)    // convection term
 	       -k*(T_gradphi[i][qp]*grad_T) );  // diffusion term
 
-	    if (compute_jacobian && context.elem_solution_derivative)
+	    if (compute_jacobian && context.get_elem_solution_derivative())
 	      {
-		libmesh_assert (context.elem_solution_derivative == 1.0);
+		libmesh_assert (context.get_elem_solution_derivative() == 1.0);
 
 		for (unsigned int j=0; j != n_T_dofs; j++)
 		  {
@@ -247,7 +247,7 @@ namespace GRINS
 		    KTz(i,j) += JxW[qp]*r*(-_rho*_Cp*T_phi[i][qp]*(vel_phi[j][qp]*grad_T(1)));
 		  } // end of the inner dof (j) loop
 
-	      } // end - if (compute_jacobian && context.elem_solution_derivative)
+	      } // end - if (compute_jacobian && context.get_elem_solution_derivative())
 
 	  } // end of the outer dof (i) loop
       } // end of the quadrature point (qp) loop
@@ -299,25 +299,25 @@ namespace GRINS
 
     // Element Jacobian * quadrature weights for interior integration
     const std::vector<Real> &JxW = 
-      context.element_fe_var[_T_var]->get_JxW();
+      context.get_element_fe(_T_var)->get_JxW();
 
     // The shape functions at interior quadrature points.
     const std::vector<std::vector<Real> >& phi = 
-      context.element_fe_var[_T_var]->get_phi();
+      context.get_element_fe(_T_var)->get_phi();
 
     // The number of local degrees of freedom in each variable
-    const unsigned int n_T_dofs = context.dof_indices_var[_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(_T_var).size();
 
     // Physical location of the quadrature points
     const std::vector<libMesh::Point>& u_qpoint =
-      context.element_fe_var[_u_r_var]->get_xyz();
+      context.get_element_fe(_u_r_var)->get_xyz();
 
     // The subvectors and submatrices we need to fill:
-    DenseSubVector<Real> &F = *context.elem_subresiduals[_T_var];
+    DenseSubVector<Real> &F = context.get_elem_residual(_T_var);
 
-    DenseSubMatrix<Real> &M = *context.elem_subjacobians[_T_var][_T_var];
+    DenseSubMatrix<Real> &M = context.get_elem_jacobian(_T_var, _T_var);
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {

--- a/src/physics/src/boussinesq_buoyancy.C
+++ b/src/physics/src/boussinesq_buoyancy.C
@@ -98,30 +98,30 @@ namespace GRINS
       _w_var = _u_var; // for convenience
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[_u_var].size();
-    const unsigned int n_T_dofs = context.dof_indices_var[_T_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(_u_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_u_var]->get_JxW();
+      context.get_element_fe(_u_var)->get_JxW();
 
     // The velocity shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& vel_phi =
-      context.element_fe_var[_u_var]->get_phi();
+      context.get_element_fe(_u_var)->get_phi();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.element_fe_var[_T_var]->get_phi();
+      context.get_element_fe(_T_var)->get_phi();
 
     // Get residuals
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(_w_var); // R_{w}
 
     // Get Jacobians
-    libMesh::DenseSubMatrix<libMesh::Number> &KuT = *context.elem_subjacobians[_u_var][_T_var]; // R_{u},{T}
-    libMesh::DenseSubMatrix<libMesh::Number> &KvT = *context.elem_subjacobians[_v_var][_T_var]; // R_{v},{T}
-    libMesh::DenseSubMatrix<libMesh::Number> &KwT = *context.elem_subjacobians[_w_var][_T_var]; // R_{w},{T}
+    libMesh::DenseSubMatrix<libMesh::Number> &KuT = context.get_elem_jacobian(_u_var, _T_var); // R_{u},{T}
+    libMesh::DenseSubMatrix<libMesh::Number> &KvT = context.get_elem_jacobian(_v_var, _T_var); // R_{v},{T}
+    libMesh::DenseSubMatrix<libMesh::Number> &KwT = context.get_elem_jacobian(_w_var, _T_var); // R_{w},{T}
 
     // Now we will build the element Jacobian and residual.
     // Constructing the residual requires the solution and its
@@ -129,7 +129,7 @@ namespace GRINS
     // calculated at each quadrature point by summing the
     // solution degree-of-freedom values by the appropriate
     // weight functions.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -90,15 +90,15 @@ namespace GRINS
     // We should prerequest all the data
     // we will need to build the linear system
     // or evaluate a quantity of interest.
-    context.element_fe_var[_T_var]->get_JxW();
-    context.element_fe_var[_T_var]->get_phi();
-    context.element_fe_var[_T_var]->get_dphi();
-    context.element_fe_var[_T_var]->get_xyz();
+    context.get_element_fe(_T_var)->get_JxW();
+    context.get_element_fe(_T_var)->get_phi();
+    context.get_element_fe(_T_var)->get_dphi();
+    context.get_element_fe(_T_var)->get_xyz();
 
-    context.side_fe_var[_T_var]->get_JxW();
-    context.side_fe_var[_T_var]->get_phi();
-    context.side_fe_var[_T_var]->get_dphi();
-    context.side_fe_var[_T_var]->get_xyz();
+    context.get_side_fe(_T_var)->get_JxW();
+    context.get_side_fe(_T_var)->get_phi();
+    context.get_side_fe(_T_var)->get_dphi();
+    context.get_side_fe(_T_var)->get_xyz();
 
     return;
   }
@@ -108,22 +108,22 @@ namespace GRINS
 						CachedValues& /*cache*/ )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(_T_var).size();
 
     // We get some references to cell-specific data that
     // will be used to assemble the linear system.
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_T_var]->get_JxW();
+      context.get_element_fe(_T_var)->get_JxW();
 
     // The temperature shape function gradients (in global coords.)
     // at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[_T_var]->get_dphi();
+      context.get_element_fe(_T_var)->get_dphi();
 
     const std::vector<libMesh::Point>& q_points = 
-      context.element_fe_var[_T_var]->get_xyz();
+      context.get_element_fe(_T_var)->get_xyz();
 
     // The subvectors and submatrices we need to fill:
     //
@@ -131,9 +131,9 @@ namespace GRINS
     // e.g., for \alpha = T and \beta = v we get: K_{Tu} = R_{T},{u}
     //
 
-    libMesh::DenseSubMatrix<Number> &KTT = *context.elem_subjacobians[_T_var][_T_var]; // R_{T},{T}
+    libMesh::DenseSubMatrix<Number> &KTT = context.get_elem_jacobian(_T_var, _T_var); // R_{T},{T}
 
-    libMesh::DenseSubVector<Number> &FT = *context.elem_subresiduals[_T_var]; // R_{T}
+    libMesh::DenseSubVector<Number> &FT = context.get_elem_residual(_T_var); // R_{T}
 
     // Now we will build the element Jacobian and residual.
     // Constructing the residual requires the solution and its
@@ -141,7 +141,7 @@ namespace GRINS
     // calculated at each quadrature point by summing the
     // solution degree-of-freedom values by the appropriate
     // weight functions.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -168,7 +168,7 @@ namespace GRINS
 		      ( -_k*(T_gradphi[i][qp]*T_gradphi[j][qp]) ); // diffusion term
 		  } // end of the inner dof (j) loop
 
-	      } // end - if (compute_jacobian && context.elem_solution_derivative)
+	      } // end - if (compute_jacobian && context.get_elem_solution_derivative())
 
 	  } // end of the outer dof (i) loop
       } // end of the quadrature point (qp) loop
@@ -185,21 +185,21 @@ namespace GRINS
 
     // Element Jacobian * quadrature weights for interior integration
     const std::vector<Real> &JxW = 
-      context.element_fe_var[_T_var]->get_JxW();
+      context.get_element_fe(_T_var)->get_JxW();
 
     // The shape functions at interior quadrature points.
     const std::vector<std::vector<Real> >& phi = 
-      context.element_fe_var[_T_var]->get_phi();
+      context.get_element_fe(_T_var)->get_phi();
 
     // The number of local degrees of freedom in each variable
-    const unsigned int n_T_dofs = context.dof_indices_var[_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(_T_var).size();
 
     // The subvectors and submatrices we need to fill:
-    DenseSubVector<Real> &F = *context.elem_subresiduals[_T_var];
+    DenseSubVector<Real> &F = context.get_elem_residual(_T_var);
 
-    DenseSubMatrix<Real> &M = *context.elem_subjacobians[_T_var][_T_var];
+    DenseSubMatrix<Real> &M = context.get_elem_jacobian(_T_var, _T_var);
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {

--- a/src/physics/src/heat_transfer_adjoint_stab.C
+++ b/src/physics/src/heat_transfer_adjoint_stab.C
@@ -56,25 +56,25 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[this->_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_T_var]->get_JxW();
+      context.get_element_fe(this->_T_var)->get_JxW();
 
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[this->_T_var]->get_dphi();
+      context.get_element_fe(this->_T_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& T_hessphi =
-      context.element_fe_var[this->_T_var]->get_d2phi();
+      context.get_element_fe(this->_T_var)->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[this->_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_T_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_T_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -112,25 +112,25 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[this->_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_T_var]->get_JxW();
+      context.get_element_fe(this->_T_var)->get_JxW();
 
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[this->_T_var]->get_dphi();
+      context.get_element_fe(this->_T_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& T_hessphi =
-      context.element_fe_var[this->_T_var]->get_d2phi();
+      context.get_element_fe(this->_T_var)->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[this->_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_T_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_T_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -112,15 +112,15 @@ namespace GRINS
     // We should prerequest all the data
     // we will need to build the linear system
     // or evaluate a quantity of interest.
-    context.element_fe_var[_T_var]->get_JxW();
-    context.element_fe_var[_T_var]->get_phi();
-    context.element_fe_var[_T_var]->get_dphi();
-    context.element_fe_var[_T_var]->get_xyz();
+    context.get_element_fe(_T_var)->get_JxW();
+    context.get_element_fe(_T_var)->get_phi();
+    context.get_element_fe(_T_var)->get_dphi();
+    context.get_element_fe(_T_var)->get_xyz();
 
-    context.side_fe_var[_T_var]->get_JxW();
-    context.side_fe_var[_T_var]->get_phi();
-    context.side_fe_var[_T_var]->get_dphi();
-    context.side_fe_var[_T_var]->get_xyz();
+    context.get_side_fe(_T_var)->get_JxW();
+    context.get_side_fe(_T_var)->get_phi();
+    context.get_side_fe(_T_var)->get_dphi();
+    context.get_side_fe(_T_var)->get_xyz();
 
     return;
   }

--- a/src/physics/src/heat_transfer_source.C
+++ b/src/physics/src/heat_transfer_source.C
@@ -78,21 +78,21 @@ namespace GRINS
 #endif
   
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_T_var]->get_JxW();
+      context.get_element_fe(_T_var)->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.element_fe_var[_T_var]->get_phi();
+      context.get_element_fe(_T_var)->get_phi();
 
     // Locations of quadrature points
-    const std::vector<libMesh::Point>& x_qp = context.element_fe_var[_T_var]->get_xyz();
+    const std::vector<libMesh::Point>& x_qp = context.get_element_fe(_T_var)->get_xyz();
 
     // Get residuals
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(_T_var); // R_{T}
 
     // Now we will build the element Jacobian and residual.
     // Constructing the residual requires the solution and its
@@ -100,7 +100,7 @@ namespace GRINS
     // calculated at each quadrature point by summing the
     // solution degree-of-freedom values by the appropriate
     // weight functions.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {

--- a/src/physics/src/heat_transfer_stab_base.C
+++ b/src/physics/src/heat_transfer_stab_base.C
@@ -53,7 +53,7 @@ namespace GRINS
     HeatTransferBase::init_context(context);
 
     // We also need second derivatives, so initialize those.
-    context.element_fe_var[this->_T_var]->get_d2phi();
+    context.get_element_fe(this->_T_var)->get_d2phi();
 
     return;
   }

--- a/src/physics/src/inc_navier_stokes.C
+++ b/src/physics/src/inc_navier_stokes.C
@@ -71,36 +71,36 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[_u_var].size();
-    const unsigned int n_p_dofs = context.dof_indices_var[_p_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(_u_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(_p_var).size();
 
     // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.dof_indices_var[_v_var].size());
+    libmesh_assert (n_u_dofs == context.get_dof_indices(_v_var).size());
     if (_dim == 3)
-      libmesh_assert (n_u_dofs == context.dof_indices_var[_w_var].size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(_w_var).size());
 
     // We get some references to cell-specific data that
     // will be used to assemble the linear system.
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_u_var]->get_JxW();
+      context.get_element_fe(_u_var)->get_JxW();
 
     // The velocity shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.element_fe_var[_u_var]->get_phi();
+      context.get_element_fe(_u_var)->get_phi();
 
     // The velocity shape function gradients (in global coords.)
     // at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[_u_var]->get_dphi();
+      context.get_element_fe(_u_var)->get_dphi();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& p_phi =
-      context.element_fe_var[_p_var]->get_phi();
+      context.get_element_fe(_p_var)->get_phi();
 
     const std::vector<libMesh::Point>& u_qpoint = 
-      context.element_fe_var[this->_u_var]->get_xyz();
+      context.get_element_fe(this->_u_var)->get_xyz();
 
     // The subvectors and submatrices we need to fill:
     //
@@ -111,25 +111,25 @@ namespace GRINS
     if (_dim != 3)
       _w_var = _u_var; // for convenience
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kuu = *context.elem_subjacobians[_u_var][_u_var]; // R_{u},{u}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kuv = *context.elem_subjacobians[_u_var][_v_var]; // R_{u},{v}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kuw = *context.elem_subjacobians[_u_var][_w_var]; // R_{u},{w}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kuu = context.get_elem_jacobian(_u_var, _u_var); // R_{u},{u}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kuv = context.get_elem_jacobian(_u_var, _v_var); // R_{u},{v}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kuw = context.get_elem_jacobian(_u_var, _w_var); // R_{u},{w}
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kvu = *context.elem_subjacobians[_v_var][_u_var]; // R_{v},{u}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kvv = *context.elem_subjacobians[_v_var][_v_var]; // R_{v},{v}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kvw = *context.elem_subjacobians[_v_var][_w_var]; // R_{v},{w}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kvu = context.get_elem_jacobian(_v_var, _u_var); // R_{v},{u}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kvv = context.get_elem_jacobian(_v_var, _v_var); // R_{v},{v}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kvw = context.get_elem_jacobian(_v_var, _w_var); // R_{v},{w}
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kwu = *context.elem_subjacobians[_w_var][_u_var]; // R_{w},{u}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kwv = *context.elem_subjacobians[_w_var][_v_var]; // R_{w},{v}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kww = *context.elem_subjacobians[_w_var][_w_var]; // R_{w},{w}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kwu = context.get_elem_jacobian(_w_var, _u_var); // R_{w},{u}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kwv = context.get_elem_jacobian(_w_var, _v_var); // R_{w},{v}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kww = context.get_elem_jacobian(_w_var, _w_var); // R_{w},{w}
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kup = *context.elem_subjacobians[_u_var][_p_var]; // R_{u},{p}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kvp = *context.elem_subjacobians[_v_var][_p_var]; // R_{v},{p}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kwp = *context.elem_subjacobians[_w_var][_p_var]; // R_{w},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kup = context.get_elem_jacobian(_u_var, _p_var); // R_{u},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kvp = context.get_elem_jacobian(_v_var, _p_var); // R_{v},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kwp = context.get_elem_jacobian(_w_var, _p_var); // R_{w},{p}
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(_w_var); // R_{w}
 
     // Now we will build the element Jacobian and residual.
     // Constructing the residual requires the solution and its
@@ -137,7 +137,7 @@ namespace GRINS
     // calculated at each quadrature point by summing the
     // solution degree-of-freedom values by the appropriate
     // weight functions.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -296,32 +296,32 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[_u_var].size();
-    const unsigned int n_p_dofs = context.dof_indices_var[_p_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(_u_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(_p_var).size();
 
     // We get some references to cell-specific data that
     // will be used to assemble the linear system.
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_u_var]->get_JxW();
+      context.get_element_fe(_u_var)->get_JxW();
 
     // The velocity shape function gradients (in global coords.)
     // at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[_u_var]->get_dphi();
+      context.get_element_fe(_u_var)->get_dphi();
 
     // The velocity shape function gradients (in global coords.)
     // at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.element_fe_var[_u_var]->get_phi();
+      context.get_element_fe(_u_var)->get_phi();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& p_phi =
-      context.element_fe_var[_p_var]->get_phi();
+      context.get_element_fe(_p_var)->get_phi();
 
     const std::vector<libMesh::Point>& u_qpoint = 
-      context.element_fe_var[this->_u_var]->get_xyz();
+      context.get_element_fe(this->_u_var)->get_xyz();
     
     // The subvectors and submatrices we need to fill:
     //
@@ -330,14 +330,14 @@ namespace GRINS
     if (_dim != 3)
       _w_var = _u_var; // for convenience
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kpu = *context.elem_subjacobians[_p_var][_u_var]; // R_{p},{u}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kpv = *context.elem_subjacobians[_p_var][_v_var]; // R_{p},{v}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kpw = *context.elem_subjacobians[_p_var][_w_var]; // R_{p},{w}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kpu = context.get_elem_jacobian(_p_var, _u_var); // R_{p},{u}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kpv = context.get_elem_jacobian(_p_var, _v_var); // R_{p},{v}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kpw = context.get_elem_jacobian(_p_var, _w_var); // R_{p},{w}
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(_p_var); // R_{p}
 
     // Add the constraint given by the continuity equation.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	// Compute the velocity gradient at the old Newton iterate.
@@ -410,33 +410,33 @@ namespace GRINS
     // Element Jacobian * quadrature weights for interior integration
     // We assume the same for each flow variable
     const std::vector<libMesh::Real> &JxW = 
-      context.element_fe_var[_u_var]->get_JxW();
+      context.get_element_fe(_u_var)->get_JxW();
 
     // The shape functions at interior quadrature points.
     // We assume the same for each flow variable
     const std::vector<std::vector<libMesh::Real> >& u_phi = 
-      context.element_fe_var[_u_var]->get_phi();
+      context.get_element_fe(_u_var)->get_phi();
 
     const std::vector<libMesh::Point>& u_qpoint = 
-      context.element_fe_var[this->_u_var]->get_xyz();
+      context.get_element_fe(this->_u_var)->get_xyz();
 
     // The number of local degrees of freedom in each variable
-    const unsigned int n_u_dofs = context.dof_indices_var[_u_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(_u_var).size();
 
     // for convenience
     if (_dim != 3)
       _w_var = _u_var;
 
     // The subvectors and submatrices we need to fill:
-    libMesh::DenseSubVector<libMesh::Real> &F_u = *context.elem_subresiduals[_u_var];
-    libMesh::DenseSubVector<libMesh::Real> &F_v = *context.elem_subresiduals[_v_var];
-    libMesh::DenseSubVector<libMesh::Real> &F_w = *context.elem_subresiduals[_w_var];
+    libMesh::DenseSubVector<libMesh::Real> &F_u = context.get_elem_residual(_u_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_v = context.get_elem_residual(_v_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_w = context.get_elem_residual(_w_var);
 
-    libMesh::DenseSubMatrix<libMesh::Real> &M_uu = *context.elem_subjacobians[_u_var][_u_var];
-    libMesh::DenseSubMatrix<libMesh::Real> &M_vv = *context.elem_subjacobians[_v_var][_v_var];
-    libMesh::DenseSubMatrix<libMesh::Real> &M_ww = *context.elem_subjacobians[_w_var][_w_var];
+    libMesh::DenseSubMatrix<libMesh::Real> &M_uu = context.get_elem_jacobian(_u_var, _u_var);
+    libMesh::DenseSubMatrix<libMesh::Real> &M_vv = context.get_elem_jacobian(_v_var, _v_var);
+    libMesh::DenseSubMatrix<libMesh::Real> &M_ww = context.get_elem_jacobian(_w_var, _w_var);
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {

--- a/src/physics/src/inc_navier_stokes_adjoint_stab.C
+++ b/src/physics/src/inc_navier_stokes_adjoint_stab.C
@@ -58,36 +58,36 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.dof_indices_var[this->_p_var].size();
-    const unsigned int n_u_dofs = context.dof_indices_var[this->_u_var].size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.element_fe_var[this->_p_var]->get_dphi();
+      context.get_element_fe(this->_p_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[this->_u_var]->get_dphi();
+      context.get_element_fe(this->_u_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& u_hessphi =
-      context.element_fe_var[this->_u_var]->get_d2phi();
+      context.get_element_fe(this->_u_var)->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[this->_u_var]; // R_{p}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[this->_v_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{p}
     libMesh::DenseSubVector<libMesh::Number> *Fw = NULL;
     if(this->_dim == 3)
-      Fw = context.elem_subresiduals[this->_w_var]; // R_{w}
+      Fw = &context.get_elem_residual(this->_w_var); // R_{w}
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -143,36 +143,36 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.dof_indices_var[this->_p_var].size();
-    const unsigned int n_u_dofs = context.dof_indices_var[this->_u_var].size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.element_fe_var[this->_p_var]->get_dphi();
+      context.get_element_fe(this->_p_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[this->_u_var]->get_dphi();
+      context.get_element_fe(this->_u_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& u_hessphi =
-      context.element_fe_var[this->_u_var]->get_d2phi();
+      context.get_element_fe(this->_u_var)->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[this->_u_var]; // R_{p}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[this->_v_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{p}
     libMesh::DenseSubVector<libMesh::Number> *Fw = NULL;
     if(this->_dim == 3)
-      Fw = context.elem_subresiduals[this->_w_var]; // R_{w}
+      Fw = &context.get_elem_residual(this->_w_var); // R_{w}
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -113,18 +113,18 @@ namespace GRINS
     // We should prerequest all the data
     // we will need to build the linear system
     // or evaluate a quantity of interest.
-    context.element_fe_var[_u_var]->get_JxW();
-    context.element_fe_var[_u_var]->get_phi();
-    context.element_fe_var[_u_var]->get_dphi();
-    context.element_fe_var[_u_var]->get_xyz();
+    context.get_element_fe(_u_var)->get_JxW();
+    context.get_element_fe(_u_var)->get_phi();
+    context.get_element_fe(_u_var)->get_dphi();
+    context.get_element_fe(_u_var)->get_xyz();
 
-    context.element_fe_var[_p_var]->get_phi();
-    context.element_fe_var[_p_var]->get_xyz();
+    context.get_element_fe(_p_var)->get_phi();
+    context.get_element_fe(_p_var)->get_xyz();
 
-    context.side_fe_var[_u_var]->get_JxW();
-    context.side_fe_var[_u_var]->get_phi();
-    context.side_fe_var[_u_var]->get_dphi();
-    context.side_fe_var[_u_var]->get_xyz();
+    context.get_side_fe(_u_var)->get_JxW();
+    context.get_side_fe(_u_var)->get_phi();
+    context.get_side_fe(_u_var)->get_dphi();
+    context.get_side_fe(_u_var)->get_xyz();
 
     return;
   }

--- a/src/physics/src/inc_navier_stokes_stab_base.C
+++ b/src/physics/src/inc_navier_stokes_stab_base.C
@@ -56,10 +56,10 @@ namespace GRINS
     IncompressibleNavierStokesBase::init_context(context);
   
     // We need pressure derivatives
-    context.element_fe_var[this->_p_var]->get_dphi();
+    context.get_element_fe(this->_p_var)->get_dphi();
 
     // We also need second derivatives, so initialize those.
-    context.element_fe_var[this->_u_var]->get_d2phi();
+    context.get_element_fe(this->_u_var)->get_d2phi();
 
     return;
   }

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -175,18 +175,18 @@ namespace GRINS
     // We should prerequest all the data
     // we will need to build the linear system
     // or evaluate a quantity of interest.
-    context.element_fe_var[_u_var]->get_JxW();
-    context.element_fe_var[_u_var]->get_phi();
-    context.element_fe_var[_u_var]->get_dphi();
-    context.element_fe_var[_u_var]->get_xyz();
+    context.get_element_fe(_u_var)->get_JxW();
+    context.get_element_fe(_u_var)->get_phi();
+    context.get_element_fe(_u_var)->get_dphi();
+    context.get_element_fe(_u_var)->get_xyz();
 
-    context.element_fe_var[_T_var]->get_JxW();
-    context.element_fe_var[_T_var]->get_phi();
-    context.element_fe_var[_T_var]->get_dphi();
-    context.element_fe_var[_T_var]->get_xyz();
+    context.get_element_fe(_T_var)->get_JxW();
+    context.get_element_fe(_T_var)->get_phi();
+    context.get_element_fe(_T_var)->get_dphi();
+    context.get_element_fe(_T_var)->get_xyz();
 
-    context.element_fe_var[_p_var]->get_phi();
-    context.element_fe_var[_p_var]->get_xyz();
+    context.get_element_fe(_p_var)->get_phi();
+    context.get_element_fe(_p_var)->get_xyz();
 
     return;
   }

--- a/src/physics/src/low_mach_navier_stokes_braack_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_braack_stab.C
@@ -97,23 +97,23 @@ namespace GRINS
 											 libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.dof_indices_var[this->_p_var].size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.element_fe_var[this->_p_var]->get_dphi();
+      context.get_element_fe(this->_p_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -154,29 +154,29 @@ namespace GRINS
 										       libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[this->_u_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
 
     // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.dof_indices_var[this->_v_var].size());
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.dof_indices_var[this->_w_var].size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[this->_u_var]->get_dphi();
+      context.get_element_fe(this->_u_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& u_hessphi =
-      context.element_fe_var[this->_u_var]->get_d2phi();
+      context.get_element_fe(this->_u_var)->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[this->_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[this->_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[this->_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -198,7 +198,7 @@ namespace GRINS
 	    grad_w = context.interior_gradient(this->_w_var, qp);
 	  }
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -253,22 +253,22 @@ namespace GRINS
 										     libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[this->_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_T_var]->get_JxW();
+      context.get_element_fe(this->_T_var)->get_JxW();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[this->_T_var]->get_dphi();
+      context.get_element_fe(this->_T_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& T_hessphi =
-      context.element_fe_var[this->_T_var]->get_d2phi();
+      context.get_element_fe(this->_T_var)->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[this->_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -290,7 +290,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -316,23 +316,23 @@ namespace GRINS
 											    libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.dof_indices_var[this->_p_var].size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.element_fe_var[this->_p_var]->get_dphi();
+      context.get_element_fe(this->_p_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -373,29 +373,29 @@ namespace GRINS
 											  libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[this->_u_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
 
     // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.dof_indices_var[this->_v_var].size());
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.dof_indices_var[this->_w_var].size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[this->_u_var]->get_dphi();
+      context.get_element_fe(this->_u_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& u_hessphi =
-      context.element_fe_var[this->_u_var]->get_d2phi();
+      context.get_element_fe(this->_u_var)->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[this->_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[this->_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[this->_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
@@ -416,7 +416,7 @@ namespace GRINS
 	    grad_w = context.fixed_interior_gradient(this->_w_var, qp);
 	  }
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -471,22 +471,22 @@ namespace GRINS
 											libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[this->_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_T_var]->get_JxW();
+      context.get_element_fe(this->_T_var)->get_JxW();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[this->_T_var]->get_dphi();
+      context.get_element_fe(this->_T_var)->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& T_hessphi =
-      context.element_fe_var[this->_T_var]->get_d2phi();
+      context.get_element_fe(this->_T_var)->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[this->_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -508,7 +508,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*cp;
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );

--- a/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
@@ -98,23 +98,23 @@ namespace GRINS
 											libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.dof_indices_var[this->_p_var].size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.element_fe_var[this->_p_var]->get_dphi();
+      context.get_element_fe(this->_p_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -151,26 +151,26 @@ namespace GRINS
 										      libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[this->_u_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
 
     // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.dof_indices_var[this->_v_var].size());
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.dof_indices_var[this->_w_var].size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[this->_u_var]->get_dphi();
+      context.get_element_fe(this->_u_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[this->_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[this->_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[this->_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -190,7 +190,7 @@ namespace GRINS
 	    grad_w = context.interior_gradient(this->_w_var, qp);
 	  }
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -226,19 +226,19 @@ namespace GRINS
 										    libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[this->_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_T_var]->get_JxW();
+      context.get_element_fe(this->_T_var)->get_JxW();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[this->_T_var]->get_dphi();
+      context.get_element_fe(this->_T_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[this->_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -260,7 +260,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -284,23 +284,23 @@ namespace GRINS
 											   libMesh::FEMContext& context)
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.dof_indices_var[this->_p_var].size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.element_fe_var[this->_p_var]->get_dphi();
+      context.get_element_fe(this->_p_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -334,26 +334,26 @@ namespace GRINS
 											 libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[this->_u_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
 
     // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.dof_indices_var[this->_v_var].size());
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.dof_indices_var[this->_w_var].size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[this->_u_var]->get_dphi();
+      context.get_element_fe(this->_u_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[this->_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[this->_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[this->_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
@@ -374,7 +374,7 @@ namespace GRINS
 	    grad_w = context.fixed_interior_gradient(this->_w_var, qp);
 	  }
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -410,19 +410,19 @@ namespace GRINS
 										       libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[this->_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_T_var]->get_JxW();
+      context.get_element_fe(this->_T_var)->get_JxW();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[this->_T_var]->get_dphi();
+      context.get_element_fe(this->_T_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[this->_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -444,7 +444,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );

--- a/src/physics/src/low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/low_mach_navier_stokes_stab_base.C
@@ -59,11 +59,11 @@ namespace GRINS
     LowMachNavierStokesBase<Mu,SH,TC>::init_context(context);
   
     // We need pressure derivatives
-    context.element_fe_var[this->_p_var]->get_dphi();
+    context.get_element_fe(this->_p_var)->get_dphi();
 
     // We also need second derivatives, so initialize those.
-    context.element_fe_var[this->_u_var]->get_d2phi();
-    context.element_fe_var[this->_T_var]->get_d2phi();
+    context.get_element_fe(this->_u_var)->get_d2phi();
+    context.get_element_fe(this->_T_var)->get_d2phi();
 
     return;
   }

--- a/src/physics/src/low_mach_navier_stokes_vms_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_vms_stab.C
@@ -97,23 +97,23 @@ namespace GRINS
 										      libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.dof_indices_var[this->_p_var].size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.element_fe_var[this->_p_var]->get_dphi();
+      context.get_element_fe(this->_p_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -150,30 +150,30 @@ namespace GRINS
 										    libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[this->_u_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
 
     // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.dof_indices_var[this->_v_var].size());
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.dof_indices_var[this->_w_var].size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.element_fe_var[this->_u_var]->get_phi();
+      context.get_element_fe(this->_u_var)->get_phi();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[this->_u_var]->get_dphi();
+      context.get_element_fe(this->_u_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[this->_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[this->_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[this->_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -193,7 +193,7 @@ namespace GRINS
 	    grad_w = context.interior_gradient(this->_w_var, qp);
 	  }
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -235,23 +235,23 @@ namespace GRINS
 										  libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[this->_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_T_var]->get_JxW();
+      context.get_element_fe(this->_T_var)->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.element_fe_var[this->_T_var]->get_phi();
+      context.get_element_fe(this->_T_var)->get_phi();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[this->_T_var]->get_dphi();
+      context.get_element_fe(this->_T_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[this->_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -274,7 +274,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -302,23 +302,23 @@ namespace GRINS
 											 libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.dof_indices_var[this->_p_var].size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.element_fe_var[this->_p_var]->get_dphi();
+      context.get_element_fe(this->_p_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -352,30 +352,30 @@ namespace GRINS
 										       libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[this->_u_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
 
     // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.dof_indices_var[this->_v_var].size());
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.dof_indices_var[this->_w_var].size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.element_fe_var[this->_u_var]->get_phi();
+      context.get_element_fe(this->_u_var)->get_phi();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[this->_u_var]->get_dphi();
+      context.get_element_fe(this->_u_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[this->_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[this->_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[this->_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
@@ -396,7 +396,7 @@ namespace GRINS
 	    grad_w = context.fixed_interior_gradient(this->_w_var, qp);
 	  }
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -441,23 +441,23 @@ namespace GRINS
 										     libMesh::FEMContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[this->_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_T_var]->get_JxW();
+      context.get_element_fe(this->_T_var)->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.element_fe_var[this->_T_var]->get_phi();
+      context.get_element_fe(this->_T_var)->get_phi();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[this->_T_var]->get_dphi();
+      context.get_element_fe(this->_T_var)->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[this->_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -480,7 +480,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.element_fe_var[this->_u_var];
+	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -149,7 +149,7 @@ namespace GRINS
 	 physics_iter++ )
       {
 	// Only compute if physics is active on current subdomain or globally
-	if( (physics_iter->second)->enabled_on_elem( c.elem ) )
+	if( (physics_iter->second)->enabled_on_elem( &c.get_elem() ) )
 	  {
 	    (physics_iter->second)->element_time_derivative( compute_jacobian, c,
 							     cache );
@@ -185,7 +185,7 @@ namespace GRINS
 	 physics_iter++ )
       {
 	// Only compute if physics is active on current subdomain or globally
-	if( (physics_iter->second)->enabled_on_elem( c.elem ) )
+	if( (physics_iter->second)->enabled_on_elem( &c.get_elem() ) )
 	  {
 	    (physics_iter->second)->side_time_derivative( compute_jacobian, c,
 							  cache );
@@ -221,7 +221,7 @@ namespace GRINS
 	 physics_iter++ )
       {
 	// Only compute if physics is active on current subdomain or globally
-	if( (physics_iter->second)->enabled_on_elem( c.elem ) )
+	if( (physics_iter->second)->enabled_on_elem( &c.get_elem() ) )
 	  {
 	    (physics_iter->second)->element_constraint( compute_jacobian, c,
 							cache);
@@ -257,7 +257,7 @@ namespace GRINS
 	 physics_iter++ )
       {
 	// Only compute if physics is active on current subdomain or globally
-	if( (physics_iter->second)->enabled_on_elem( c.elem ) )
+	if( (physics_iter->second)->enabled_on_elem( &c.get_elem() ) )
 	  {
 	    (physics_iter->second)->side_constraint( compute_jacobian, c,
 						     cache);
@@ -293,7 +293,7 @@ namespace GRINS
 	 physics_iter++ )
       {
 	// Only compute if physics is active on current subdomain or globally
-	if( (physics_iter->second)->enabled_on_elem( c.elem ) )
+	if( (physics_iter->second)->enabled_on_elem( &c.get_elem() ) )
 	  {
 	    (physics_iter->second)->mass_residual( compute_jacobian, c,
 						   cache);

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -83,15 +83,15 @@ namespace GRINS
     GRINS::ReactingLowMachNavierStokesBase<Mixture>::init_context(context);
 
     // We also need the side shape functions, etc.
-    context.side_fe_var[this->_u_var]->get_JxW();
-    context.side_fe_var[this->_u_var]->get_phi();
-    context.side_fe_var[this->_u_var]->get_dphi();
-    context.side_fe_var[this->_u_var]->get_xyz();
+    context.get_side_fe(this->_u_var)->get_JxW();
+    context.get_side_fe(this->_u_var)->get_phi();
+    context.get_side_fe(this->_u_var)->get_dphi();
+    context.get_side_fe(this->_u_var)->get_xyz();
 
-    context.side_fe_var[this->_T_var]->get_JxW();
-    context.side_fe_var[this->_T_var]->get_phi();
-    context.side_fe_var[this->_T_var]->get_dphi();
-    context.side_fe_var[this->_T_var]->get_xyz();
+    context.get_side_fe(this->_T_var)->get_JxW();
+    context.get_side_fe(this->_T_var)->get_phi();
+    context.get_side_fe(this->_T_var)->get_dphi();
+    context.get_side_fe(this->_T_var)->get_xyz();
 
     return;
   }
@@ -101,7 +101,7 @@ namespace GRINS
                                                                                 libMesh::FEMContext& context,
                                                                                 CachedValues& cache )
   {
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -159,20 +159,20 @@ namespace GRINS
                                                                                  const CachedValues& cache )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.dof_indices_var[this->_p_var].size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
     
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real>& JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
     
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& p_phi =
-      context.element_fe_var[this->_p_var]->get_phi();
+      context.get_element_fe(this->_p_var)->get_phi();
     
     const std::vector<libMesh::Point>& u_qpoint = 
-      context.element_fe_var[this->_u_var]->get_xyz();
+      context.get_element_fe(this->_u_var)->get_xyz();
 
-    libMesh::DenseSubVector<libMesh::Number>& Fp = *context.elem_subresiduals[this->_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number>& Fp = context.get_elem_residual(this->_p_var); // R_{p}
 
     libMesh::Number u, v, T;
     u = cache.get_cached_values(Cache::X_VELOCITY)[qp];
@@ -243,19 +243,19 @@ namespace GRINS
     
     /* The number of local degrees of freedom in each species variable.
        We assume the same number of dofs for each species */
-    const unsigned int n_s_dofs = context.dof_indices_var[s0_var].size();
+    const unsigned int n_s_dofs = context.get_dof_indices(s0_var).size();
     
     // Element Jacobian * quadrature weights for interior integration.
-    const std::vector<libMesh::Real> &JxW = context.element_fe_var[s0_var]->get_JxW();
+    const std::vector<libMesh::Real> &JxW = context.get_element_fe(s0_var)->get_JxW();
     
     // The species shape functions at interior quadrature points.
-    const std::vector<std::vector<libMesh::Real> >& s_phi = context.element_fe_var[s0_var]->get_phi();
+    const std::vector<std::vector<libMesh::Real> >& s_phi = context.get_element_fe(s0_var)->get_phi();
 
     // The species shape function gradients at interior quadrature points.
-    const std::vector<std::vector<libMesh::Gradient> >& s_grad_phi = context.element_fe_var[s0_var]->get_dphi();
+    const std::vector<std::vector<libMesh::Gradient> >& s_grad_phi = context.get_element_fe(s0_var)->get_dphi();
 
     const std::vector<libMesh::Point>& s_qpoint = 
-      context.element_fe_var[this->_species_vars[0]]->get_xyz();
+      context.get_element_fe(this->_species_vars[0])->get_xyz();
 
     libMesh::Number rho = cache.get_cached_values(Cache::MIXTURE_DENSITY)[qp];
 
@@ -291,7 +291,7 @@ namespace GRINS
     for(unsigned int s=0; s < this->_n_species; s++ )
       {
 	libMesh::DenseSubVector<libMesh::Number> &Fs = 
-	  *context.elem_subresiduals[this->_species_vars[s]]; // R_{s}
+	  context.get_elem_residual(this->_species_vars[s]); // R_{s}
 
 	const libMesh::Real term1 = -rho*(U*grad_w[s]) + omega_dot[s];
 	const libMesh::Gradient term2 = -rho*D[s]*grad_w[s];
@@ -314,31 +314,31 @@ namespace GRINS
 									  const CachedValues& cache)
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[this->_u_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
 
     // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.dof_indices_var[this->_v_var].size());
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.dof_indices_var[this->_w_var].size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_u_var]->get_JxW();
+      context.get_element_fe(this->_u_var)->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.element_fe_var[this->_u_var]->get_phi();
+      context.get_element_fe(this->_u_var)->get_phi();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[this->_u_var]->get_dphi();
+      context.get_element_fe(this->_u_var)->get_dphi();
 
     const std::vector<libMesh::Point>& u_qpoint = 
-      context.element_fe_var[this->_u_var]->get_xyz();
+      context.get_element_fe(this->_u_var)->get_xyz();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[this->_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[this->_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[this->_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
     
     libMesh::Number rho = cache.get_cached_values(Cache::MIXTURE_DENSITY)[qp];
 
@@ -436,25 +436,25 @@ namespace GRINS
                                                                                    const CachedValues& cache)
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.dof_indices_var[this->_T_var].size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[this->_T_var]->get_JxW();
+      context.get_element_fe(this->_T_var)->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.element_fe_var[this->_T_var]->get_phi();
+      context.get_element_fe(this->_T_var)->get_phi();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.element_fe_var[this->_T_var]->get_dphi();
+      context.get_element_fe(this->_T_var)->get_dphi();
 
     // Physical location of the quadrature points
     const std::vector<libMesh::Point>& T_qpoint =
-      context.element_fe_var[this->_T_var]->get_xyz();
+      context.get_element_fe(this->_T_var)->get_xyz();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = *context.elem_subresiduals[this->_T_var]; // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
 
     libMesh::Number rho = cache.get_cached_values(Cache::MIXTURE_DENSITY)[qp];
 
@@ -517,7 +517,7 @@ namespace GRINS
   {
     Evaluator gas_evaluator( this->_gas_mixture );
 
-    const unsigned int n_qpoints = context.element_qrule->n_points();
+    const unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     std::vector<libMesh::Real> u, v, w, T, p, p0;
     u.resize(n_qpoints);
@@ -665,7 +665,7 @@ namespace GRINS
   {
     Evaluator gas_evaluator( this->_gas_mixture );
 
-    const unsigned int n_qpoints = context.side_qrule->n_points();
+    const unsigned int n_qpoints = context.get_side_qrule().n_points();
 
     // Need for Catalytic Wall
     /*! \todo Add mechanism for checking if this side is a catalytic wall so we don't 

--- a/src/physics/src/reacting_low_mach_navier_stokes_base.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_base.C
@@ -186,23 +186,23 @@ namespace GRINS
     // We should prerequest all the data
     // we will need to build the linear system
     // or evaluate a quantity of interest.
-    context.element_fe_var[_species_vars[0]]->get_JxW();
-    context.element_fe_var[_species_vars[0]]->get_phi();
-    context.element_fe_var[_species_vars[0]]->get_dphi();
-    context.element_fe_var[_species_vars[0]]->get_xyz();
+    context.get_element_fe(_species_vars[0])->get_JxW();
+    context.get_element_fe(_species_vars[0])->get_phi();
+    context.get_element_fe(_species_vars[0])->get_dphi();
+    context.get_element_fe(_species_vars[0])->get_xyz();
 
-    context.element_fe_var[_u_var]->get_JxW();
-    context.element_fe_var[_u_var]->get_phi();
-    context.element_fe_var[_u_var]->get_dphi();
-    context.element_fe_var[_u_var]->get_xyz();
+    context.get_element_fe(_u_var)->get_JxW();
+    context.get_element_fe(_u_var)->get_phi();
+    context.get_element_fe(_u_var)->get_dphi();
+    context.get_element_fe(_u_var)->get_xyz();
 
-    context.element_fe_var[_T_var]->get_JxW();
-    context.element_fe_var[_T_var]->get_phi();
-    context.element_fe_var[_T_var]->get_dphi();
-    context.element_fe_var[_T_var]->get_xyz();
+    context.get_element_fe(_T_var)->get_JxW();
+    context.get_element_fe(_T_var)->get_phi();
+    context.get_element_fe(_T_var)->get_dphi();
+    context.get_element_fe(_T_var)->get_xyz();
 
-    context.element_fe_var[_p_var]->get_phi();
-    context.element_fe_var[_p_var]->get_xyz();
+    context.get_element_fe(_p_var)->get_phi();
+    context.get_element_fe(_p_var)->get_xyz();
 
     return;
   }

--- a/src/physics/src/stab_helper.C
+++ b/src/physics/src/stab_helper.C
@@ -52,7 +52,7 @@ namespace GRINS
     libMesh::RealGradient g( fe->get_dxidx()[qp] + fe->get_detadx()[qp],
 			     fe->get_dxidy()[qp] + fe->get_detady()[qp] );
   
-    if( c.dim == 3 )
+    if( c.get_dim() == 3 )
       {
 	g(0) += fe->get_dzetadx()[qp];
 	g(1) += fe->get_dzetady()[qp];
@@ -79,7 +79,7 @@ namespace GRINS
 			   dxidy*dxidy + detady*detady,
 			   0.0 );
   
-    if( c.dim == 3 )
+    if( c.get_dim() == 3 )
       {
 	libMesh::Real dxidz = fe->get_dxidz()[qp];
       

--- a/src/physics/src/stokes.C
+++ b/src/physics/src/stokes.C
@@ -64,29 +64,29 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[_u_var].size();
-    const unsigned int n_p_dofs = context.dof_indices_var[_p_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(_u_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(_p_var).size();
 
     // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.dof_indices_var[_v_var].size());
+    libmesh_assert (n_u_dofs == context.get_dof_indices(_v_var).size());
     if (_dim == 3)
-      libmesh_assert (n_u_dofs == context.dof_indices_var[_w_var].size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(_w_var).size());
 
     // We get some references to cell-specific data that
     // will be used to assemble the linear system.
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_u_var]->get_JxW();
+      context.get_element_fe(_u_var)->get_JxW();
 
     // The velocity shape function gradients (in global coords.)
     // at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[_u_var]->get_dphi();
+      context.get_element_fe(_u_var)->get_dphi();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& p_phi =
-      context.element_fe_var[_p_var]->get_phi();
+      context.get_element_fe(_p_var)->get_phi();
 
     // The subvectors and submatrices we need to fill:
     //
@@ -97,17 +97,17 @@ namespace GRINS
     if (_dim != 3)
       _w_var = _u_var; // for convenience
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kuu = *context.elem_subjacobians[_u_var][_u_var]; // R_{u},{u}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kvv = *context.elem_subjacobians[_v_var][_v_var]; // R_{v},{v}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kww = *context.elem_subjacobians[_w_var][_w_var]; // R_{w},{w}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kuu = context.get_elem_jacobian(_u_var, _u_var); // R_{u},{u}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kvv = context.get_elem_jacobian(_v_var, _v_var); // R_{v},{v}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kww = context.get_elem_jacobian(_w_var, _w_var); // R_{w},{w}
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kup = *context.elem_subjacobians[_u_var][_p_var]; // R_{u},{p}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kvp = *context.elem_subjacobians[_v_var][_p_var]; // R_{v},{p}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kwp = *context.elem_subjacobians[_w_var][_p_var]; // R_{w},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kup = context.get_elem_jacobian(_u_var, _p_var); // R_{u},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kvp = context.get_elem_jacobian(_v_var, _p_var); // R_{v},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kwp = context.get_elem_jacobian(_w_var, _p_var); // R_{w},{p}
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = *context.elem_subresiduals[_u_var]; // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = *context.elem_subresiduals[_v_var]; // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = *context.elem_subresiduals[_w_var]; // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(_u_var); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(_v_var); // R_{v}
+    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(_w_var); // R_{w}
 
     // Now we will build the element Jacobian and residual.
     // Constructing the residual requires the solution and its
@@ -115,7 +115,7 @@ namespace GRINS
     // calculated at each quadrature point by summing the
     // solution degree-of-freedom values by the appropriate
     // weight functions.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
@@ -187,7 +187,7 @@ namespace GRINS
 		      Kwp(i,j) += JxW[qp]*u_gradphi[i][qp](2)*p_phi[j][qp];
 		  } // end of the inner dof (j) loop
 
-	      } // end - if (compute_jacobian && context.elem_solution_derivative)
+	      } // end - if (compute_jacobian && context.get_elem_solution_derivative())
 
 	  } // end of the outer dof (i) loop
       } // end of the quadrature point (qp) loop
@@ -208,24 +208,24 @@ namespace GRINS
 #endif
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.dof_indices_var[_u_var].size();
-    const unsigned int n_p_dofs = context.dof_indices_var[_p_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(_u_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(_p_var).size();
 
     // We get some references to cell-specific data that
     // will be used to assemble the linear system.
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.element_fe_var[_u_var]->get_JxW();
+      context.get_element_fe(_u_var)->get_JxW();
 
     // The velocity shape function gradients (in global coords.)
     // at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.element_fe_var[_u_var]->get_dphi();
+      context.get_element_fe(_u_var)->get_dphi();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& p_phi =
-      context.element_fe_var[_p_var]->get_phi();
+      context.get_element_fe(_p_var)->get_phi();
 
     // The subvectors and submatrices we need to fill:
     //
@@ -234,14 +234,14 @@ namespace GRINS
     if (_dim != 3)
       _w_var = _u_var; // for convenience
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kpu = *context.elem_subjacobians[_p_var][_u_var]; // R_{p},{u}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kpv = *context.elem_subjacobians[_p_var][_v_var]; // R_{p},{v}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kpw = *context.elem_subjacobians[_p_var][_w_var]; // R_{p},{w}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kpu = context.get_elem_jacobian(_p_var, _u_var); // R_{p},{u}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kpv = context.get_elem_jacobian(_p_var, _v_var); // R_{p},{v}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kpw = context.get_elem_jacobian(_p_var, _w_var); // R_{p},{w}
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = *context.elem_subresiduals[_p_var]; // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(_p_var); // R_{p}
 
     // Add the constraint given by the continuity equation.
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	// Compute the velocity gradient at the old Newton iterate.
@@ -271,7 +271,7 @@ namespace GRINS
 		      Kpw(i,j) += JxW[qp]*p_phi[i][qp]*u_gradphi[j][qp](2);
 		  } // end of the inner dof (j) loop
 
-	      } // end - if (compute_jacobian && context.elem_solution_derivative)
+	      } // end - if (compute_jacobian && context.get_elem_solution_derivative())
 
 	  } // end of the outer dof (i) loop
       } // end of the quadrature point (qp) loop
@@ -298,30 +298,30 @@ namespace GRINS
     // Element Jacobian * quadrature weights for interior integration
     // We assume the same for each flow variable
     const std::vector<libMesh::Real> &JxW = 
-      context.element_fe_var[_u_var]->get_JxW();
+      context.get_element_fe(_u_var)->get_JxW();
 
     // The shape functions at interior quadrature points.
     // We assume the same for each flow variable
     const std::vector<std::vector<libMesh::Real> >& u_phi = 
-      context.element_fe_var[_u_var]->get_phi();
+      context.get_element_fe(_u_var)->get_phi();
 
     // The number of local degrees of freedom in each variable
-    const unsigned int n_u_dofs = context.dof_indices_var[_u_var].size();
+    const unsigned int n_u_dofs = context.get_dof_indices(_u_var).size();
 
     // for convenience
     if (_dim != 3)
       _w_var = _u_var;
 
     // The subvectors and submatrices we need to fill:
-    libMesh::DenseSubVector<libMesh::Real> &F_u = *context.elem_subresiduals[_u_var];
-    libMesh::DenseSubVector<libMesh::Real> &F_v = *context.elem_subresiduals[_v_var];
-    libMesh::DenseSubVector<libMesh::Real> &F_w = *context.elem_subresiduals[_w_var];
+    libMesh::DenseSubVector<libMesh::Real> &F_u = context.get_elem_residual(_u_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_v = context.get_elem_residual(_v_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_w = context.get_elem_residual(_w_var);
 
-    libMesh::DenseSubMatrix<libMesh::Real> &M_uu = *context.elem_subjacobians[_u_var][_u_var];
-    libMesh::DenseSubMatrix<libMesh::Real> &M_vv = *context.elem_subjacobians[_v_var][_v_var];
-    libMesh::DenseSubMatrix<libMesh::Real> &M_ww = *context.elem_subjacobians[_w_var][_w_var];
+    libMesh::DenseSubMatrix<libMesh::Real> &M_uu = context.get_elem_jacobian(_u_var, _u_var);
+    libMesh::DenseSubMatrix<libMesh::Real> &M_vv = context.get_elem_jacobian(_v_var, _v_var);
+    libMesh::DenseSubMatrix<libMesh::Real> &M_ww = context.get_elem_jacobian(_w_var, _w_var);
 
-    unsigned int n_qpoints = context.element_qrule->n_points();
+    unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {

--- a/src/qoi/src/average_nusselt_number.C
+++ b/src/qoi/src/average_nusselt_number.C
@@ -121,7 +121,7 @@ namespace GRINS
 
 	    unsigned int n_qpoints = c.get_side_qrule().n_points();
 	    
-	    libMesh::Number& qoi = c.elem_qoi[0];
+	    libMesh::Number& qoi = c.get_qois()[0];
 	    
 	    // Loop over quadrature points  
 	    
@@ -165,7 +165,7 @@ namespace GRINS
 
             const std::vector<std::vector<libMesh::Gradient> >& T_gradphi = T_side_fe->get_dphi();
 
-	    DenseSubVector<Number>& dQ_dT = *c.elem_qoi_subderivatives[0][_T_var];
+	    DenseSubVector<Number>& dQ_dT = c.get_qoi_derivatives(0, _T_var);
 
 	    // Loop over quadrature points  
 	    

--- a/src/qoi/src/vorticity.C
+++ b/src/qoi/src/vorticity.C
@@ -94,7 +94,7 @@ namespace GRINS
   {
     libMesh::FEMContext &c = libmesh_cast_ref<libMesh::FEMContext&>(context);
 
-    if( _subdomain_ids.find( (c.elem)->subdomain_id() ) != _subdomain_ids.end() )
+    if( _subdomain_ids.find( (&c.get_elem())->subdomain_id() ) != _subdomain_ids.end() )
       {
 	libMesh::FEBase* element_fe;
 	c.get_element_fe<libMesh::Real>(this->_u_var, element_fe);
@@ -103,7 +103,7 @@ namespace GRINS
 	unsigned int n_qpoints = c.get_element_qrule().n_points();
 
 	/*! \todo Need to generalize this to the multiple QoI case */
-	libMesh::Number& qoi = c.elem_qoi[0];
+	libMesh::Number& qoi = c.get_qois()[0];
 
 	for( unsigned int qp = 0; qp != n_qpoints; qp++ )
 	  {
@@ -122,7 +122,7 @@ namespace GRINS
   {
     libMesh::FEMContext &c = libmesh_cast_ref<libMesh::FEMContext&>(context);
 
-    if( _subdomain_ids.find( (c.elem)->subdomain_id() ) != _subdomain_ids.end() )
+    if( _subdomain_ids.find( (&c.get_elem())->subdomain_id() ) != _subdomain_ids.end() )
       {
 	// Element
 	libMesh::FEBase* element_fe;
@@ -133,19 +133,19 @@ namespace GRINS
 
 	// Grad of basis functions
 	const std::vector<std::vector<libMesh::RealGradient> >& du_phi =
-	  c.element_fe_var[_u_var]->get_dphi();
+	  c.get_element_fe(_u_var)->get_dphi();
 	const std::vector<std::vector<libMesh::RealGradient> >& dv_phi =
-	  c.element_fe_var[_v_var]->get_dphi();
+	  c.get_element_fe(_v_var)->get_dphi();
 
 	// Local DOF count and quadrature point count
-	const unsigned int n_T_dofs = c.dof_indices_var[0].size();
+	const unsigned int n_T_dofs = c.get_dof_indices(0).size();
 	unsigned int n_qpoints = c.get_element_qrule().n_points();  
 
 	// Warning: we assume here that vorticity is the only QoI!
 	// This should be consistent with the assertion in grins_mesh_adaptive_solver.C
 	/*! \todo Need to generalize this to the multiple QoI case */
-	libMesh::DenseSubVector<Number> &Qu = *c.elem_qoi_subderivatives[0][0];
-	libMesh::DenseSubVector<Number> &Qv = *c.elem_qoi_subderivatives[0][1];
+	libMesh::DenseSubVector<Number> &Qu = c.get_qoi_derivatives(0, 0);
+	libMesh::DenseSubVector<Number> &Qv = c.get_qoi_derivatives(0, 1);
 
 	// Integration loop
 	for( unsigned int qp = 0; qp != n_qpoints; qp++ )


### PR DESCRIPTION
This passes "make check" for me.  We probably don't want to merge it until a libMesh 0.9.2.2 has been tagged with the backported FEBase accessors from revision 2ffb39def45636d0a608fe70dfc4f0ae38cc805f there.
