### PR TITLE
Print command line at the start of a GRINS run

### DIFF
--- a/src/solver/src/grins.C
+++ b/src/solver/src/grins.C
@@ -77,6 +77,11 @@ int main(int argc, char* argv[])
   // Initialize libMesh library.
   LibMeshInit libmesh_init(argc, argv);
  
+  libMesh::out << "Starting GRINS with command:\n";
+  for (unsigned int i=0; i != argc; ++i)
+    libMesh::out << argv[i] << ' ';
+  libMesh::out << std::endl;
+
   GRINS::SimulationBuilder sim_builder;
 
   GRINS::Simulation grins( libMesh_inputfile,


### PR DESCRIPTION
This is useful when testing performance with various PETSc option combinations, and for keeping outputs reproduceable.

If you don't want to clutter up the output by default then we could make this an option itself.
