### PR TITLE
Use LIBMESH_LIBS and display in configure summary

### DIFF
--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -34,6 +34,7 @@ echo Library Dependencies:
 echo libMesh....................... : $LIBMESH_PREFIX
 echo libMesh CXXFLAGS.............. : $LIBMESH_CXXFLAGS
 echo libMesh INCLUDE............... : $LIBMESH_INCLUDE
+echo libMesh LIBS.................. : $LIBMESH_LIBS
 #echo QUESO......................... : $QUESO_PREFIX
 #echo Trilinos...................... : $TRILINOS_PREFIX
 #echo HDF5.......................... : $HDF5_PREFIX

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -381,7 +381,7 @@ include_HEADERS += visualization/include/grins/postprocessing_factory.h
 if LIBMESH_LIBTOOL
    libgrins_la_LIBADD = $(LIBMESH_LIBDIR)/libmesh_$(LIBMESH_METHOD).la
 else
-   libgrins_la_LIBADD = $(LIBMESH_LDFLAGS)
+   libgrins_la_LIBADD = $(LIBMESH_LIBS)
 endif
 
 if GRVY_ENABLED
@@ -395,13 +395,13 @@ endif
 grins_SOURCES = solver/src/grins.C
 grins_LDADD = libgrins.la
 if !LIBMESH_LIBTOOL
-grins_LDADD += $(LIBMESH_LDFLAGS)
+grins_LDADD += $(LIBMESH_LIBS)
 endif
 
 grins_version_SOURCES = utilities/src/version.C
 grins_version_LDADD = libgrins.la
 if !LIBMESH_LIBTOOL
-grins_version_LDADD += $(LIBMESH_LDFLAGS)
+grins_version_LDADD += $(LIBMESH_LIBS)
 endif
 
 if CANTERA_ENABLED


### PR DESCRIPTION
Found this in working in #225 with @capitalaslash. If the libtool file is not found, we were using LIBMESH_LDFLAGS, but LIBMESH_LIBS is what gets populated by libmesh-config. Also now display LIBMESH_LIBS in the configure summary.

