### PR TITLE
Allow DiffSolver::continue_after_backtrack_failure

### DIFF
--- a/src/solver/include/grins/grins_solver.h
+++ b/src/solver/include/grins/grins_solver.h
@@ -72,8 +72,9 @@ namespace GRINS
     double _absolute_step_tolerance;
     double _relative_residual_tolerance;
     double _absolute_residual_tolerance;
-    unsigned int _max_linear_iterations;
     double _initial_linear_tolerance;
+    unsigned int _max_linear_iterations;
+    bool _continue_after_backtrack_failure;
 
     // Screen display options
     bool _solver_quiet;

--- a/src/solver/src/grins_solver.C
+++ b/src/solver/src/grins_solver.C
@@ -45,8 +45,9 @@ namespace GRINS
       _absolute_step_tolerance( input("linear-nonlinear-solver/absolute_step_tolerance", 0.0 ) ),
       _relative_residual_tolerance( input("linear-nonlinear-solver/relative_residual_tolerance", 1.e-15 ) ),
       _absolute_residual_tolerance( input("linear-nonlinear-solver/absolute_residual_tolerance", 0.0 ) ),
-      _max_linear_iterations( input("linear-nonlinear-solver/max_linear_iterations", 500 ) ),
       _initial_linear_tolerance( input("linear-nonlinear-solver/initial_linear_tolerance", 1.e-3 ) ),
+      _max_linear_iterations( input("linear-nonlinear-solver/max_linear_iterations", 500 ) ),
+      _continue_after_backtrack_failure( input("linear-nonlinear-solver/continue_after_backtrack_failure", false ) ),
       _solver_quiet( input("screen-options/solver_quiet", false ) ),
       _solver_verbose( input("screen-options/solver_verbose", false ) )
   {
@@ -89,6 +90,7 @@ namespace GRINS
     solver.relative_residual_tolerance = this->_relative_residual_tolerance;
     solver.absolute_residual_tolerance = this->_absolute_residual_tolerance;
     solver.max_linear_iterations       = this->_max_linear_iterations;
+    solver.continue_after_backtrack_failure = this->_continue_after_backtrack_failure;
     solver.initial_linear_tolerance    = this->_initial_linear_tolerance;
 
     return;


### PR DESCRIPTION
This doesn't change the default behavior, but it's useful to turn on when investigating a new problem.
