### PR TITLE
Fix libMesh header inclusions

### DIFF
--- a/examples/laminar_flame/bunsen_source.h
+++ b/examples/laminar_flame/bunsen_source.h
@@ -28,6 +28,10 @@
 #include "grins/grins_enums.h"
 #include "grins/physics.h"
 
+// libMesh
+#include "libmesh/enum_fe_family.h"
+#include "libmesh/enum_order.h"
+
 namespace GRINS
 {
   class AssemblyContext;

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -37,6 +37,7 @@
 
 //libMesh
 #include "libmesh/libmesh.h"
+#include "libmesh/point.h"
 
 // GRVY
 #ifdef GRINS_HAVE_GRVY

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -39,6 +39,7 @@
 #include "grins/postprocessed_quantities.h"
 
 // libMesh
+#include "libmesh/error_estimator.h"
 #include "libmesh/getpot.h"
 #include "libmesh/mesh.h"
 

--- a/src/solver/include/grins/solver_context.h
+++ b/src/solver/include/grins/solver_context.h
@@ -27,12 +27,13 @@
 
 #include "boost/tr1/memory.hpp"
 
-// libMesh
-#include "libmesh/equation_systems.h"
-
 // GRINS
 #include "grins/visualization.h"
 #include "grins/postprocessed_quantities.h"
+
+// libMesh
+#include "libmesh/error_estimator.h"
+#include "libmesh/equation_systems.h"
 
 namespace GRINS
 {

--- a/src/utilities/include/grins/cached_values.h
+++ b/src/utilities/include/grins/cached_values.h
@@ -32,7 +32,7 @@
 
 // libMesh
 #include "libmesh/libmesh.h"
-#include "libmesh/exact_error_estimator.h" //libMesh::Gradient
+#include "libmesh/vector_value.h" //libMesh::Gradient
 
 // GRINS
 #include "grins/cached_quantities_enum.h"


### PR DESCRIPTION
There seems to have been a libMesh header change (include replaced
with forward declaration?) which broke GRINS; this fixes that, and
removes error_estimator.h inclusion from files that don't use it.
