### PR TITLE
Print perflog mid-simulation if requested

### DIFF
--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -111,6 +111,7 @@ namespace GRINS
     bool _print_mesh_info;
     bool _print_log_info;
     bool _print_equation_system_info;
+    bool _print_perflog;
     bool _print_qoi;
     bool _print_scalars;
 
@@ -119,6 +120,7 @@ namespace GRINS
     bool _output_residual;
 
     unsigned int _timesteps_per_vis;
+    unsigned int _timesteps_per_perflog;
 
     std::tr1::shared_ptr<libMesh::ErrorEstimator> _error_estimator;
 

--- a/src/solver/include/grins/solver_context.h
+++ b/src/solver/include/grins/solver_context.h
@@ -57,8 +57,10 @@ namespace GRINS
     std::tr1::shared_ptr<libMesh::EquationSystems> equation_system;
     std::tr1::shared_ptr<GRINS::Visualization> vis;
     unsigned int timesteps_per_vis;
+    unsigned int timesteps_per_perflog;
     bool output_vis;
     bool output_residual;
+    bool print_perflog;
     bool print_scalars;
 
     std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> > postprocessing;

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -174,8 +174,8 @@ namespace GRINS
 	  context.vis->output_residual( context.equation_system, context.system,
                                         t_step, sim_time );
 
-        if ( context.print_perflog &&
-             !((t_step+1)%context.timesteps_per_perflog) )
+        if ( context.print_perflog && context.timesteps_per_perflog
+             && !((t_step+1)%context.timesteps_per_perflog) )
           libMesh::perflog.print_log();
 
         if ( context.print_scalars )

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -174,6 +174,10 @@ namespace GRINS
 	  context.vis->output_residual( context.equation_system, context.system,
                                         t_step, sim_time );
 
+        if ( context.print_perflog &&
+             !((t_step+1)%context.timesteps_per_perflog) )
+          libMesh::perflog.print_log();
+
         if ( context.print_scalars )
           for (unsigned int v=0; v != context.system->n_vars(); ++v)
             if (context.system->variable(v).type().family ==

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -51,13 +51,12 @@ namespace GRINS
     _print_mesh_info( input("screen-options/print_mesh_info", false ) ),
     _print_log_info( input("screen-options/print_log_info", false ) ),
     _print_equation_system_info( input("screen-options/print_equation_system_info", false ) ),
-    _print_perflog( input("screen-options/print_perflog", false ) ),
     _print_qoi( input("screen-options/print_qoi", false ) ),
     _print_scalars( input("screen-options/print_scalars", false ) ),
     _output_vis( input("vis-options/output_vis", false ) ),
     _output_residual( input( "vis-options/output_residual", false ) ),
     _timesteps_per_vis( input("vis-options/timesteps_per_vis", 1 ) ),
-    _timesteps_per_perflog( input("screen-options/timesteps_per_perflog", 1 ) ),
+    _timesteps_per_perflog( input("screen-options/timesteps_per_perflog", 0 ) ),
     _error_estimator() // effectively NULL
   {
     // Only print libMesh logging info if the user requests it
@@ -139,7 +138,7 @@ namespace GRINS
     context.output_vis = _output_vis;
     context.output_residual = _output_residual;
     context.print_scalars = _print_scalars;
-    context.print_perflog = _print_perflog;
+    context.print_perflog = _print_log_info;
     context.postprocessing = _postprocessing;
     context.error_estimator = _error_estimator;
 

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -51,11 +51,13 @@ namespace GRINS
     _print_mesh_info( input("screen-options/print_mesh_info", false ) ),
     _print_log_info( input("screen-options/print_log_info", false ) ),
     _print_equation_system_info( input("screen-options/print_equation_system_info", false ) ),
+    _print_perflog( input("screen-options/print_perflog", false ) ),
     _print_qoi( input("screen-options/print_qoi", false ) ),
     _print_scalars( input("screen-options/print_scalars", false ) ),
     _output_vis( input("vis-options/output_vis", false ) ),
     _output_residual( input( "vis-options/output_residual", false ) ),
     _timesteps_per_vis( input("vis-options/timesteps_per_vis", 1 ) ),
+    _timesteps_per_perflog( input("screen-options/timesteps_per_perflog", 1 ) ),
     _error_estimator() // effectively NULL
   {
     // Only print libMesh logging info if the user requests it
@@ -133,9 +135,11 @@ namespace GRINS
     context.equation_system = _equation_system;
     context.vis = _vis;
     context.timesteps_per_vis = _timesteps_per_vis;
+    context.timesteps_per_perflog = _timesteps_per_perflog;
     context.output_vis = _output_vis;
     context.output_residual = _output_residual;
     context.print_scalars = _print_scalars;
+    context.print_perflog = _print_perflog;
     context.postprocessing = _postprocessing;
     context.error_estimator = _error_estimator;
 

--- a/src/solver/src/solver_context.C
+++ b/src/solver/src/solver_context.C
@@ -36,8 +36,10 @@ namespace GRINS
       equation_system( std::tr1::shared_ptr<libMesh::EquationSystems>() ),
       vis( std::tr1::shared_ptr<GRINS::Visualization>() ),
       timesteps_per_vis( 1 ),
+      timesteps_per_perflog( 1 ),
       output_vis( false ),
       output_residual( false ),
+      print_perflog( false ),
       print_scalars( false ),
       postprocessing( std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> >() )
   {

--- a/test/input_files/dirichlet_fem.in
+++ b/test/input_files/dirichlet_fem.in
@@ -37,6 +37,8 @@ print_mesh_info = 'true'
 print_log_info = 'true'
 solver_verbose = 'true'
 solver_quiet = 'false'
+print_perflog = 'true'
+timesteps_per_perflog = 4
 
 echo_physics = 'true'
 

--- a/test/input_files/dirichlet_fem.in
+++ b/test/input_files/dirichlet_fem.in
@@ -37,7 +37,6 @@ print_mesh_info = 'true'
 print_log_info = 'true'
 solver_verbose = 'true'
 solver_quiet = 'false'
-print_perflog = 'true'
 timesteps_per_perflog = 4
 
 echo_physics = 'true'


### PR DESCRIPTION
This is a feature @nicholasmalaya may find useful - we output the accumulating PerfLog data every N timesteps, not just at the end of a simulation, so there's less of a wait time before being able to examine performance changes.

One oddity: due to the way the libMesh PerfLog works, we get the machine info with the first print, and not with any subsequent prints.  I think this is the best way to do things, but it looks weird and I can move the machine info back to the final PerfLog if that's preferred.