### PR TITLE
Pass physics_name to flow_vars in IncompressibleNavierStokesBase

### DIFF
--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -42,7 +42,7 @@ namespace GRINS
   template<class Mu>
   IncompressibleNavierStokesBase<Mu>::IncompressibleNavierStokesBase(const std::string& physics_name, const GetPot& input )
     : Physics(physics_name, input),
-      _flow_vars(input, incompressible_navier_stokes),
+      _flow_vars(input, physics_name),
       _rho(input("Physics/"+incompressible_navier_stokes+"/rho", 1.0)),
       _mu(input)
   {


### PR DESCRIPTION
Contrary to 08e99bc49c27c8fdd6ab86336aa310fa05d39774, this really
should be physics_name because Stokes is subclassing this and
we should be able to parse Stokes section. Uncovered this as part of
turning on UFO detection.

I actually think that the variable classes could actually be treated
as "mixins" and we use multiple inheritance in the root physics classes
with these variable classes. Another day...

Make check is passing for me with this change.