### PR TITLE
Cannot "initialize" value in the postprocessing computation

### DIFF
--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -26,9 +26,6 @@
 // This class
 #include "grins/low_mach_navier_stokes.h"
 
-// C++
-#include <limits>
-
 // GRINS
 #include "grins_config.h"
 #include "grins/assembly_context.h"
@@ -867,8 +864,6 @@ namespace GRINS
                                                                       const libMesh::Point& point,
                                                                       libMesh::Real& value )
   {
-    value = std::numeric_limits<libMesh::Real>::quiet_NaN();
-
     if( quantity_index == this->_rho_index )
       {
         libMesh::Real T = this->T(point,context);

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -798,8 +798,6 @@ namespace GRINS
   {
     Evaluator gas_evaluator( this->_gas_mixture );
 
-    value = std::numeric_limits<libMesh::Real>::quiet_NaN();
-
     if( quantity_index == this->_rho_index )
       {
         std::vector<libMesh::Real> Y( this->_n_species );

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -226,8 +226,6 @@ namespace GRINS
                                                             const libMesh::Point& point,
                                                             libMesh::Real& value )
   {
-    value = std::numeric_limits<libMesh::Real>::quiet_NaN();
-
     libMesh::DenseVector<libMesh::Number> output_vec(3);
 
     if( quantity_index == this->_velocity_penalty_x_index )


### PR DESCRIPTION
See discussion in #175. TL;DR - was "initializing" the value in the postprocessing computation, but we can't do that because we might overwrite a value set by a previous Physics. #175 discusses redoing the API so folks don't make that goof in the future.

Merging to 0.5.0-release branch, but will manually merge to master immediately.
