### PR TITLE
Use tar-pax format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AX_PREFIX_CONFIG_H(grins_config.h,GRINS,grins_config.h.tmp)
 
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CANONICAL_TARGET()
-AM_INIT_AUTOMAKE([dist-bzip2 tar-ustar 1.11 no-define color-tests parallel-tests])
+AM_INIT_AUTOMAKE([dist-bzip2 tar-pax 1.11 no-define color-tests parallel-tests])
 AM_SILENT_RULES(yes)  # use silent rules where available - automake 1.11
 
 LT_INIT


### PR DESCRIPTION
GNU docs say the format is "new" but was standardized in 2001.

With the older tar-ustar format, we were failing "make distcheck"
thanks to a 100+-character regression test filename that would end up
omitted (silently!?!) from the dist tarballs.  We could rename our
long-named tests, but doxygen seems to like generating huge filenames
from huge class names and I don't want to risk future equally-subtle
bugs.
