### PR TITLE
[GRINS]: fixing typo: 'steppping'-->'stepping'

### DIFF
--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -155,7 +155,7 @@ namespace GRINS
 
     std::time_t final_wall_time = std::time(NULL);
     std::cout << "==========================================================" << std::endl
-	      << "   Ending time steppping, t = " << context.system->time <<
+	      << "   Ending time stepping, t = " << context.system->time <<
                  ", runtime = " << (final_wall_time - first_wall_time) << 
                  std::endl
               << "==========================================================" << std::endl;


### PR DESCRIPTION
Admittedly a very petty edit but this minor typo keeps jumping out at me when I am looking at the log files from runs. 
