### PR TITLE
Always throw errors for bad string conversions

### DIFF
--- a/src/utilities/include/grins/string_utils.h
+++ b/src/utilities/include/grins/string_utils.h
@@ -43,7 +43,8 @@ namespace GRINS
     std::istringstream converter(input);
     T returnval;
     converter >> returnval;
-    libmesh_assert(!converter.fail());
+    if (converter.fail())
+      libmesh_error();
     return returnval;
   }
 


### PR DESCRIPTION
If we're doing things right, the only string conversions are at
initialization time and the results get cached as proper types, so
it shouldn't be too expensive to do an extra if() even in opt mode.

Not as expensive as having a typo in my config file and not noticing
until I see the time steps full of NaNs, certainly...
