### PR TITLE
Add google group hyperlinks to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Engineering and Sciences ([ICES](https://www.ices.utexas.edu))
 at [The University of Texas at Austin](https://www.utexas.edu).
 
 We encourage pull requests for new features, bug fixes, etc. For questions regarding development,
-we have a grins-devel Google group setup. For user related questions, please use the grins-users
+we have a [grins-devel](https://groups.google.com/forum/#!forum/grins-devel) Google group setup. For user related questions, please use the [grins-users](https://groups.google.com/forum/#!forum/grins-users)
 group.
 
 Dependencies


### PR DESCRIPTION
I had to google around a bit to find the associated user and development lists. We should add grins-users and grins-devel google group hyperlinks to the readme, to make this more accessible.
