### PR TITLE
Add "backtrack_deltat" option

### DIFF
--- a/src/solver/include/grins/grins_unsteady_solver.h
+++ b/src/solver/include/grins/grins_unsteady_solver.h
@@ -46,8 +46,9 @@ namespace GRINS
 
     virtual void init_time_solver(GRINS::MultiphysicsSystem* system);
 
-    double _theta;
     unsigned int _n_timesteps;
+    unsigned int _backtrack_deltat;
+    double _theta;
     double _deltat;
 
     // Options for adaptive time solvers

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -42,8 +42,9 @@ namespace GRINS
 
   UnsteadySolver::UnsteadySolver( const GetPot& input )
     : Solver(input),
-      _theta( input("unsteady-solver/theta", 0.5 ) ),
       _n_timesteps( input("unsteady-solver/n_timesteps", 1 ) ),
+      _backtrack_deltat( input("unsteady-solver/backtrack_deltat", 0 ) ),
+      _theta( input("unsteady-solver/theta", 0.5 ) ),
       /*! \todo Is this the best default for delta t?*/
       _deltat( input("unsteady-solver/deltat", 0.0 ) ),
       _target_tolerance( input("unsteady-solver/target_tolerance", 0.0 ) ),
@@ -97,6 +98,7 @@ namespace GRINS
 
     // Set theta parameter for time-stepping scheme
     time_solver->theta = this->_theta;
+    time_solver->reduce_deltat_on_diffsolver_failure = this->_backtrack_deltat;
 
     return;
   }


### PR DESCRIPTION
This hooks into the existing reduce_deltat_on_diffsolver_failure option
in libMesh::UnsteadySolver
