### PR TITLE
Velocity penalty orthogonality

### DIFF
--- a/src/physics/include/grins/velocity_penalty_base.h
+++ b/src/physics/include/grins/velocity_penalty_base.h
@@ -60,7 +60,12 @@ namespace GRINS
    
   protected:
 
+    // Make penalty force proportional to |u|(u*n) instead of just
+    // (u*n)
     bool _quadratic_scaling;
+
+    // Do not apply any force parallel to the velocity
+    bool _orthogonal_force;
 
     libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > normal_vector_function;
 

--- a/src/physics/src/velocity_penalty_base.C
+++ b/src/physics/src/velocity_penalty_base.C
@@ -35,7 +35,8 @@ namespace GRINS
 
   VelocityPenaltyBase::VelocityPenaltyBase( const std::string& physics_name, const GetPot& input )
     : IncompressibleNavierStokesBase(physics_name, input),
-    _quadratic_scaling(false)
+    _quadratic_scaling(false),
+    _orthogonal_force(false)
   {
     this->read_input_options(input);
 
@@ -76,6 +77,9 @@ namespace GRINS
 
     _quadratic_scaling = 
       input("Physics/"+velocity_penalty+"/quadratic_scaling", false);
+
+    _orthogonal_force = 
+      input("Physics/"+velocity_penalty+"/orthogonal_force", false);
   }
 
   bool VelocityPenaltyBase::compute_force
@@ -153,15 +157,31 @@ namespace GRINS
       }
 
     // With correction term to avoid doing work on flow
-    bool do_correction = false;
-    if (do_correction)
+    if (_orthogonal_force)
       {
-        if (dFdU)
-          libmesh_not_implemented();
-
         const libMesh::Number U_Rel_mag_sq = U_Rel * U_Rel;
+
         if (U_Rel_mag_sq)
           {
+            if (dFdU)
+              {
+                const libMesh::Number RF = U_Rel * F;
+                const libMesh::Number RF_over_RR = RF / U_Rel_mag_sq;
+                const libMesh::NumberVectorValue RFp = dFdU->transpose() * U_Rel;
+                const libMesh::NumberVectorValue QV =
+                  (RFp-RF_over_RR*2*U_Rel)/U_Rel_mag_sq;
+
+                for (unsigned int i=0; i != 3; ++i)
+                  {
+                    (*dFdU)(i,i) -= RF_over_RR;
+
+                    for (unsigned int j=0; j != 3; ++j)
+                      {
+                        (*dFdU)(i,j) -= U_Rel(i)*QV(j);
+                      }
+                  }
+              }
+
             F -= (U_Rel*F)*U_Rel/U_Rel_mag_sq;
           }
       }


### PR DESCRIPTION
Not sure this is worth merging; putting it up for @nicholasmalaya to look at.

Nick, apparently the answer to the paradox of "if we can't impose any penalty force parallel to the velocity, then what happens if the penalty normal is parallel to the velocity" is "the nonlinear solver screams and dies".  The Jacobians here are satisfying numeric tests, I switched from ILU to MUMPS LU to get the linear solves to all converge, but the nonlinear solver dies after a few (barely residual reducing) steps anyway.  I'll let Bob know and we'll see if this is worth futzing with further.