### PR TITLE
Bump Version to 0.6.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+Version 0.6.0 (In progress)
+
 Version 0.5.0
 https://github.com/grinsfem/grins/releases/tag/v0.5.0
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Requirements
 
 In addition to a modern C++ compiler,
 GRINS requires an up-to-date installation of the [libMesh](https://github.com/libMesh/libmesh.git)
-finite element library (currently version 1.0.0 prerelease) as well as the Boost C++ library.
+finite element library. GRINS release 0.5.0 can use libMesh versions as old as 0.9.4. Subsequent to
+the 0.5.0 release requires at least libMesh 1.0.0. The Boost C++ library is also required (header only).
 
 Optional Packages
 -----------------

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AC_PROG_FC
 dnl----------------
 dnl Libmesh Config
 dnl----------------
-AX_PATH_LIBMESH_NEW(0.9.4,yes)
+AX_PATH_LIBMESH_NEW(1.0.0,yes)
 AX_LIBMESH_DIM()
 
 AC_ARG_ENABLE([libmesh-flags],

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT(grins, 0.5.0, grins-users@googlegroups.com)
+AC_INIT(grins, 0.6.0, grins-users@googlegroups.com)
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CONFIG_HEADER(grins_config.h.tmp)


### PR DESCRIPTION
Also, I think I accidentally had overwritten the libMesh version requirement. It's back to 1.0.0 now. Also updated README.