### PR TITLE
mkdir when vis output gets placed in a subdir

### DIFF
--- a/src/visualization/src/visualization.C
+++ b/src/visualization/src/visualization.C
@@ -40,6 +40,7 @@
 #include "libmesh/vtk_io.h"
 
 // POSIX
+#include <sys/errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
This way we don't have to remember to pre-create subdirectories before
launching jobs with more organized output locations.

This seems to work correctly upon testing.
