### PR TITLE
Guard against get_elem() calls for SCALAR variables

### DIFF
--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -186,6 +186,14 @@ namespace GRINS
 			    libMesh::DiffContext& context,
                             ResFuncType resfunc,
                             CacheFuncType cachefunc);
+
+    // Refactored nonlocal residual evaluation implementation
+    // This is separate since this is only called when context._elem=NULL
+    // and the enabled_on_elem() is meaningless.
+    bool _nonlocal_residual( bool request_jacobian,
+                             libMesh::DiffContext& context,
+                             ResFuncType resfunc,
+                             CacheFuncType cachefunc);
   };
 
   inline

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -186,14 +186,6 @@ namespace GRINS
 			    libMesh::DiffContext& context,
                             ResFuncType resfunc,
                             CacheFuncType cachefunc);
-
-    // Refactored nonlocal residual evaluation implementation
-    // This is separate since this is only called when context._elem=NULL
-    // and the enabled_on_elem() is meaningless.
-    bool _nonlocal_residual( bool request_jacobian,
-                             libMesh::DiffContext& context,
-                             ResFuncType resfunc,
-                             CacheFuncType cachefunc);
   };
 
   inline

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -226,51 +226,23 @@ namespace GRINS
 	 physics_iter != _physics_list.end();
 	 physics_iter++ )
       {
-	// Only compute if physics is active on current subdomain or globally
-	if( (physics_iter->second)->enabled_on_elem( &c.get_elem() ) )
-	  {
-	    ((*(physics_iter->second)).*resfunc)( compute_jacobian, c, cache );
-	  }
+        if(c.has_elem())
+          {
+            if( (physics_iter->second)->enabled_on_elem( &c.get_elem() ) )
+              {
+                ((*(physics_iter->second)).*resfunc)( compute_jacobian, c, cache );
+              }
+          }
+        else
+          {
+            ((*(physics_iter->second)).*resfunc)( compute_jacobian, c, cache );
+          }
       }
 
     // TODO: Need to think about the implications of this because there might be some
     // TODO: jacobian terms we don't want to compute for efficiency reasons
     return compute_jacobian;
   }
-
-   bool MultiphysicsSystem::_nonlocal_residual( bool request_jacobian,
-                                                libMesh::DiffContext& context,
-                                                ResFuncType resfunc,
-                                                CacheFuncType cachefunc)
-  {
-    AssemblyContext& c = libMesh::libmesh_cast_ref<AssemblyContext&>(context);
-
-    bool compute_jacobian = true;
-    if( !request_jacobian || _use_numerical_jacobians_only ) compute_jacobian = false;
-
-    CachedValues cache;
-
-    // Now compute cache for this element
-    for( PhysicsListIter physics_iter = _physics_list.begin();
-	 physics_iter != _physics_list.end();
-	 physics_iter++ )
-      {
-        // boost::shared_ptr gets confused by operator->*
-	((*(physics_iter->second)).*cachefunc)( c, cache );
-      }
-
-    // Loop over each physics and compute their contributions
-    for( PhysicsListIter physics_iter = _physics_list.begin();
-	 physics_iter != _physics_list.end();
-	 physics_iter++ )
-      {
-
-        ((*(physics_iter->second)).*resfunc)( compute_jacobian, c, cache );
-      }
-
-    return compute_jacobian;
-  }
-
 
   bool MultiphysicsSystem::element_time_derivative( bool request_jacobian,
 						    libMesh::DiffContext& context )
@@ -295,7 +267,7 @@ namespace GRINS
   bool MultiphysicsSystem::nonlocal_time_derivative( bool request_jacobian,
 						     libMesh::DiffContext& context )
   {
-    return this->_nonlocal_residual
+    return this->_general_residual
       (request_jacobian,
        context,
        &GRINS::Physics::nonlocal_time_derivative,
@@ -325,7 +297,7 @@ namespace GRINS
   bool MultiphysicsSystem::nonlocal_constraint( bool request_jacobian,
 					        libMesh::DiffContext& context )
   {
-    return this->_nonlocal_residual
+    return this->_general_residual
       (request_jacobian,
        context,
        &GRINS::Physics::nonlocal_constraint,
@@ -345,7 +317,7 @@ namespace GRINS
   bool MultiphysicsSystem::nonlocal_mass_residual( bool request_jacobian,
 					           libMesh::DiffContext& context )
   {
-    return this->_nonlocal_residual
+    return this->_general_residual
       (request_jacobian,
        context,
        &GRINS::Physics::nonlocal_mass_residual,

--- a/src/visualization/src/postprocessed_quantities.C
+++ b/src/visualization/src/postprocessed_quantities.C
@@ -117,11 +117,28 @@ namespace GRINS
   {
     // Check if the Elem is the same between the incoming context and the cached one.
     // If not, reinit the cached MultiphysicsSystem context
-    if( &(context.get_elem()) != &(_multiphysics_context->get_elem()) )
+    if(context.has_elem() && _multiphysics_context->has_elem())
       {
-	_multiphysics_context->pre_fe_reinit(*_multiphysics_sys,&context.get_elem());
-	_multiphysics_context->elem_fe_reinit();
+        if( &(context.get_elem()) != &(_multiphysics_context->get_elem()) )
+          {
+            _multiphysics_context->pre_fe_reinit(*_multiphysics_sys,&context.get_elem());
+            _multiphysics_context->elem_fe_reinit();
+          }
       }
+    else if( !context.has_elem() && _multiphysics_context->has_elem() )
+      {
+        // Incoming context has NULL elem ==> SCALAR variables
+        _multiphysics_context->pre_fe_reinit(*_multiphysics_sys,NULL);
+        _multiphysics_context->elem_fe_reinit();
+      }
+    else if( context.has_elem() && !_multiphysics_context->has_elem() )
+      {
+        _multiphysics_context->pre_fe_reinit(*_multiphysics_sys,&context.get_elem());
+        _multiphysics_context->elem_fe_reinit();
+      }
+    //else
+    /* If has_elem() is false for both contexts, we're still dealing with SCALAR variables
+       and therefore don't need to reinit. */
 
     libMesh::Real value = 0.0;
 


### PR DESCRIPTION
Basically in conjunction with libMesh/libmesh#467. With that plus this PR, master `make check` runs cleanly.