### PR TITLE
Tolerance tweaks on penalty regression test

### DIFF
--- a/test/input_files/penalty_poiseuille.in
+++ b/test/input_files/penalty_poiseuille.in
@@ -24,8 +24,8 @@ max_linear_iterations = 2500
 initial_linear_tolerance = 1.0e-12
 minimum_linear_tolerance = 1.0e-12
 
-relative_residual_tolerance = 1.0e-9
-relative_step_tolerance     = 1.0e-9
+relative_residual_tolerance = 1.0e-10
+relative_step_tolerance     = 1.0e-10
 
 verify_analytic_jacobians = 1.e-6
 

--- a/test/penalty_poiseuille.sh.in
+++ b/test/penalty_poiseuille.sh.in
@@ -2,7 +2,7 @@
 
 PROG="@top_builddir@/test/grins_flow_regression"
 
-INPUT="@top_srcdir@/test/input_files/penalty_poiseuille.in @top_srcdir@/test/test_data/penalty_poiseuille.xdr"
+INPUT="@top_srcdir@/test/input_files/penalty_poiseuille.in @top_srcdir@/test/test_data/penalty_poiseuille.xdr 1e-9"
 
 PETSC_OPTIONS="-pc_type ilu"
 


### PR DESCRIPTION
Non-zero regression tolerance to handle rounding error; smaller
solver tolerance to make sure we're not handling more error.
