### PR TITLE
Fix sign error in AdjointStabilization classes

### DIFF
--- a/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
@@ -341,24 +341,24 @@ namespace GRINS
         // for both at the same time.
         for (unsigned int i=0; i != n_p_dofs; i++)
           {
-            Fp(i) += -tau_M*residual*p_dphi[i][qp]*JxW[qp];
+            Fp(i) += tau_M*residual*p_dphi[i][qp]*JxW[qp];
 
             if (compute_jacobian)
               {
                 for (unsigned int j=0; j != n_T_dofs; ++j)
                   {
-                    KpT(i,j) += -tau_M*d_residual_dT*T_phi[j][qp]*p_dphi[i][qp]*JxW[qp];
+                    KpT(i,j) += tau_M*d_residual_dT*T_phi[j][qp]*p_dphi[i][qp]*JxW[qp];
                   }
 
                 for (unsigned int j=0; j != n_u_dofs; ++j)
                   {
-                    Kpu(i,j) += -d_tau_M_dU(0)*u_phi[j][qp]*residual*p_dphi[i][qp]*JxW[qp];
-                    Kpv(i,j) += -d_tau_M_dU(1)*u_phi[j][qp]*residual*p_dphi[i][qp]*JxW[qp];
+                    Kpu(i,j) += d_tau_M_dU(0)*u_phi[j][qp]*residual*p_dphi[i][qp]*JxW[qp];
+                    Kpv(i,j) += d_tau_M_dU(1)*u_phi[j][qp]*residual*p_dphi[i][qp]*JxW[qp];
                   }
                 if( this->_dim == 3 )
                   for (unsigned int j=0; j != n_u_dofs; ++j)
                     {
-                      (*Kpw)(i,j) += -d_tau_M_dU(2)*u_phi[j][qp]*residual*p_dphi[i][qp]*JxW[qp];
+                      (*Kpw)(i,j) += d_tau_M_dU(2)*u_phi[j][qp]*residual*p_dphi[i][qp]*JxW[qp];
                     }
               }
           }

--- a/src/physics/src/velocity_penalty_adjoint_stab.C
+++ b/src/physics/src/velocity_penalty_adjoint_stab.C
@@ -322,27 +322,27 @@ namespace GRINS
         // for both at the same time.
         for (unsigned int i=0; i != n_p_dofs; i++)
           {
-            Fp(i) += tau_M*F*p_dphi[i][qp]*JxW[qp];
+            Fp(i) += -tau_M*F*p_dphi[i][qp]*JxW[qp];
 
             if (compute_jacobian)
               {
                 for (unsigned int j=0; j != n_u_dofs; ++j)
                   {
-                    Kpu(i,j) += d_tau_M_dU(0)*u_phi[j][qp]*F*p_dphi[i][qp]*JxW[qp];
-                    Kpv(i,j) += d_tau_M_dU(1)*u_phi[j][qp]*F*p_dphi[i][qp]*JxW[qp];
+                    Kpu(i,j) += -d_tau_M_dU(0)*u_phi[j][qp]*F*p_dphi[i][qp]*JxW[qp];
+                    Kpv(i,j) += -d_tau_M_dU(1)*u_phi[j][qp]*F*p_dphi[i][qp]*JxW[qp];
                     for (unsigned int d=0; d != 3; ++d)
                       {
-                        Kpu(i,j) += tau_M*dFdU(d,0)*u_phi[j][qp]*p_dphi[i][qp](d)*JxW[qp];
-                        Kpv(i,j) += tau_M*dFdU(d,1)*u_phi[j][qp]*p_dphi[i][qp](d)*JxW[qp];
+                        Kpu(i,j) += -tau_M*dFdU(d,0)*u_phi[j][qp]*p_dphi[i][qp](d)*JxW[qp];
+                        Kpv(i,j) += -tau_M*dFdU(d,1)*u_phi[j][qp]*p_dphi[i][qp](d)*JxW[qp];
                       }
                   }
                 if( this->_dim == 3 )
                   for (unsigned int j=0; j != n_u_dofs; ++j)
                     {
-                      (*Kpw)(i,j) += d_tau_M_dU(2)*u_phi[j][qp]*F*p_dphi[i][qp]*JxW[qp];
+                      (*Kpw)(i,j) += -d_tau_M_dU(2)*u_phi[j][qp]*F*p_dphi[i][qp]*JxW[qp];
                       for (unsigned int d=0; d != 3; ++d)
                         {
-                          (*Kpw)(i,j) += tau_M*dFdU(d,2)*u_phi[j][qp]*p_dphi[i][qp](d)*JxW[qp];
+                          (*Kpw)(i,j) += -tau_M*dFdU(d,2)*u_phi[j][qp]*p_dphi[i][qp](d)*JxW[qp];
                         }
                     }
               }


### PR DESCRIPTION
This does still turn the examples/convection_cell results into garbage.

However, refinement (especially boundary layer refinement) fixes those results (they converge towards a reasonable looking solution, and if I bump up mu&k then the solution resembles an unstabilized solution).

With the wrong sign, coarse grids look better superficially, but the flow behavior seems to be incredibly sensitive to T_ref, which in theory should have no effect other than to add or subtract a vertical pressure gradient.

We can discuss this for a bit before merging.
