### PR TITLE
Fix for outputting auxiliary vis quantities from steady adaptive solver

### DIFF
--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -80,6 +80,7 @@ namespace GRINS
         libMesh::NumericVector<Number>& primal_solution = *(context.system->solution);
         if( context.output_vis )
           {
+            context.postprocessing->update_quantities( *(context.equation_system) );
             context.vis->output( context.equation_system );
           }
 


### PR DESCRIPTION
Density now prints out again the cavity_benchmark example.
