### PR TITLE
Fix SplitString for single entry case

### DIFF
--- a/src/utilities/include/grins/string_utils.h
+++ b/src/utilities/include/grins/string_utils.h
@@ -108,9 +108,16 @@ namespace GRINS
 
     newPos = input.find (delimiter, 0);
 
-    if( newPos < 0 )
+    /* We already checked if the input size was zero, so if we didn't
+       find any delimiters, we assume that there is exactly one entry
+       in the input and just return that. */
+    /*! \todo We should probably try and trim white space in this case */
+    if( newPos == input.npos )
       { 
-	return 0; 
+        results.push_back(input);
+
+        // We found 1 entry
+        return 1;
       }
 
     int numFound = 0;


### PR DESCRIPTION
We do this by assuming that, if the string is not empty, then there
must be just one entry if no delimiters are found, so we just return
what was input.

@roystgnr, look OK to you?
