### PR TITLE
Assorted unused variables warning fixes

### DIFF
--- a/src/bc_handling/src/bc_handling_base.C
+++ b/src/bc_handling/src/bc_handling_base.C
@@ -74,8 +74,8 @@ namespace GRINS
   {
     int num_ids = input.vector_variable_size(id_str);
     int num_bcs = input.vector_variable_size(bc_str);
-    int num_vars = input.vector_variable_size(var_str);
-    int num_vals = input.vector_variable_size(val_str);
+    // int num_vars = input.vector_variable_size(var_str);
+    // int num_vals = input.vector_variable_size(val_str);
 
     if( num_ids != num_bcs )
       {

--- a/src/physics/src/inc_navier_stokes.C
+++ b/src/physics/src/inc_navier_stokes.C
@@ -412,7 +412,7 @@ namespace GRINS
 
   void IncompressibleNavierStokes::side_constraint( bool compute_jacobian,
                                                     AssemblyContext& context,
-                                                    CachedValues& /*cache*/ )
+                                                    CachedValues& /* cache */)
   {
     // Pin p = p_value at p_point
     if( _pin_pressure )

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -139,7 +139,7 @@ namespace GRINS
   template<class Mu, class SH, class TC>
   void LowMachNavierStokes<Mu,SH,TC>::side_constraint( bool compute_jacobian,
                                                        AssemblyContext& context,
-                                                       CachedValues& cache )
+                                                       CachedValues& /* cache */ )
   {
     // Pin p = p_value at p_point
     if( this->_pin_pressure )

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -137,7 +137,7 @@ namespace GRINS
   template<typename Mixture, typename Evaluator>
   void ReactingLowMachNavierStokes<Mixture,Evaluator>::side_constraint( bool compute_jacobian,
                                                                         AssemblyContext& context,
-                                                                        CachedValues& cache )
+                                                                        CachedValues& /* cache */ )
   {
     // Pin p = p_value at p_point
     if( _pin_pressure )

--- a/src/properties/include/grins/cantera_mixture.h
+++ b/src/properties/include/grins/cantera_mixture.h
@@ -32,9 +32,11 @@
 // libMesh
 #include "libmesh/threads.h"
 
-// Cantera
+// Cantera (with compiler warnings disabled)
+#include "libmesh/ignore_warnings.h"
 #include "cantera/IdealGasMix.h"
 #include "cantera/transport.h"
+#include "libmesh/restore_warnings.h"
 
 // Boost
 #include <boost/scoped_ptr.hpp>

--- a/src/properties/src/antioch_kinetics.C
+++ b/src/properties/src/antioch_kinetics.C
@@ -53,7 +53,7 @@ namespace GRINS
 
   void AntiochKinetics::omega_dot( const Antioch::TempCache<libMesh::Real>& temp_cache,
                                    const libMesh::Real rho,
-                                   const libMesh::Real R_mix,
+                                   const libMesh::Real /* R_mix */,
                                    const std::vector<libMesh::Real>& mass_fractions,
                                    std::vector<libMesh::Real>& omega_dot )
   {

--- a/src/properties/src/cantera_kinetics.C
+++ b/src/properties/src/cantera_kinetics.C
@@ -36,8 +36,10 @@
 // libMesh
 #include "libmesh/getpot.h"
 
-// Cantera
+// Cantera (with compiler warnings disabled)
+#include "libmesh/ignore_warnings.h"
 #include "cantera/IdealGasMix.h"
+#include "libmesh/restore_warnings.h"
 
 namespace GRINS
 {

--- a/src/properties/src/cantera_transport.C
+++ b/src/properties/src/cantera_transport.C
@@ -36,9 +36,11 @@
 // libMesh
 #include "libmesh/getpot.h"
 
-// Cantera
+// Cantera (with compiler warnings disabled)
+#include "libmesh/ignore_warnings.h"
 #include "cantera/IdealGasMix.h"
 #include "cantera/transport.h"
+#include "libmesh/restore_warnings.h"
 
 namespace GRINS
 {


### PR DESCRIPTION
I'm also using the libMesh ignore/restore_warnings headers to get the
compiler to shut up about Cantera.  Grant me the serenity and all
that.
