### PR TITLE
Warning and error when using outdated vis-options/output_vars

### DIFF
--- a/examples/laminar_flame/bunsen.in
+++ b/examples/laminar_flame/bunsen.in
@@ -81,6 +81,8 @@ bound_species_3 = '0.0 0.2 0.0 0.0 0.0 0.0 0.0 0.8'
 enable_thermo_press_calc = 'false'
 pin_pressure = 'false'
 
+output_vars = 'rho_mix h_s mole_fractions omega_dot'
+
 []
 
 [restart-options]
@@ -118,8 +120,6 @@ vis_output_file_prefix = 'output'
 output_residual = 'false'
 
 output_format = 'ExodusII xdr'
-
-output_vars = 'rho_mix h_s mole_fractions omega_dot'
 
 # Options for print info to the screen
 [screen-options]

--- a/src/visualization/src/postprocessed_quantities.C
+++ b/src/visualization/src/postprocessed_quantities.C
@@ -31,9 +31,20 @@
 namespace GRINS
 {
   template<class NumericType>
-  PostProcessedQuantities<NumericType>::PostProcessedQuantities( const GetPot& /*input*/ )
+  PostProcessedQuantities<NumericType>::PostProcessedQuantities( const GetPot& input )
     : libMesh::FEMFunctionBase<NumericType>()
   {
+    if( input.have_variable("vis-options/output_vars") )
+      {
+
+        std::cerr << "================================================================================" << std::endl
+                  << "WARNING: Detected input variable 'vis-options/output_vars." << std::endl
+                  << "WARNING: THIS IS OUTDATED. output_vars is now input within" << std::endl
+                  << "WARNING: each Physics section." << std::endl
+                  << "         Erroring out to make you aware." << std::endl
+                  << "================================================================================" << std::endl;
+        libmesh_error();
+      }
     return;
   }
 


### PR DESCRIPTION
@roystgnr rightly pointed out that I should've had a warning scream at you if you still use vis-options/output_vars following #167. This adds such a warning. Also throw libmesh_error() for now.

Set to merge to 0.5.0-release. Will manually merge to master once the PR merges.