### PR TITLE
Bump up tolerance 60%

### DIFF
--- a/test/low_mach_cavity_benchmark_regression.C
+++ b/test/low_mach_cavity_benchmark_regression.C
@@ -88,7 +88,7 @@ int main(int argc, char* argv[])
   // and not even close to the real QoI for this problem.
   const Real exact_qoi = 4.8158910675853654e+00;
 
-  const Real tol = 5.0e-12;
+  const Real tol = 8.0e-12;
 
   int return_flag = 0;
 


### PR DESCRIPTION
I got a ~5.2e-12 level error here on stampede's login node with 1 core.
