### PR TITLE
Runtime selection of Mesh/SerialMesh/ParallelMesh

### DIFF
--- a/src/solver/include/grins/mesh_builder.h
+++ b/src/solver/include/grins/mesh_builder.h
@@ -41,7 +41,7 @@ namespace GRINS
   {    
   public:
 
-    //! This Object handles building a libMesh::Mesh
+    //! This Object handles building a libMesh::UnstructuredMesh subclass.
     /*! Based on runtime input, either a generic 1, 2, or 3-dimensional
         mesh is built; or is read from input from a specified file. */
     MeshBuilder();
@@ -49,8 +49,8 @@ namespace GRINS
 
     void read_input_options( const GetPot& input );
 
-    //! Builds the libMesh::Mesh according to input options.
-    std::tr1::shared_ptr<libMesh::Mesh> build(const GetPot& input );
+    //! Builds the libMesh::UnstructuredMesh subclass according to input options.
+    std::tr1::shared_ptr<libMesh::UnstructuredMesh> build(const GetPot& input );
 
   };
 

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -87,7 +87,7 @@ namespace GRINS
     void attach_dirichlet_bc_funcs( std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > dbc_map,
 				    GRINS::MultiphysicsSystem* system );
 
-    std::tr1::shared_ptr<libMesh::Mesh> _mesh;
+    std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 
     std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;
 

--- a/src/solver/include/grins/simulation_builder.h
+++ b/src/solver/include/grins/simulation_builder.h
@@ -44,7 +44,7 @@ namespace GRINS
     SimulationBuilder();
     virtual ~SimulationBuilder();
 
-    std::tr1::shared_ptr<libMesh::Mesh> build_mesh( const GetPot& input );
+    std::tr1::shared_ptr<libMesh::UnstructuredMesh> build_mesh( const GetPot& input );
 
     GRINS::PhysicsList build_physics( const GetPot& input );
 

--- a/src/solver/src/simulation_builder.C
+++ b/src/solver/src/simulation_builder.C
@@ -94,7 +94,7 @@ namespace GRINS
     this->_error_estimator_factory = error_estimator_factory;
   }
 
-  std::tr1::shared_ptr<libMesh::Mesh> SimulationBuilder::build_mesh( const GetPot& input )
+  std::tr1::shared_ptr<libMesh::UnstructuredMesh> SimulationBuilder::build_mesh( const GetPot& input )
   {
     return (this->_mesh_builder)->build(input);
   }


### PR DESCRIPTION
We default to whatever libMesh was configured with, but now we can change that at runtime rather than by reconfiguring libMesh.
