### PR TITLE
Doxygen update

### DIFF
--- a/doxygen/grins.dox.in
+++ b/doxygen/grins.dox.in
@@ -1263,7 +1263,8 @@ INCLUDE_FILE_PATTERNS  =
 # undefined via #undef or recursively expanded use the := operator 
 # instead of the = operator.
 
-PREDEFINED             = 
+PREDEFINED             = GRINS_HAVE_ANTIOCH \
+                         GRINS_HAVE_CANTERA
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then 
 # this tag can be used to specify a list of macro names that should be expanded. 

--- a/doxygen/grins.dox.in
+++ b/doxygen/grins.dox.in
@@ -567,15 +567,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories 
 # with spaces.
 
-INPUT                  = @abs_top_srcdir@/src/bc_handling          \
-                         @abs_top_srcdir@/src/boundary_conditions  \
-                         @abs_top_srcdir@/src/error_estimation     \
-                         @abs_top_srcdir@/src/ic_handling          \
-                         @abs_top_srcdir@/src/physics              \
-                         @abs_top_srcdir@/src/qoi                  \
-                         @abs_top_srcdir@/src/solver               \
-                         @abs_top_srcdir@/src/utilities            \
-                         @abs_top_srcdir@/src/visualization        \
+INPUT                  = @abs_top_srcdir@/src                      \
                          @abs_top_srcdir@/test                     \
 		       	 @abs_top_srcdir@/doxygen/grins.page       \
 			 @abs_top_builddir@/doxygen/txt_common/about_vpath.page \


### PR DESCRIPTION
Fixes Doxygen input file to actually build documentation for all the classes. This required 1. updating the INPUT variable (just tell it look in src and it will find everything) and 2. actually including Antioch and Cantera. We could've accomplished 2 by cluing Doxygen into grins_config.h in the build directory where then it would only include Antioch, for example, if it was actually present in the build. Using the PREDEFINED variable, we can tell Doxygen to just define those preprocessing parameters so that their documentation is always built. I prefer this so that we just always have the documentation for everything built all the time.

Set to merge to 0.5.0-release, will manually merge to master after this PR is merged.

Will leave this up for comments tonight and then merge tomorrow if no one has anything to add.