### PR TITLE
Refactor mesh options input file specification

### DIFF
--- a/examples/backward_facing_step/backward_facing_step.in
+++ b/examples/backward_facing_step/backward_facing_step.in
@@ -49,9 +49,10 @@ tau_factor = '0.05'
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'read_mesh_from_file' 
-mesh_filename = 'mesh.e'
+[Mesh]
+   [./Read]
+      filename = 'mesh.e'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/examples/cable_displacement/cable.in
+++ b/examples/cable_displacement/cable.in
@@ -42,14 +42,14 @@ n_increments = '50'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_1D_mesh'
-#element_type = 'EDGE2'
-                                                                                                                                                                                                                                           
-domain_x1_min = '0.0'
-domain_x1_max = '8.0'
-
-mesh_nx1 = '10'
+[Mesh]
+   [./Generation]
+      dimension = '1'
+      element_type = 'EDGE2'
+      x_min = '0.0'
+      x_max = '8.0'
+      n_elems_x = '10'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/examples/cavity_benchmark/cavity.in
+++ b/examples/cavity_benchmark/cavity.in
@@ -108,17 +108,17 @@ cp = '1004.5' #[J/kg-K]
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 0.067
-domain_x2_min = 0.0
-domain_x2_max = 0.067
-
-mesh_nx1 = 50 
-mesh_nx2 = 50
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      x_min = '0.0'
+      x_max = '0.067'
+      y_min = '0.0'
+      y_max = '0.067'
+      n_elems_x = '50'
+      n_elems_y = '50'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/examples/convection_cell/convection_cell.in
+++ b/examples/convection_cell/convection_cell.in
@@ -101,17 +101,17 @@ tau_factor_T = '3.0'
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = -10.0
-domain_x1_max = 10.0
-domain_x2_min = 0.0
-domain_x2_max = 4.0
-
-mesh_nx1 = '40' 
-mesh_nx2 = '16'
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      x_min = '-10.0'
+      x_max = '10.0'
+      y_min = '0.0'
+      y_max = '4.0'
+      n_elems_x = '40'
+      n_elems_y = '16'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/examples/coupled_stokes_navierstokes/stokes_ns.in
+++ b/examples/coupled_stokes_navierstokes/stokes_ns.in
@@ -1,9 +1,11 @@
 # Mesh related options
-[mesh-options]
-mesh_option = 'read_mesh_from_file'
-mesh_filename = 'mesh.e'
+[Mesh]
+   [./Read]
+      filename = 'mesh.e'
 
-uniformly_refine = '2'
+   [../Refinement]
+      uniformly_refine = '2'
+[]
 
 # Options for time solvers
 [unsteady-solver]

--- a/examples/elastic_sheet/sheet.in
+++ b/examples/elastic_sheet/sheet.in
@@ -44,17 +44,15 @@ n_increments = '50'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_2D_mesh'
-element_type = 'QUAD4'
-                                                                                                                                                                                                                                           
-domain_x1_min = '0.0'
-domain_x1_max = '8.0'
-domain_x2_min = '0.0'
-domain_x2_max = '8.0'
-
-mesh_nx1 = '50'
-mesh_nx2 = '50'
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD4'
+      x_max = '8.0'
+      y_max = '8.0'
+      n_elems_x = '50'
+      n_elems_y = '50'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/examples/inflating_sheet/sheet.in
+++ b/examples/inflating_sheet/sheet.in
@@ -46,12 +46,11 @@ n_increments = '50'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'read_mesh_from_file'
-mesh_filename = 'sheet_coarse.e'
+[Mesh]
+   [./Read]
+      filename = 'sheet_coarse.e'
+[]
 
-#uniformly_refine = '1'
-                                                                                                                                                                                                                                           
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]
 relative_residual_tolerance = '1.0e-10'

--- a/examples/lid_driven_cavity/lid_driven_cavity.in
+++ b/examples/lid_driven_cavity/lid_driven_cavity.in
@@ -50,17 +50,18 @@ tau_factor = '1.0'
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      x_min = '0.0'
+      x_max = '1.0'
+      y_min = '-1.0'
+      y_max = '0.0'
+      n_elems_x = '15'
+      n_elems_y = '15'
+[]
 
-domain_x1_min = 0.0
-domain_x1_max = 1.0
-domain_x2_min = -1.0
-domain_x2_max = 0.0
-
-mesh_nx1 = '15' 
-mesh_nx2 = '15'
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -41,41 +41,41 @@
    # options will be in the Generation subsection.
    [./Generate]
 
-   # Specify the dimension of the mesh to build.
-   # Mandatory.
-   # Acceptable values: 1, 2, 3
-   dimension = '3'
+      # Specify the dimension of the mesh to build.
+      # Mandatory.
+      # Acceptable values: 1, 2, 3
+      dimension = '3'
 
-   # Specify the number of elements in the {x,y,z}-direction
-   # Mandatory:
-   #    dimension = 1: n_elems_x
-   #    dimension = 2: n_elems_x, n_elems_y
-   #    dimension = 3: n_elems_x, n_elems_y, n_elems_z
-   # Acceptable values: postive integer
-   n_elems_x = '10'
-   n_elems_y = '10'
-   n_elems_z = '10'
+      # Specify the number of elements in the {x,y,z}-direction
+      # Mandatory:
+      #    dimension = 1: n_elems_x
+      #    dimension = 2: n_elems_x, n_elems_y
+      #    dimension = 3: n_elems_x, n_elems_y, n_elems_z
+      # Acceptable values: postive integer
+      n_elems_x = '10'
+      n_elems_y = '10'
+      n_elems_z = '10'
 
-   # Specify the spatial extents in the {x,y,z}-direction
-   # Optional. {x,y,z}_min defaults to 0.0, {x,y,z}_max defaults to 1.0
-   # Acceptable values: Real number
-   x_min = '0.0'
-   x_max = '1.0'
+      # Specify the spatial extents in the {x,y,z}-direction
+      # Optional. {x,y,z}_min defaults to 0.0, {x,y,z}_max defaults to 1.0
+      # Acceptable values: Real number
+      x_min = '0.0'
+      x_max = '1.0'
 
-   y_min = '0.0'
-   y_max = '1.0'
+      y_min = '0.0'
+      y_max = '1.0'
 
-   z_min = '0.0'
-   z_max = '1.0'
+      z_min = '0.0'
+      z_max = '1.0'
 
-   # Specify the geometric element type to use in the mesh
-   # Optional:
-   #    dimension = 1, defaults to EDGE3
-   #    dimension = 2, defaults to TRI6
-   #    dimension = 3, defaults to TET10
-   # Acceptable values:
-   #    See enum libMesh::ElemType at libmesh.github.io/doxygen/index.html
-   element_type = 'QUAD4'
+      # Specify the geometric element type to use in the mesh
+      # Optional:
+      #    dimension = 1, defaults to EDGE3
+      #    dimension = 2, defaults to TRI6
+      #    dimension = 3, defaults to TET10
+      # Acceptable values:
+      #    See enum libMesh::ElemType at libmesh.github.io/doxygen/index.html
+      element_type = 'QUAD4'
 
 []
 

--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -30,10 +30,6 @@
 # a mesh from a file is given below. Use only ONE of these sections.
 [Mesh]
 
-   # Specify that we are generating a mesh
-   # Mandatory.
-   type = 'generate'
-
    # Specify whether you want to use libMesh::SerialMesh
    # or libMesh::ParallelMesh.
    # Optional. Defaults to libMesh::Mesh (which depends on the
@@ -88,10 +84,6 @@
 # mesh file. An example of generating  a mesh using libMesh's basic
 # utilities is given above. Use only ONE of these sections.
 [Mesh]
-
-   # Specify that we are generating a mesh
-   # Mandatory.
-   type = 'read'
 
    # Specify whether you want to use libMesh::SerialMesh
    # or libMesh::ParallelMesh.

--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -39,7 +39,7 @@
    # Optional. Defaults to libMesh::Mesh (which depends on the
    #           libMesh build.
    # Acceptable values: serial, parallel
-   mesh_class = 'serial'
+   class = 'serial'
 
    # Since we are generating a mesh, all the generation
    # options will be in the Generation subsection.
@@ -98,7 +98,7 @@
    # Optional. Defaults to libMesh::Mesh (which depends on the
    #           libMesh build.
    # Acceptable values: serial, parallel
-   mesh_class = 'serial'
+   class = 'serial'
 
    # Since we are reading a mesh, all read options
    # go in the Read subsection.

--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -39,7 +39,7 @@
 
    # Since we are generating a mesh, all the generation
    # options will be in the Generation subsection.
-   [./Generate]
+   [./Generation]
 
       # Specify the dimension of the mesh to build.
       # Mandatory.

--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -102,3 +102,37 @@
        filename = 'meshfile.exo'
 
 []
+
+# The block below illustrates two optional sections.
+# They can be used together, where redistribution will be done
+# before refinement, and can be used in conjunction with mesh
+# generation or reading a mesh from a file.
+[Mesh]
+
+   # Options related to doing input-based refinement. Adaptive refinement
+   # is controlled in the in solver section.
+   [./Refinement]
+
+       # Specify the number of uniform refinements to perform
+       # Optional. Defaults to 0.
+       uniformly_refine = '1'
+
+       # Specify a function of (x,y,z) suitable for libMesh::ParsedFunction.
+       # This function should return the number of refinements to be performed
+       # as a function of (x,y,z); element centroids are used to evaluate the
+       # spatial locations. Value from function will automatically be converted to int.
+       # If the value is less than zero, no refinements will be done.
+       locally_h_refine = '(9-x)/4.5+(abs(y)<.2)'
+
+   # Options related to input-based mesh redistribution
+   [../Redistribution]
+
+       # Specify a function of (x,y,z) suitable for libMesh::ParsedFunction.
+       # Nodal (x,y,z) locations will be mapped according to the function given.
+       # See libMesh::MeshTools::Modification::redistribute. Note each mapping componenet
+       # is in separated by {}. In the example given, the x-components of the node will be
+       # mapped by x+x*(x-30)/30, the y-compoenents of the nodes will by scaled by a factor of 2,
+       # and z-components remain unchanged.
+       function = '{x+x*(x-30)/30}{y*2}{z}'
+
+[]

--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -1,0 +1,112 @@
+# This master example input file is for reference on specifying
+# various input parameters to GRINS. The GetPot parsing library
+# is used to parse the input files. Documentation about GetPot
+# can be found here:
+# http://getpot.sourceforge.net/documentation-index.html
+# The Doxygen documentation can be found here:
+# http://libmesh.github.io/doxygen/classGETPOT__NAMESPACE_1_1GetPot.html
+#
+# We heavily use GetPots sectioning system, particularly nested
+# sections. Discussion of this can be found here:
+# http://getpot.sourceforge.net/node13.html
+# Below we give examples of different uses for the various sections
+# GRINS uses. Note that the section names must be unique. We provide
+# multiple example usages of the sections below, but you must only use
+# one. E.g. we illustrate the different uses of [Mesh] below, but
+# there must only be one instance of the [Mesh] section in the input
+# file used.
+#
+# GRINS uses GetPot's UFO capability so that if there are variables in the
+# input file that are unused during your program, GRINS will throw
+# an error. This is to reduce the chance of errors in the input
+# file specification.
+#
+# The primary sections are:
+#    [Mesh] - all options related to the mesh used in the simulation
+
+
+# The block below is an example of using basic mesh generation
+# utilities in libMesh to construct a mesh. An example of reading
+# a mesh from a file is given below. Use only ONE of these sections.
+[Mesh]
+
+   # Specify that we are generating a mesh
+   # Mandatory.
+   type = 'generate'
+
+   # Specify whether you want to use libMesh::SerialMesh
+   # or libMesh::ParallelMesh.
+   # Optional. Defaults to libMesh::Mesh (which depends on the
+   #           libMesh build.
+   # Acceptable values: serial, parallel
+   mesh_class = 'serial'
+
+   # Since we are generating a mesh, all the generation
+   # options will be in the Generation subsection.
+   [./Generate]
+
+   # Specify the dimension of the mesh to build.
+   # Mandatory.
+   # Acceptable values: 1, 2, 3
+   dimension = '3'
+
+   # Specify the number of elements in the {x,y,z}-direction
+   # Mandatory:
+   #    dimension = 1: n_elems_x
+   #    dimension = 2: n_elems_x, n_elems_y
+   #    dimension = 3: n_elems_x, n_elems_y, n_elems_z
+   # Acceptable values: postive integer
+   n_elems_x = '10'
+   n_elems_y = '10'
+   n_elems_z = '10'
+
+   # Specify the spatial extents in the {x,y,z}-direction
+   # Optional. {x,y,z}_min defaults to 0.0, {x,y,z}_max defaults to 1.0
+   # Acceptable values: Real number
+   x_min = '0.0'
+   x_max = '1.0'
+
+   y_min = '0.0'
+   y_max = '1.0'
+
+   z_min = '0.0'
+   z_max = '1.0'
+
+   # Specify the geometric element type to use in the mesh
+   # Optional:
+   #    dimension = 1, defaults to EDGE3
+   #    dimension = 2, defaults to TRI6
+   #    dimension = 3, defaults to TET10
+   # Acceptable values:
+   #    See enum libMesh::ElemType at libmesh.github.io/doxygen/index.html
+   element_type = 'QUAD4'
+
+[]
+
+
+# The block below is an example of reading a mesh from a given
+# mesh file. An example of generating  a mesh using libMesh's basic
+# utilities is given above. Use only ONE of these sections.
+[Mesh]
+
+   # Specify that we are generating a mesh
+   # Mandatory.
+   type = 'read'
+
+   # Specify whether you want to use libMesh::SerialMesh
+   # or libMesh::ParallelMesh.
+   # Optional. Defaults to libMesh::Mesh (which depends on the
+   #           libMesh build.
+   # Acceptable values: serial, parallel
+   mesh_class = 'serial'
+
+   # Since we are reading a mesh, all read options
+   # go in the Read subsection.
+   [./Read]
+
+       # Specify filename to be read. This can be a Unix path.
+       # libMesh decides which reader to use based on the suffix.
+       # Mandatory.
+       filename = 'meshfile.exo'
+
+[]

--- a/examples/mixed_dim_inflating_sheet/sheet.in
+++ b/examples/mixed_dim_inflating_sheet/sheet.in
@@ -1,10 +1,10 @@
 ##### Mesh related options #####
-[mesh-options]
-mesh_option = 'read_mesh_from_file'
-mesh_filename = 'quarter_sheet.exo'
+[Mesh]
+   [./Read]
+      filename = 'quarter_sheet.exo'
 
-uniformly_refine = '2'
-
+   [../Refinement]
+      uniformly_refine = '2'
 []
 
 ##### Options related to all Physics #####

--- a/examples/rayleigh_taylor/rayleigh.in
+++ b/examples/rayleigh_taylor/rayleigh.in
@@ -94,18 +94,15 @@ cp = '2.5' #[J/kg-K]
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = '0.0'
-domain_x1_max = '0.25'
-
-domain_x2_min = '0.0'
-domain_x2_max = '1.0'
-
-mesh_nx1 = 50
-mesh_nx2 = 100
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      x_max = '0.25'
+      y_max = '1.0'
+      n_elems_x = '50'
+      n_elems_y = '100'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/examples/simple_fan/fan.in
+++ b/examples/simple_fan/fan.in
@@ -42,21 +42,21 @@ area_swept = '{r:=sqrt(x^2+y^2); 2*pi*r*(.6-.4)/4}' # 4 blade fan
 angle_of_attack = '{pi/4}'
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_3D_mesh'
-element_type = 'HEX27'
+[Mesh]
+   [./Generation]
+      dimension = '3'
+      element_type = 'HEX27'
+      n_elems_x = '10'
+      n_elems_y = '10'
+      n_elems_z = '10'
 
-mesh_nx1 = '10'
-mesh_nx2 = '10'
-mesh_nx3 = '10'
-
-domain_x1_min = '-0.5'
-domain_x1_max = '0.5'
-domain_x2_min = '-0.5'
-domain_x2_max = '0.5'
-domain_x3_min = '0.0'
-domain_x3_max = '1.0'
-
+      x_min = '-0.5'
+      x_max = '0.5'
+      y_min = '-0.5'
+      y_max = '0.5'
+      z_min = '0.0'
+      z_max = '1.0'
+[]
 
 # Options for time solvers
 [unsteady-solver]

--- a/examples/simple_prop/fan.in
+++ b/examples/simple_prop/fan.in
@@ -49,21 +49,21 @@ area_swept = '{r:=sqrt(x^2+y^2); 2*pi*r*(.6-.4)/4}' # 4 blade fan
 angle_of_attack = '{pi/4}'
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_3D_mesh'
-element_type = 'HEX27'
+[Mesh]
+   [./Generation]
+      dimension = '3'
+      element_type = 'HEX27'
+      n_elems_x = '10'
+      n_elems_y = '10'
+      n_elems_z = '10'
 
-mesh_nx1 = '10'
-mesh_nx2 = '10'
-mesh_nx3 = '10'
-
-domain_x1_min = '-0.5'
-domain_x1_max = '0.5'
-domain_x2_min = '-0.5'
-domain_x2_max = '0.5'
-domain_x3_min = '0.0'
-domain_x3_max = '1.0'
-
+      x_min = '-0.5'
+      x_max = '0.5'
+      y_min = '-0.5'
+      y_max = '0.5'
+      z_min = '0.0'
+      z_max = '1.0'
+[]
 
 # Options for time solvers
 [unsteady-solver]

--- a/examples/suspended_cable/cable.in
+++ b/examples/suspended_cable/cable.in
@@ -42,14 +42,13 @@ E = '1.0e6'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_1D_mesh'
-#element_type = 'EDGE2'
-                                                                                                                                                                                                                                           
-domain_x1_min = '0.0'
-domain_x1_max = '200.0'
-
-mesh_nx1 = '10'
+[Mesh]
+   [./Generation]
+      dimension = '1'
+      x_min = '0.0'
+      x_max = '200.0'
+      n_elems_x = '10'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/examples/velocity_penalty/velocity_penalty.in
+++ b/examples/velocity_penalty/velocity_penalty.in
@@ -54,17 +54,17 @@ tau_factor = '1.0'
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 1.0
-domain_x2_min = -1.0
-domain_x2_max = 0.0
-
-mesh_nx1 = '15' 
-mesh_nx2 = '15'
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      x_min = '0.0'
+      x_max = '1.0'
+      y_min = '-1.0'
+      y_max = '0.0'
+      n_elems_x = '15'
+      n_elems_y = '15'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/src/common/include/grins/common.h
+++ b/src/common/include/grins/common.h
@@ -24,9 +24,16 @@
 
 #include "libmesh/libmesh_common.h"
 
-#define grins_warning(message) \
+#define grins_warning_once(message) \
   libmesh_do_once(libMesh::out <<"==========================================================" << std::endl \
                   << message \
                   << __FILE__ << ", line " << __LINE__ << ", compiled " << __LIBMESH_DATE__ << " at " << __LIBMESH_TIME__ << " ***" << std::endl \
                   <<"==========================================================" \
                   << std::endl;)
+
+#define grins_warning(message) \
+  libMesh::out <<"==========================================================" << std::endl \
+               << message \
+               << __FILE__ << ", line " << __LINE__ << ", compiled " << __LIBMESH_DATE__ << " at " << __LIBMESH_TIME__ << " ***" << std::endl \
+               <<"==========================================================" \
+               << std::endl;

--- a/src/solver/include/grins/mesh_builder.h
+++ b/src/solver/include/grins/mesh_builder.h
@@ -31,9 +31,11 @@
 
 // libMesh
 #include "libmesh/mesh.h"
+#include "libmesh/getpot.h"
 
-// libMesh forward declarations
-class GetPot;
+
+// GRINS
+#include "grins/common.h"
 
 namespace GRINS
 {
@@ -70,8 +72,31 @@ namespace GRINS
     void generate_mesh( const std::string& mesh_build_type, const GetPot& input,
                         libMesh::UnstructuredMesh* mesh );
 
+    //! Helper function for displaying deprecated warnings.
+    template <typename T>
+    void deprecated_option( const GetPot& input, const std::string& old_option,
+                            const std::string& new_option, const T& default_value,
+                            T& option_value ) const;
+
   };
 
+  template <typename T>
+  inline
+  void MeshBuilder::deprecated_option( const GetPot& input, const std::string& old_option,
+                            const std::string& new_option, const T& default_value,
+                            T& option_value ) const
+  {
+    if( input.have_variable(old_option) )
+      {
+        std::string warning = "WARNING: "+old_option+" is DEPRECATED.\n";
+        warning += "         Please update to use "+new_option+".\n";
+        grins_warning(warning);
+
+        option_value = input(old_option, default_value);
+      }
+
+    return;
+  }
 } // end namespace block
 
 #endif // GRINS_MESH_BUILDER_H

--- a/src/solver/include/grins/mesh_builder.h
+++ b/src/solver/include/grins/mesh_builder.h
@@ -65,6 +65,11 @@ namespace GRINS
                                         const libMesh::Parallel::Communicator &comm,
                                         libMesh::UnstructuredMesh& mesh ) const;
 
+  private:
+
+    void generate_mesh( const std::string& mesh_build_type, const GetPot& input,
+                        libMesh::UnstructuredMesh* mesh );
+
   };
 
 } // end namespace block

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -101,13 +101,13 @@ namespace GRINS
 
     // Were we specifically asked to use a ParallelMesh or SerialMesh?
     {
-      std::string mesh_class = input("Mesh/mesh_class", "default");
+      std::string mesh_class = input("Mesh/class", "default");
 
       if( input.have_variable("mesh-options/mesh_class") )
         {
           std::string warning = "WARNING: mesh-options/mesh_class is DEPRECATED.\n";
-          warning += "         Please update to use Mesh/mesh_class.\n";
-          warning += "         Mesh/mesh_class can take values: serial, parallel\n";
+          warning += "         Please update to use Mesh/class.\n";
+          warning += "         Mesh/class can take values: serial, parallel\n";
           grins_warning(warning);
 
           mesh_class = input("mesh-options/mesh_class", "default");
@@ -121,7 +121,7 @@ namespace GRINS
         mesh = new libMesh::Mesh(comm);
       else
         {
-          std::string error = "ERROR: Invalid mesh_class "+mesh_class+" input for Mesh/mesh_class.\n";
+          std::string error = "ERROR: Invalid class "+mesh_class+" input for Mesh/class.\n";
             error += "       Valid choices are: serial, parallel.\n";
             libmesh_error_msg(error);
         }

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -390,8 +390,9 @@ namespace GRINS
           }
       }
 
-    int uniformly_refine = input("mesh-options/uniformly_refine", 0);
-    
+    int uniformly_refine = input("Mesh/Refinement/uniformly_refine", 0);
+    this->deprecated_option( input, "mesh-options/uniformly_refine", "Mesh/Refinement/uniformly_refine", 0, uniformly_refine );
+
     if( uniformly_refine > 0 )
       {
         libMesh::MeshRefinement(mesh).uniformly_refine(uniformly_refine);

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -264,14 +264,7 @@ namespace GRINS
     /* Now grab the element_type the user wants for the mesh. */
 
     std::string element_type = input("Mesh/Generation/element_type", "default");
-    if( input.have_variable("mesh-options/element_type") )
-      {
-        std::string warning = "WARNING: mesh-options/element_type is DEPRECATED.\n";
-        warning += "         Please update to use Mesh/Generation/element_type.\n";
-        grins_warning(warning);
-
-        element_type = input("mesh-options/element_type", "default");
-      }
+    this->deprecated_option<std::string>( input, "mesh-options/element_type", "Mesh/Generation/element_type", "default", element_type );
 
     /* Now generate the mesh. */
     if( dimension == 1 )

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -362,7 +362,8 @@ namespace GRINS
                                                    libMesh::UnstructuredMesh& mesh ) const
   {
     std::string redistribution_function_string =
-            input("mesh-options/redistribute", std::string("0"));
+            input("Mesh/Redistribution/function", std::string("0"));
+    this->deprecated_option<std::string>( input, "mesh-options/redistribute", "Mesh/Redistribution/function", "0", redistribution_function_string );
 
     if (redistribution_function_string != "0")
       {

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -215,26 +215,6 @@ namespace GRINS
           x_min = input("mesh-options/domain_x1_min", 0.0);
       }
 
-    libMesh::Real y_min = input("Mesh/Generation/y_min", 0.0);
-    if( input.have_variable("mesh-options/domain_x2_min") )
-      {
-        std::string warning = "WARNING: mesh-options/domain_x2_min is DEPRECATED.\n";
-          warning += "         Please update to use Mesh/Generation/y_min.\n";
-          grins_warning(warning);
-
-          y_min = input("mesh-options/domain_x2_min", 0.0);
-      }
-
-    libMesh::Real z_min = input("Mesh/Generation/z_min", 0.0);
-    if( input.have_variable("mesh-options/domain_x3_min") )
-      {
-        std::string warning = "WARNING: mesh-options/domain_x3_min is DEPRECATED.\n";
-          warning += "         Please update to use Mesh/Generation/z_min.\n";
-          grins_warning(warning);
-
-          z_min = input("mesh-options/domain_x3_min", 0.0);
-      }
-
     libMesh::Real x_max = input("Mesh/Generation/x_max", 1.0);
     if( input.have_variable("mesh-options/domain_x1_max") )
       {
@@ -245,24 +225,62 @@ namespace GRINS
           x_max = input("mesh-options/domain_x1_max", 1.0);
       }
 
-    libMesh::Real y_max = input("Mesh/Generation/y_max", 1.0);
-    if( input.have_variable("mesh-options/domain_x2_max") )
-      {
-        std::string warning = "WARNING: mesh-options/domain_x2_max is DEPRECATED.\n";
-          warning += "         Please update to use Mesh/Generation/y_max.\n";
-          grins_warning(warning);
+    /* We only check the y_{min,max} input if dimension is > 1 so that GetPot
+       UFO detection will give us an error if we have this in the input file
+       and are only using a 1D grid. */
+    libMesh::Real y_min = 0.0;
+    libMesh::Real y_max = 0.0;
 
-          y_max = input("mesh-options/domain_x2_max", 1.0);
+    if( dimension > 1 )
+      {
+        y_min = input("Mesh/Generation/y_min", 0.0);
+        if( input.have_variable("mesh-options/domain_x2_min") )
+          {
+            std::string warning = "WARNING: mesh-options/domain_x2_min is DEPRECATED.\n";
+            warning += "         Please update to use Mesh/Generation/y_min.\n";
+            grins_warning(warning);
+
+            y_min = input("mesh-options/domain_x2_min", 0.0);
+          }
+
+        y_max = input("Mesh/Generation/y_max", 1.0);
+        if( input.have_variable("mesh-options/domain_x2_max") )
+          {
+            std::string warning = "WARNING: mesh-options/domain_x2_max is DEPRECATED.\n";
+            warning += "         Please update to use Mesh/Generation/y_max.\n";
+            grins_warning(warning);
+
+            y_max = input("mesh-options/domain_x2_max", 1.0);
+          }
       }
 
-    libMesh::Real z_max = input("Mesh/Generation/z_max", 1.0);
-    if( input.have_variable("mesh-options/domain_x3_max") )
-      {
-        std::string warning = "WARNING: mesh-options/domain_x3_max is DEPRECATED.\n";
-          warning += "         Please update to use Mesh/Generation/z_max.\n";
-          grins_warning(warning);
+    /* We only check the z_{min,max} input if dimension is > 2 so that GetPot
+       UFO detection will give us an error if we have this in the input file
+       and are only using a 1D or 2D grid. */
+    libMesh::Real z_min = 0.0;
+    libMesh::Real z_max = 0.0;
 
-          z_max = input("mesh-options/domain_x3_max", 1.0);
+    if( dimension > 2 )
+      {
+        z_min = input("Mesh/Generation/z_min", 0.0);
+        if( input.have_variable("mesh-options/domain_x3_min") )
+          {
+            std::string warning = "WARNING: mesh-options/domain_x3_min is DEPRECATED.\n";
+            warning += "         Please update to use Mesh/Generation/z_min.\n";
+            grins_warning(warning);
+
+            z_min = input("mesh-options/domain_x3_min", 0.0);
+          }
+
+        z_max = input("Mesh/Generation/z_max", 1.0);
+        if( input.have_variable("mesh-options/domain_x3_max") )
+          {
+            std::string warning = "WARNING: mesh-options/domain_x3_max is DEPRECATED.\n";
+            warning += "         Please update to use Mesh/Generation/z_max.\n";
+            grins_warning(warning);
+
+            z_max = input("mesh-options/domain_x3_max", 1.0);
+          }
       }
 
     // Make sure user gave us info about how many elements to use

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -294,24 +294,6 @@ namespace GRINS
         libmesh_error_msg("ERROR: Must supply Mesh/Generation/n_elems_x for mesh generation.");
       }
 
-    if( dimension > 1 )
-      {
-        if( !input.have_variable("mesh-options/mesh_nx2") /* Deprecated */ &&
-        !input.have_variable("Mesh/Generation/n_elems_y") )
-          {
-            libmesh_error_msg("ERROR: Must supply Mesh/Generation/n_elems_y for mesh generation.");
-          }
-      }
-
-    if( dimension > 2 )
-      {
-        if( !input.have_variable("mesh-options/mesh_nx3") /* Deprecated */ &&
-        !input.have_variable("Mesh/Generation/n_elems_z") )
-          {
-            libmesh_error_msg("ERROR: Must supply Mesh/Generation/n_elems_z for mesh generation.");
-          }
-      }
-
     unsigned int n_elems_x = input("Mesh/Generation/n_elems_x", 0);
     if( input.have_variable("mesh-options/mesh_nx1") )
       {
@@ -322,25 +304,52 @@ namespace GRINS
         n_elems_x = input("mesh-options/mesh_nx1", 0);
       }
 
-    unsigned int n_elems_y = input("Mesh/Generation/n_elems_y", 0);
-    if( input.have_variable("mesh-options/mesh_nx2") )
+    /* We only check n_elems_y input if dimension is > 1 so that GetPot
+       UFO detection will give us an error if we have this in the input file
+       and are only using a 1D grid. */
+    unsigned int n_elems_y = 0;
+    if( dimension > 1 )
       {
-        std::string warning = "WARNING: mesh-options/mesh_nx2 is DEPRECATED.\n";
-        warning += "         Please update to use Mesh/Generation/n_elems_y.\n";
-        grins_warning(warning);
+        if( !input.have_variable("mesh-options/mesh_nx2") /* Deprecated */ &&
+        !input.have_variable("Mesh/Generation/n_elems_y") )
+          {
+            libmesh_error_msg("ERROR: Must supply Mesh/Generation/n_elems_y for mesh generation.");
+          }
 
-        n_elems_y = input("mesh-options/mesh_nx2", 0);
+        n_elems_y = input("Mesh/Generation/n_elems_y", 0);
+        if( input.have_variable("mesh-options/mesh_nx2") )
+          {
+            std::string warning = "WARNING: mesh-options/mesh_nx2 is DEPRECATED.\n";
+            warning += "         Please update to use Mesh/Generation/n_elems_y.\n";
+            grins_warning(warning);
+
+            n_elems_y = input("mesh-options/mesh_nx2", 0);
+          }
       }
 
-    unsigned int n_elems_z = input("Mesh/Generation/n_elems_z", 0);
-    if( input.have_variable("mesh-options/mesh_nx3") )
+    /* We only check n_elems_z input if dimension is > 2 so that GetPot
+       UFO detection will give us an error if we have this in the input file
+       and are only using a 1D or 2D grid. */
+    unsigned int n_elems_z = 0;
+    if( dimension > 2 )
       {
-        std::string warning = "WARNING: mesh-options/mesh_nx3 is DEPRECATED.\n";
-        warning += "         Please update to use Mesh/Generation/n_elems_z.\n";
-        grins_warning(warning);
+        if( !input.have_variable("mesh-options/mesh_nx3") /* Deprecated */ &&
+        !input.have_variable("Mesh/Generation/n_elems_z") )
+          {
+            libmesh_error_msg("ERROR: Must supply Mesh/Generation/n_elems_z for mesh generation.");
+          }
 
-        n_elems_z = input("mesh-options/mesh_nx3", 0);
+        n_elems_z = input("Mesh/Generation/n_elems_z", 0);
+        if( input.have_variable("mesh-options/mesh_nx3") )
+          {
+            std::string warning = "WARNING: mesh-options/mesh_nx3 is DEPRECATED.\n";
+            warning += "         Please update to use Mesh/Generation/n_elems_z.\n";
+            grins_warning(warning);
+
+            n_elems_z = input("mesh-options/mesh_nx3", 0);
+          }
       }
+
     /* Now grab the element_type the user wants for the mesh. */
 
     std::string element_type = input("Mesh/Generation/element_type", "default");

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -196,24 +196,10 @@ namespace GRINS
     if( dimension > 1 )
       {
         y_min = input("Mesh/Generation/y_min", 0.0);
-        if( input.have_variable("mesh-options/domain_x2_min") )
-          {
-            std::string warning = "WARNING: mesh-options/domain_x2_min is DEPRECATED.\n";
-            warning += "         Please update to use Mesh/Generation/y_min.\n";
-            grins_warning(warning);
-
-            y_min = input("mesh-options/domain_x2_min", 0.0);
-          }
+        this->deprecated_option( input, "mesh-options/domain_x2_min", "Mesh/Generation/y_min", 0.0, y_min );
 
         y_max = input("Mesh/Generation/y_max", 1.0);
-        if( input.have_variable("mesh-options/domain_x2_max") )
-          {
-            std::string warning = "WARNING: mesh-options/domain_x2_max is DEPRECATED.\n";
-            warning += "         Please update to use Mesh/Generation/y_max.\n";
-            grins_warning(warning);
-
-            y_max = input("mesh-options/domain_x2_max", 1.0);
-          }
+        this->deprecated_option( input, "mesh-options/domain_x2_max", "Mesh/Generation/y_max", 1.0, y_max );
       }
 
     /* We only check the z_{min,max} input if dimension is > 2 so that GetPot

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -120,14 +120,7 @@ namespace GRINS
 
         std::string mesh_filename = input("Mesh/Read/filename", "DIE!");
 
-        if( input.have_variable("mesh-options/mesh_filename") )
-          {
-            std::string warning = "WARNING: mesh-options/mesh_filename is DEPRECATED.\n";
-            warning += "         Please update to use Mesh/Read/filename.\n";
-            grins_warning(warning);
-
-            mesh_filename = input("mesh-options/mesh_filename", "DIE!");
-          }
+        this->deprecated_option<std::string>( input, "mesh-options/mesh_filename", "Mesh/Read/filename", "DIE!", mesh_filename);
 
 	// According to Roy Stogner, the only read format
 	// that won't properly reset the dimension is gmsh.

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -319,11 +319,11 @@ namespace GRINS
         n_elems_z = input("mesh-options/mesh_nx3", 0);
       }
 
-    std::string element_type = input("mesh-options/element_type", "NULL");
+    std::string element_type = input("mesh-options/element_type", "default");
 
     if( dimension == 1 )
       {
-        if(element_type=="NULL")
+        if(element_type=="default")
 	  {
 	    element_type = "EDGE3";
 	  }
@@ -340,7 +340,7 @@ namespace GRINS
 
     else if( dimension == 2 )
       {
-	if(element_type=="NULL")
+	if(element_type=="default")
 	  {
 	    element_type = "TRI6";
 	  }
@@ -360,7 +360,7 @@ namespace GRINS
 
     else if( dimension == 3 )
       {
-	if(element_type=="NULL")
+	if(element_type=="default")
 	  {
 	    element_type = "TET10";
 	  }

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -205,6 +205,8 @@ namespace GRINS
     // Set the mesh dimension
     mesh->set_mesh_dimension(dimension);
 
+    /* Now look for spatial extent of the grid that the user wants to generate. */
+
     libMesh::Real x_min = input("Mesh/Generation/x_min", 0.0);
     if( input.have_variable("mesh-options/domain_x1_min") )
       {
@@ -283,6 +285,8 @@ namespace GRINS
           }
       }
 
+    /* Now check for the number of elements in each direction */
+
     // Make sure user gave us info about how many elements to use
     if( !input.have_variable("mesh-options/mesh_nx1") /* Deprecated */ &&
         !input.have_variable("Mesh/Generation/n_elems_x") )
@@ -337,6 +341,7 @@ namespace GRINS
 
         n_elems_z = input("mesh-options/mesh_nx3", 0);
       }
+    /* Now grab the element_type the user wants for the mesh. */
 
     std::string element_type = input("Mesh/Generation/element_type", "default");
     if( input.have_variable("mesh-options/element_type") )
@@ -348,6 +353,7 @@ namespace GRINS
         element_type = input("mesh-options/element_type", "default");
       }
 
+    /* Now generate the mesh. */
     if( dimension == 1 )
       {
         if(element_type=="default")
@@ -413,6 +419,8 @@ namespace GRINS
         // This shouldn't have happened
 	libmesh_error();
       }
+
+    return;
   }
 
   void MeshBuilder::do_mesh_refinement_from_input( const GetPot& input,

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -399,7 +399,8 @@ namespace GRINS
       }
 
     std::string h_refinement_function_string =
-            input("mesh-options/locally_h_refine", std::string("0"));
+            input("Mesh/Refinement/locally_h_refine", std::string("0"));
+    this->deprecated_option<std::string>( input, "mesh-options/locally_h_refine", "Mesh/Refinement/locally_h_refine", "0", h_refinement_function_string );
 
     if (h_refinement_function_string != "0")
       { 

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -211,24 +211,10 @@ namespace GRINS
     if( dimension > 2 )
       {
         z_min = input("Mesh/Generation/z_min", 0.0);
-        if( input.have_variable("mesh-options/domain_x3_min") )
-          {
-            std::string warning = "WARNING: mesh-options/domain_x3_min is DEPRECATED.\n";
-            warning += "         Please update to use Mesh/Generation/z_min.\n";
-            grins_warning(warning);
-
-            z_min = input("mesh-options/domain_x3_min", 0.0);
-          }
+        this->deprecated_option( input, "mesh-options/domain_x3_min", "Mesh/Generation/z_min", 0.0, z_min );
 
         z_max = input("Mesh/Generation/z_max", 1.0);
-        if( input.have_variable("mesh-options/domain_x3_max") )
-          {
-            std::string warning = "WARNING: mesh-options/domain_x3_max is DEPRECATED.\n";
-            warning += "         Please update to use Mesh/Generation/z_max.\n";
-            grins_warning(warning);
-
-            z_max = input("mesh-options/domain_x3_max", 1.0);
-          }
+        this->deprecated_option( input, "mesh-options/domain_x3_max", "Mesh/Generation/z_max", 1.0, z_max );
       }
 
     /* Now check for the number of elements in each direction */

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -30,11 +30,7 @@
 #include "grins/grins_enums.h"
 #include "grins/mesh_builder.h"
 
-// GRINS
-#include "grins/common.h"
-
 // libMesh
-#include "libmesh/getpot.h"
 #include "libmesh/string_to_enum.h"
 #include "libmesh/mesh_generation.h"
 #include "libmesh/mesh_modification.h"
@@ -71,15 +67,7 @@ namespace GRINS
     // Are we generating the mesh or are we reading one in from a file?
     std::string mesh_build_type = input("Mesh/type", "DIE!");
 
-    if( input.have_variable("mesh-options/mesh_option") )
-      {
-        std::string warning = "WARNING: mesh-options/mesh_option is DEPRECATED.\n";
-        warning += "         Please update to use Mesh/type.\n";
-        warning += "         Mesh/type can take values: generate, read\n";
-        grins_warning(warning);
-
-        mesh_build_type = input("mesh-options/mesh_option", "DIE!");
-      }
+    this->deprecated_option<std::string>( input, "mesh-options/mesh_option", "Mesh/Read or Mesh/Generation", "DIE!", mesh_build_type);
 
     // Make sure the user gave a valid option
     /*! \todo Can remove last 4 checks once mesh-options/mesh_option support is removed. */

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -63,18 +63,19 @@ namespace GRINS
   {
     // User needs to tell us if we are generating or reading a mesh
     if( !input.have_variable("mesh-options/mesh_option") &&
-        !input.have_variable("MeshOptions/type") )
+        !input.have_variable("Mesh/type") )
       {
-        libmesh_error_msg("ERROR: Must specify MeshOptions/type in input.");
+        libmesh_error_msg("ERROR: Must specify Mesh/type in input.");
       }
 
     // Are we generating the mesh or are we reading one in from a file?
-    std::string mesh_build_type = input("MeshOptions/type", "DIE!");
+    std::string mesh_build_type = input("Mesh/type", "DIE!");
+
     if( input.have_variable("mesh-options/mesh_option") )
       {
         std::string warning = "WARNING: mesh-options/mesh_option is DEPRECATED.\n";
-        warning += "         Please update to use MeshOptions/type.\n";
-        warning += "         MeshOptions/type can take values: generate, read\n";
+        warning += "         Please update to use Mesh/type.\n";
+        warning += "         Mesh/type can take values: generate, read\n";
         grins_warning(warning);
 
         mesh_build_type = input("mesh-options/mesh_option", "DIE!");
@@ -89,7 +90,7 @@ namespace GRINS
         mesh_build_type != std::string("create_2D_mesh") &&
         mesh_build_type != std::string("create_3D_mesh") )
       {
-        std::string error = "ERROR: Invalid value of "+mesh_build_type+" for MeshOptions/type.\n";
+        std::string error = "ERROR: Invalid value of "+mesh_build_type+" for Mesh/type.\n";
           error += "       Valid values are: generate\n";
           error += "                         read\n";
           libmesh_error_msg(error);
@@ -100,13 +101,13 @@ namespace GRINS
 
     // Were we specifically asked to use a ParallelMesh or SerialMesh?
     {
-      std::string mesh_class = input("MeshOptions/mesh_class", "default");
+      std::string mesh_class = input("Mesh/mesh_class", "default");
 
       if( input.have_variable("mesh-options/mesh_class") )
         {
           std::string warning = "WARNING: mesh-options/mesh_class is DEPRECATED.\n";
-          warning += "         Please update to use MeshOptions/mesh_class.\n";
-          warning += "         MeshOptions/mesh_class can take values: serial, parallel\n";
+          warning += "         Please update to use Mesh/mesh_class.\n";
+          warning += "         Mesh/mesh_class can take values: serial, parallel\n";
           grins_warning(warning);
 
           mesh_class = input("mesh-options/mesh_class", "default");
@@ -120,7 +121,7 @@ namespace GRINS
         mesh = new libMesh::Mesh(comm);
       else
         {
-          std::string error = "ERROR: Invalid mesh_class "+mesh_class+" input for MeshOptions/mesh_class.\n";
+          std::string error = "ERROR: Invalid mesh_class "+mesh_class+" input for Mesh/mesh_class.\n";
             error += "       Valid choices are: serial, parallel.\n";
             libmesh_error_msg(error);
         }
@@ -132,17 +133,17 @@ namespace GRINS
       {
         // Make sure the user set the filename to read
         if( !input.have_variable("mesh-options/mesh_filename") /* This is deprecated */ &&
-            !input.have_variable("MeshOptions/Read/filename") )
+            !input.have_variable("Mesh/Read/filename") )
           {
-            libmesh_error_msg("ERROR: Must specify MeshOptions/Read/filename for reading mesh.");
+            libmesh_error_msg("ERROR: Must specify Mesh/Read/filename for reading mesh.");
           }
 
-        std::string mesh_filename = input("MeshOptions/Read/filename", "DIE!");
+        std::string mesh_filename = input("Mesh/Read/filename", "DIE!");
 
         if( input.have_variable("mesh-options/mesh_filename") )
           {
             std::string warning = "WARNING: mesh-options/mesh_filename is DEPRECATED.\n";
-            warning += "         Please update to use MeshOptions/Read/filename.\n";
+            warning += "         Please update to use Mesh/Read/filename.\n";
             grins_warning(warning);
 
             mesh_filename = input("mesh-options/mesh_filename", "DIE!");
@@ -183,12 +184,12 @@ namespace GRINS
   void MeshBuilder::generate_mesh( const std::string& mesh_build_type, const GetPot& input,
                                    libMesh::UnstructuredMesh* mesh )
   {
-    unsigned int dimension = input("MeshOptions/Generation/dimension",0);
+    unsigned int dimension = input("Mesh/Generation/dimension",0);
 
     if( !input.have_variable("mesh-options/mesh_option") /* Deprecated */ &&
-        !input.have_variable("MeshOptions/Generation/dimension") )
+        !input.have_variable("Mesh/Generation/dimension") )
       {
-        libmesh_error_msg("ERROR: Must specify MeshOptions/Generation/dimension for generating mesh.");
+        libmesh_error_msg("ERROR: Must specify Mesh/Generation/dimension for generating mesh.");
       }
 
     /* Remove these once suport for mesh-options/mesh_option is removed */
@@ -204,61 +205,61 @@ namespace GRINS
     // Set the mesh dimension
     mesh->set_mesh_dimension(dimension);
 
-    libMesh::Real x_min = input("MeshOptions/Generation/x_min", 0.0);
+    libMesh::Real x_min = input("Mesh/Generation/x_min", 0.0);
     if( input.have_variable("mesh-options/domain_x1_min") )
       {
         std::string warning = "WARNING: mesh-options/domain_x1_min is DEPRECATED.\n";
-          warning += "         Please update to use MeshOptions/Generation/x_min.\n";
+          warning += "         Please update to use Mesh/Generation/x_min.\n";
           grins_warning(warning);
 
           x_min = input("mesh-options/domain_x1_min", 0.0);
       }
 
-    libMesh::Real y_min = input("MeshOptions/Generation/y_min", 0.0);
+    libMesh::Real y_min = input("Mesh/Generation/y_min", 0.0);
     if( input.have_variable("mesh-options/domain_x2_min") )
       {
         std::string warning = "WARNING: mesh-options/domain_x2_min is DEPRECATED.\n";
-          warning += "         Please update to use MeshOptions/Generation/y_min.\n";
+          warning += "         Please update to use Mesh/Generation/y_min.\n";
           grins_warning(warning);
 
           y_min = input("mesh-options/domain_x2_min", 0.0);
       }
 
-    libMesh::Real z_min = input("MeshOptions/Generation/z_min", 0.0);
+    libMesh::Real z_min = input("Mesh/Generation/z_min", 0.0);
     if( input.have_variable("mesh-options/domain_x3_min") )
       {
         std::string warning = "WARNING: mesh-options/domain_x3_min is DEPRECATED.\n";
-          warning += "         Please update to use MeshOptions/Generation/z_min.\n";
+          warning += "         Please update to use Mesh/Generation/z_min.\n";
           grins_warning(warning);
 
           z_min = input("mesh-options/domain_x3_min", 0.0);
       }
 
-    libMesh::Real x_max = input("MeshOptions/Generation/x_max", 1.0);
+    libMesh::Real x_max = input("Mesh/Generation/x_max", 1.0);
     if( input.have_variable("mesh-options/domain_x1_max") )
       {
         std::string warning = "WARNING: mesh-options/domain_x1_max is DEPRECATED.\n";
-          warning += "         Please update to use MeshOptions/Generation/x_max.\n";
+          warning += "         Please update to use Mesh/Generation/x_max.\n";
           grins_warning(warning);
 
           x_max = input("mesh-options/domain_x1_max", 1.0);
       }
 
-    libMesh::Real y_max = input("MeshOptions/Generation/y_max", 1.0);
+    libMesh::Real y_max = input("Mesh/Generation/y_max", 1.0);
     if( input.have_variable("mesh-options/domain_x2_max") )
       {
         std::string warning = "WARNING: mesh-options/domain_x2_max is DEPRECATED.\n";
-          warning += "         Please update to use MeshOptions/Generation/y_max.\n";
+          warning += "         Please update to use Mesh/Generation/y_max.\n";
           grins_warning(warning);
 
           y_max = input("mesh-options/domain_x2_max", 1.0);
       }
 
-    libMesh::Real z_max = input("MeshOptions/Generation/z_max", 1.0);
+    libMesh::Real z_max = input("Mesh/Generation/z_max", 1.0);
     if( input.have_variable("mesh-options/domain_x3_max") )
       {
         std::string warning = "WARNING: mesh-options/domain_x3_max is DEPRECATED.\n";
-          warning += "         Please update to use MeshOptions/Generation/z_max.\n";
+          warning += "         Please update to use Mesh/Generation/z_max.\n";
           grins_warning(warning);
 
           z_max = input("mesh-options/domain_x3_max", 1.0);
@@ -266,64 +267,64 @@ namespace GRINS
 
     // Make sure user gave us info about how many elements to use
     if( !input.have_variable("mesh-options/mesh_nx1") /* Deprecated */ &&
-        !input.have_variable("MeshOptions/Generation/n_elems_x") )
+        !input.have_variable("Mesh/Generation/n_elems_x") )
       {
-        libmesh_error_msg("ERROR: Must supply MeshOptions/Generation/n_elems_x for mesh generation.");
+        libmesh_error_msg("ERROR: Must supply Mesh/Generation/n_elems_x for mesh generation.");
       }
 
     if( dimension > 1 )
       {
         if( !input.have_variable("mesh-options/mesh_nx2") /* Deprecated */ &&
-        !input.have_variable("MeshOptions/Generation/n_elems_y") )
+        !input.have_variable("Mesh/Generation/n_elems_y") )
           {
-            libmesh_error_msg("ERROR: Must supply MeshOptions/Generation/n_elems_y for mesh generation.");
+            libmesh_error_msg("ERROR: Must supply Mesh/Generation/n_elems_y for mesh generation.");
           }
       }
 
     if( dimension > 2 )
       {
         if( !input.have_variable("mesh-options/mesh_nx3") /* Deprecated */ &&
-        !input.have_variable("MeshOptions/Generation/n_elems_z") )
+        !input.have_variable("Mesh/Generation/n_elems_z") )
           {
-            libmesh_error_msg("ERROR: Must supply MeshOptions/Generation/n_elems_z for mesh generation.");
+            libmesh_error_msg("ERROR: Must supply Mesh/Generation/n_elems_z for mesh generation.");
           }
       }
 
-    unsigned int n_elems_x = input("MeshOptions/Generation/n_elems_x", 0);
+    unsigned int n_elems_x = input("Mesh/Generation/n_elems_x", 0);
     if( input.have_variable("mesh-options/mesh_nx1") )
       {
         std::string warning = "WARNING: mesh-options/mesh_nx1 is DEPRECATED.\n";
-        warning += "         Please update to use MeshOptions/Generation/n_elems_x.\n";
+        warning += "         Please update to use Mesh/Generation/n_elems_x.\n";
         grins_warning(warning);
 
         n_elems_x = input("mesh-options/mesh_nx1", 0);
       }
 
-    unsigned int n_elems_y = input("MeshOptions/Generation/n_elems_y", 0);
+    unsigned int n_elems_y = input("Mesh/Generation/n_elems_y", 0);
     if( input.have_variable("mesh-options/mesh_nx2") )
       {
         std::string warning = "WARNING: mesh-options/mesh_nx2 is DEPRECATED.\n";
-        warning += "         Please update to use MeshOptions/Generation/n_elems_y.\n";
+        warning += "         Please update to use Mesh/Generation/n_elems_y.\n";
         grins_warning(warning);
 
         n_elems_y = input("mesh-options/mesh_nx2", 0);
       }
 
-    unsigned int n_elems_z = input("MeshOptions/Generation/n_elems_z", 0);
+    unsigned int n_elems_z = input("Mesh/Generation/n_elems_z", 0);
     if( input.have_variable("mesh-options/mesh_nx3") )
       {
         std::string warning = "WARNING: mesh-options/mesh_nx3 is DEPRECATED.\n";
-        warning += "         Please update to use MeshOptions/Generation/n_elems_z.\n";
+        warning += "         Please update to use Mesh/Generation/n_elems_z.\n";
         grins_warning(warning);
 
         n_elems_z = input("mesh-options/mesh_nx3", 0);
       }
 
-    std::string element_type = input("MeshOptions/Generation/element_type", "default");
+    std::string element_type = input("Mesh/Generation/element_type", "default");
     if( input.have_variable("mesh-options/element_type") )
       {
         std::string warning = "WARNING: mesh-options/element_type is DEPRECATED.\n";
-        warning += "         Please update to use MeshOptions/Generation/element_type.\n";
+        warning += "         Please update to use Mesh/Generation/element_type.\n";
         grins_warning(warning);
 
         element_type = input("mesh-options/element_type", "default");

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -185,7 +185,7 @@ namespace GRINS
   {
     unsigned int dimension = input("MeshOptions/Generation/dimension",0);
 
-    if( !input.have_variable("mesh-options/mesh_option") &&
+    if( !input.have_variable("mesh-options/mesh_option") /* Deprecated */ &&
         !input.have_variable("MeshOptions/Generation/dimension") )
       {
         libmesh_error_msg("ERROR: Must specify MeshOptions/Generation/dimension for generating mesh.");

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -130,7 +130,23 @@ namespace GRINS
     if(mesh_build_type =="read_mesh_from_file" /* This is deprecated */ ||
        mesh_build_type == "read" )
       {
-        std::string mesh_filename = input("mesh-options/mesh_filename", "NULL");
+        // Make sure the user set the filename to read
+        if( !input.have_variable("mesh-options/mesh_filename") /* This is deprecated */ &&
+            !input.have_variable("MeshOptions/Read/filename") )
+          {
+            libmesh_error_msg("ERROR: Must specify MeshOptions/Read/filename for reading mesh.");
+          }
+
+        std::string mesh_filename = input("MeshOptions/Read/filename", "DIE!");
+
+        if( input.have_variable("mesh-options/mesh_filename") )
+          {
+            std::string warning = "WARNING: mesh-options/mesh_filename is DEPRECATED.\n";
+            warning += "         Please update to use MeshOptions/Read/filename.\n";
+            grins_warning(warning);
+
+            mesh_filename = input("mesh-options/mesh_filename", "DIE!");
+          }
 
 	// According to Roy Stogner, the only read format
 	// that won't properly reset the dimension is gmsh.

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -181,24 +181,11 @@ namespace GRINS
     /* Now look for spatial extent of the grid that the user wants to generate. */
 
     libMesh::Real x_min = input("Mesh/Generation/x_min", 0.0);
-    if( input.have_variable("mesh-options/domain_x1_min") )
-      {
-        std::string warning = "WARNING: mesh-options/domain_x1_min is DEPRECATED.\n";
-          warning += "         Please update to use Mesh/Generation/x_min.\n";
-          grins_warning(warning);
-
-          x_min = input("mesh-options/domain_x1_min", 0.0);
-      }
+    this->deprecated_option( input, "mesh-options/domain_x1_min", "Mesh/Generation/x_min", 0.0, x_min );
 
     libMesh::Real x_max = input("Mesh/Generation/x_max", 1.0);
-    if( input.have_variable("mesh-options/domain_x1_max") )
-      {
-        std::string warning = "WARNING: mesh-options/domain_x1_max is DEPRECATED.\n";
-          warning += "         Please update to use Mesh/Generation/x_max.\n";
-          grins_warning(warning);
+    this->deprecated_option( input, "mesh-options/domain_x1_max", "Mesh/Generation/x_max", 1.0, x_max );
 
-          x_max = input("mesh-options/domain_x1_max", 1.0);
-      }
 
     /* We only check the y_{min,max} input if dimension is > 1 so that GetPot
        UFO detection will give us an error if we have this in the input file

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -204,9 +204,35 @@ namespace GRINS
     // Set the mesh dimension
     mesh->set_mesh_dimension(dimension);
 
-    libMesh::Real x_min = input("mesh-options/domain_x1_min", 0.0);
-    libMesh::Real y_min = input("mesh-options/domain_x2_min", 0.0);
-    libMesh::Real z_min = input("mesh-options/domain_x3_min", 0.0);
+    libMesh::Real x_min = input("MeshOptions/Generation/x_min", 0.0);
+    if( input.have_variable("mesh-options/domain_x1_min") )
+      {
+        std::string warning = "WARNING: mesh-options/domain_x1_min is DEPRECATED.\n";
+          warning += "         Please update to use MeshOptions/Generation/x_min.\n";
+          grins_warning(warning);
+
+          x_min = input("mesh-options/domain_x1_min", 0.0);
+      }
+
+    libMesh::Real y_min = input("MeshOptions/Generation/y_min", 0.0);
+    if( input.have_variable("mesh-options/domain_x2_min") )
+      {
+        std::string warning = "WARNING: mesh-options/domain_x2_min is DEPRECATED.\n";
+          warning += "         Please update to use MeshOptions/Generation/y_min.\n";
+          grins_warning(warning);
+
+          y_min = input("mesh-options/domain_x2_min", 0.0);
+      }
+
+    libMesh::Real z_min = input("MeshOptions/Generation/z_min", 0.0);
+    if( input.have_variable("mesh-options/domain_x3_min") )
+      {
+        std::string warning = "WARNING: mesh-options/domain_x3_min is DEPRECATED.\n";
+          warning += "         Please update to use MeshOptions/Generation/z_min.\n";
+          grins_warning(warning);
+
+          z_min = input("mesh-options/domain_x3_min", 0.0);
+      }
 
     libMesh::Real x_max = input("mesh-options/domain_x1_max", 1.0);
     libMesh::Real y_max = input("mesh-options/domain_x2_max", 1.0);

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -234,9 +234,35 @@ namespace GRINS
           z_min = input("mesh-options/domain_x3_min", 0.0);
       }
 
-    libMesh::Real x_max = input("mesh-options/domain_x1_max", 1.0);
-    libMesh::Real y_max = input("mesh-options/domain_x2_max", 1.0);
-    libMesh::Real z_max = input("mesh-options/domain_x3_max", 1.0);
+    libMesh::Real x_max = input("MeshOptions/Generation/x_max", 1.0);
+    if( input.have_variable("mesh-options/domain_x1_max") )
+      {
+        std::string warning = "WARNING: mesh-options/domain_x1_max is DEPRECATED.\n";
+          warning += "         Please update to use MeshOptions/Generation/x_max.\n";
+          grins_warning(warning);
+
+          x_max = input("mesh-options/domain_x1_max", 1.0);
+      }
+
+    libMesh::Real y_max = input("MeshOptions/Generation/y_max", 1.0);
+    if( input.have_variable("mesh-options/domain_x2_max") )
+      {
+        std::string warning = "WARNING: mesh-options/domain_x2_max is DEPRECATED.\n";
+          warning += "         Please update to use MeshOptions/Generation/y_max.\n";
+          grins_warning(warning);
+
+          y_max = input("mesh-options/domain_x2_max", 1.0);
+      }
+
+    libMesh::Real z_max = input("MeshOptions/Generation/z_max", 1.0);
+    if( input.have_variable("mesh-options/domain_x3_max") )
+      {
+        std::string warning = "WARNING: mesh-options/domain_x3_max is DEPRECATED.\n";
+          warning += "         Please update to use MeshOptions/Generation/z_max.\n";
+          grins_warning(warning);
+
+          z_max = input("mesh-options/domain_x3_max", 1.0);
+      }
 
     int n_elems_x = input("mesh-options/mesh_nx1", -1);
     int n_elems_y = input("mesh-options/mesh_nx2", -1);

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -57,6 +57,13 @@ namespace GRINS
     (const GetPot& input,
      const libMesh::Parallel::Communicator &comm)
   {
+    // First check if the user has both old and new versions of mesh input
+    if( input.have_section("mesh-options/") &&
+        input.have_section("Mesh/") )
+      {
+        libmesh_error_msg("Error: Detected illegal simulataneous use of [mesh-options] and [Mesh] in input!");
+      }
+
     // User needs to tell us if we are generating or reading a mesh
     if( !input.have_variable("mesh-options/mesh_option") &&
         !input.have_variable("Mesh/type") )

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -258,14 +258,7 @@ namespace GRINS
           }
 
         n_elems_z = input("Mesh/Generation/n_elems_z", 0);
-        if( input.have_variable("mesh-options/mesh_nx3") )
-          {
-            std::string warning = "WARNING: mesh-options/mesh_nx3 is DEPRECATED.\n";
-            warning += "         Please update to use Mesh/Generation/n_elems_z.\n";
-            grins_warning(warning);
-
-            n_elems_z = input("mesh-options/mesh_nx3", 0);
-          }
+        this->deprecated_option<unsigned int>( input, "mesh-options/mesh_nx3", "Mesh/Generation/n_elems_z", 0, n_elems_z );
       }
 
     /* Now grab the element_type the user wants for the mesh. */

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -264,9 +264,60 @@ namespace GRINS
           z_max = input("mesh-options/domain_x3_max", 1.0);
       }
 
-    int n_elems_x = input("mesh-options/mesh_nx1", -1);
-    int n_elems_y = input("mesh-options/mesh_nx2", -1);
-    int n_elems_z = input("mesh-options/mesh_nx3", -1);
+    // Make sure user gave us info about how many elements to use
+    if( !input.have_variable("mesh-options/mesh_nx1") /* Deprecated */ &&
+        !input.have_variable("MeshOptions/Generation/n_elems_x") )
+      {
+        libmesh_error_msg("ERROR: Must supply MeshOptions/Generation/n_elems_x for mesh generation.");
+      }
+
+    if( dimension > 1 )
+      {
+        if( !input.have_variable("mesh-options/mesh_nx2") /* Deprecated */ &&
+        !input.have_variable("MeshOptions/Generation/n_elems_y") )
+          {
+            libmesh_error_msg("ERROR: Must supply MeshOptions/Generation/n_elems_y for mesh generation.");
+          }
+      }
+
+    if( dimension > 2 )
+      {
+        if( !input.have_variable("mesh-options/mesh_nx3") /* Deprecated */ &&
+        !input.have_variable("MeshOptions/Generation/n_elems_z") )
+          {
+            libmesh_error_msg("ERROR: Must supply MeshOptions/Generation/n_elems_z for mesh generation.");
+          }
+      }
+
+    unsigned int n_elems_x = input("MeshOptions/Generation/n_elems_x", 0);
+    if( input.have_variable("mesh-options/mesh_nx1") )
+      {
+        std::string warning = "WARNING: mesh-options/mesh_nx1 is DEPRECATED.\n";
+        warning += "         Please update to use MeshOptions/Generation/n_elems_x.\n";
+        grins_warning(warning);
+
+        n_elems_x = input("mesh-options/mesh_nx1", 0);
+      }
+
+    unsigned int n_elems_y = input("MeshOptions/Generation/n_elems_y", 0);
+    if( input.have_variable("mesh-options/mesh_nx2") )
+      {
+        std::string warning = "WARNING: mesh-options/mesh_nx2 is DEPRECATED.\n";
+        warning += "         Please update to use MeshOptions/Generation/n_elems_y.\n";
+        grins_warning(warning);
+
+        n_elems_y = input("mesh-options/mesh_nx2", 0);
+      }
+
+    unsigned int n_elems_z = input("MeshOptions/Generation/n_elems_z", 0);
+    if( input.have_variable("mesh-options/mesh_nx3") )
+      {
+        std::string warning = "WARNING: mesh-options/mesh_nx3 is DEPRECATED.\n";
+        warning += "         Please update to use MeshOptions/Generation/n_elems_z.\n";
+        grins_warning(warning);
+
+        n_elems_z = input("mesh-options/mesh_nx3", 0);
+      }
 
     std::string element_type = input("mesh-options/element_type", "NULL");
 

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -65,14 +65,28 @@ namespace GRINS
       }
 
     // User needs to tell us if we are generating or reading a mesh
+    // We infer this by checking and seeing if the use has a Mesh/Read
+    // or a Mesh/Generation section
     if( !input.have_variable("mesh-options/mesh_option") &&
-        !input.have_variable("Mesh/type") )
+        !input.have_section("Mesh/Read/") &&
+        !input.have_section("Mesh/Generation/") )
       {
-        libmesh_error_msg("ERROR: Must specify Mesh/type in input.");
+        libmesh_error_msg("ERROR: Must specify either Mesh/Read or Mesh/Generation in input.");
+      }
+
+    // But you can't have it both ways
+    if( input.have_section("Mesh/Read/") && input.have_section("Mesh/Generation/") )
+      {
+        libmesh_error_msg("ERROR: Can only specify one of Mesh/Read and Mesh/Generation");
       }
 
     // Are we generating the mesh or are we reading one in from a file?
-    std::string mesh_build_type = input("Mesh/type", "DIE!");
+    std::string mesh_build_type = "NULL";
+    if( input.have_section("Mesh/Read/") )
+      mesh_build_type = "read";
+
+    else if( input.have_section("Mesh/Generation/") )
+      mesh_build_type = "generate";
 
     this->deprecated_option<std::string>( input, "mesh-options/mesh_option", "Mesh/Read or Mesh/Generation", "DIE!", mesh_build_type);
 

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -227,14 +227,7 @@ namespace GRINS
       }
 
     unsigned int n_elems_x = input("Mesh/Generation/n_elems_x", 0);
-    if( input.have_variable("mesh-options/mesh_nx1") )
-      {
-        std::string warning = "WARNING: mesh-options/mesh_nx1 is DEPRECATED.\n";
-        warning += "         Please update to use Mesh/Generation/n_elems_x.\n";
-        grins_warning(warning);
-
-        n_elems_x = input("mesh-options/mesh_nx1", 0);
-      }
+    this->deprecated_option<unsigned int>( input, "mesh-options/mesh_nx1", "Mesh/Generation/n_elems_x", 0, n_elems_x );
 
     /* We only check n_elems_y input if dimension is > 1 so that GetPot
        UFO detection will give us an error if we have this in the input file

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -204,17 +204,17 @@ namespace GRINS
     // Set the mesh dimension
     mesh->set_mesh_dimension(dimension);
 
-    libMesh::Real domain_x1_min = input("mesh-options/domain_x1_min", 0.0);
-    libMesh::Real domain_x2_min = input("mesh-options/domain_x2_min", 0.0);
-    libMesh::Real domain_x3_min = input("mesh-options/domain_x3_min", 0.0);
+    libMesh::Real x_min = input("mesh-options/domain_x1_min", 0.0);
+    libMesh::Real y_min = input("mesh-options/domain_x2_min", 0.0);
+    libMesh::Real z_min = input("mesh-options/domain_x3_min", 0.0);
 
-    libMesh::Real domain_x1_max = input("mesh-options/domain_x1_max", 1.0); 
-    libMesh::Real domain_x2_max = input("mesh-options/domain_x2_max", 1.0);
-    libMesh::Real domain_x3_max = input("mesh-options/domain_x3_max", 1.0);
+    libMesh::Real x_max = input("mesh-options/domain_x1_max", 1.0);
+    libMesh::Real y_max = input("mesh-options/domain_x2_max", 1.0);
+    libMesh::Real z_max = input("mesh-options/domain_x3_max", 1.0);
 
-    int mesh_nx1 = input("mesh-options/mesh_nx1", -1);
-    int mesh_nx2 = input("mesh-options/mesh_nx2", -1);
-    int mesh_nx3 = input("mesh-options/mesh_nx3", -1);
+    int n_elems_x = input("mesh-options/mesh_nx1", -1);
+    int n_elems_y = input("mesh-options/mesh_nx2", -1);
+    int n_elems_z = input("mesh-options/mesh_nx3", -1);
 
     std::string element_type = input("mesh-options/element_type", "NULL");
 
@@ -229,9 +229,9 @@ namespace GRINS
 	  libMesh::Utility::string_to_enum<GRINSEnums::ElemType>(element_type);
 
 	libMesh::MeshTools::Generation::build_line(*mesh,
-						   mesh_nx1,
-						   domain_x1_min,
-						   domain_x1_max,
+                                                   n_elems_x,
+                                                   x_min,
+                                                   x_max,
 						   element_enum_type);
       }
 
@@ -246,12 +246,12 @@ namespace GRINS
 	  libMesh::Utility::string_to_enum<GRINSEnums::ElemType>(element_type);
 
 	libMesh::MeshTools::Generation::build_square(*mesh,
-						     mesh_nx1,
-						     mesh_nx2,
-						     domain_x1_min,
-						     domain_x1_max,
-						     domain_x2_min,
-						     domain_x2_max,
+                                                     n_elems_x,
+                                                     n_elems_y,
+                                                     x_min,
+                                                     x_max,
+                                                     y_min,
+                                                     y_max,
 						     element_enum_type);
       }
 
@@ -266,15 +266,15 @@ namespace GRINS
 	  libMesh::Utility::string_to_enum<GRINSEnums::ElemType>(element_type);
 
 	libMesh::MeshTools::Generation::build_cube(*mesh,
-						   mesh_nx1,
-						   mesh_nx2,
-						   mesh_nx3,
-						   domain_x1_min,
-						   domain_x1_max,
-						   domain_x2_min,
-						   domain_x2_max,
-						   domain_x3_min,
-						   domain_x3_max,
+                                                   n_elems_x,
+                                                   n_elems_y,
+                                                   n_elems_z,
+                                                   x_min,
+                                                   x_max,
+                                                   y_min,
+                                                   y_max,
+                                                   z_min,
+                                                   z_max,
 						   element_enum_type);
       }
 

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -242,14 +242,7 @@ namespace GRINS
           }
 
         n_elems_y = input("Mesh/Generation/n_elems_y", 0);
-        if( input.have_variable("mesh-options/mesh_nx2") )
-          {
-            std::string warning = "WARNING: mesh-options/mesh_nx2 is DEPRECATED.\n";
-            warning += "         Please update to use Mesh/Generation/n_elems_y.\n";
-            grins_warning(warning);
-
-            n_elems_y = input("mesh-options/mesh_nx2", 0);
-          }
+        this->deprecated_option<unsigned int>( input, "mesh-options/mesh_nx2", "Mesh/Generation/n_elems_y", 0, n_elems_y );
       }
 
     /* We only check n_elems_z input if dimension is > 2 so that GetPot

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -319,7 +319,15 @@ namespace GRINS
         n_elems_z = input("mesh-options/mesh_nx3", 0);
       }
 
-    std::string element_type = input("mesh-options/element_type", "default");
+    std::string element_type = input("MeshOptions/Generation/element_type", "default");
+    if( input.have_variable("mesh-options/element_type") )
+      {
+        std::string warning = "WARNING: mesh-options/element_type is DEPRECATED.\n";
+        warning += "         Please update to use MeshOptions/Generation/element_type.\n";
+        grins_warning(warning);
+
+        element_type = input("mesh-options/element_type", "default");
+      }
 
     if( dimension == 1 )
       {

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -91,15 +91,7 @@ namespace GRINS
     {
       std::string mesh_class = input("Mesh/class", "default");
 
-      if( input.have_variable("mesh-options/mesh_class") )
-        {
-          std::string warning = "WARNING: mesh-options/mesh_class is DEPRECATED.\n";
-          warning += "         Please update to use Mesh/class.\n";
-          warning += "         Mesh/class can take values: serial, parallel\n";
-          grins_warning(warning);
-
-          mesh_class = input("mesh-options/mesh_class", "default");
-        }
+      this->deprecated_option<std::string>( input, "mesh-options/mesh_class", "Mesh/class", "default", mesh_class);
 
       if (mesh_class == "parallel")
         mesh = new libMesh::ParallelMesh(comm);

--- a/test/input_files/2d_fantrick.in
+++ b/test/input_files/2d_fantrick.in
@@ -56,18 +56,17 @@ pressure = 'p'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_2D_mesh'
-element_type = 'QUAD9'
-
-mesh_nx1 = '10'
-mesh_nx2 = '10'
-
-domain_x1_min = '-0.5'
-domain_x1_max = '0.5'
-domain_x2_min = '-0.5'
-domain_x2_max = '0.5'
-
+[Mesh]
+   [./Generation]
+     dimension = '2'
+     element_type = 'QUAD9'
+     n_elems_x = '10'
+     n_elems_y = '10'
+     x_min = '-0.5'
+     x_max = '0.5'
+     y_min = '-0.5'
+     y_max = '0.5'
+[]
 
 # Options for time solvers
 [unsteady-solver]

--- a/test/input_files/2d_proptrick.in
+++ b/test/input_files/2d_proptrick.in
@@ -65,18 +65,17 @@ pressure = 'p'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_2D_mesh'
-element_type = 'QUAD9'
-
-mesh_nx1 = '10'
-mesh_nx2 = '10'
-
-domain_x1_min = '-0.5'
-domain_x1_max = '0.5'
-domain_x2_min = '-0.5'
-domain_x2_max = '0.5'
-
+[Mesh]
+   [./Generation]
+     dimension = '2'
+     element_type = 'QUAD9'
+     n_elems_x = '10'
+     n_elems_y = '10'
+     x_min = '-0.5'
+     x_max = '0.5'
+     y_min = '-0.5'
+     y_max = '0.5'
+[]
 
 # Options for time solvers
 [unsteady-solver]

--- a/test/input_files/2d_pseudofan.in
+++ b/test/input_files/2d_pseudofan.in
@@ -49,18 +49,17 @@ pressure = 'p'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_2D_mesh'
-element_type = 'QUAD9'
-
-mesh_nx1 = '10'
-mesh_nx2 = '10'
-
-domain_x1_min = '-0.5'
-domain_x1_max = '0.5'
-domain_x2_min = '-0.5'
-domain_x2_max = '0.5'
-
+[Mesh]
+   [./Generation]
+     dimension = '2'
+     element_type = 'QUAD9'
+     n_elems_x = '10'
+     n_elems_y = '10'
+     x_min = '-0.5'
+     x_max = '0.5'
+     y_min = '-0.5'
+     y_max = '0.5'
+[]
 
 # Options for time solvers
 [unsteady-solver]

--- a/test/input_files/2d_pseudoprop.in
+++ b/test/input_files/2d_pseudoprop.in
@@ -56,18 +56,17 @@ pressure = 'p'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_2D_mesh'
-element_type = 'QUAD9'
-
-mesh_nx1 = '10'
-mesh_nx2 = '10'
-
-domain_x1_min = '-0.5'
-domain_x1_max = '0.5'
-domain_x2_min = '-0.5'
-domain_x2_max = '0.5'
-
+[Mesh]
+   [./Generation]
+     dimension = '2'
+     element_type = 'QUAD9'
+     n_elems_x = '10'
+     n_elems_y = '10'
+     x_min = '-0.5'
+     x_max = '0.5'
+     y_min = '-0.5'
+     y_max = '0.5'
+[]
 
 # Options for time solvers
 [unsteady-solver]

--- a/test/input_files/3d_low_mach_jacobians_xy.in
+++ b/test/input_files/3d_low_mach_jacobians_xy.in
@@ -95,13 +95,14 @@ cp = '1.0' #[J/kg-K]
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_3D_mesh
-element_type = HEX27
-
-mesh_nx1 = 3
-mesh_nx2 = 3
-mesh_nx3 = 3
+[Mesh]
+   [./Generation]
+      dimension = '3'
+      element_type = 'HEX27'
+      n_elems_x = '3'
+      n_elems_y = '3'
+      n_elems_z = '3'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/3d_low_mach_jacobians_xz.in
+++ b/test/input_files/3d_low_mach_jacobians_xz.in
@@ -96,13 +96,14 @@ cp = '1.0' #[J/kg-K]
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_3D_mesh
-element_type = HEX27
-
-mesh_nx1 = 3
-mesh_nx2 = 3
-mesh_nx3 = 3
+[Mesh]
+   [./Generation]
+      dimension = '3'
+      element_type = 'HEX27'
+      n_elems_x = '3'
+      n_elems_y = '3'
+      n_elems_z = '3'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/3d_low_mach_jacobians_yz.in
+++ b/test/input_files/3d_low_mach_jacobians_yz.in
@@ -95,13 +95,14 @@ cp = '1.0' #[J/kg-K]
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_3D_mesh
-element_type = HEX27
-
-mesh_nx1 = 3
-mesh_nx2 = 3
-mesh_nx3 = 3
+[Mesh]
+   [./Generation]
+      dimension = '3'
+      element_type = 'HEX27'
+      n_elems_x = '3'
+      n_elems_y = '3'
+      n_elems_z = '3'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/axi_con_cyl_flow.in
+++ b/test/input_files/axi_con_cyl_flow.in
@@ -1,12 +1,13 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 500 
-mesh_nx2 = 1 
-
-domain_x1_min = 1.0
-domain_x1_max = 2.0
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '500'
+      n_elems_y = '1'
+      x_min = '1.0'
+      x_max = '2.0'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/axi_poiseuille_flow_input.in
+++ b/test/input_files/axi_poiseuille_flow_input.in
@@ -1,11 +1,11 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 5 
-mesh_nx2 = 5 
-
-domain_x1_max = 1.0
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '5'
+      n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/axi_thermally_driven_flow.in
+++ b/test/input_files/axi_thermally_driven_flow.in
@@ -1,9 +1,11 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 10
-mesh_nx2 = 10
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '10'
+      n_elems_y = '10'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/backward_facing_step.in.in
+++ b/test/input_files/backward_facing_step.in.in
@@ -55,9 +55,10 @@ tau_factor = '0.05'
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'read_mesh_from_file' 
-mesh_filename = '@abs_top_srcdir@/test/grids/backward_facing_step.e'
+[Mesh]
+   [./Read]
+      filename = '@abs_top_srcdir@/test/grids/backward_facing_step.e'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/convection_cell_regression.in
+++ b/test/input_files/convection_cell_regression.in
@@ -102,17 +102,16 @@ tau_factor_T = '3.0'
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = -10.0
-domain_x1_max = 10.0
-domain_x2_min = 0.0
-domain_x2_max = 4.0
-
-mesh_nx1 = '20' 
-mesh_nx2 = '8'
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      x_min = '-10.0'
+      x_max = '10.0'
+      y_max = '4.0'
+      n_elems_x = '20'
+      n_elems_y = '8'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/couette_flow_input_2d_x.in
+++ b/test/input_files/couette_flow_input_2d_x.in
@@ -1,11 +1,17 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 2 
-mesh_nx2 = 1
 
-domain_x1_max = 1.0
+[Mesh]
+
+   class = 'serial'
+
+   [./Generation]
+
+     dimension = '2'
+     element_type = 'QUAD9'
+     n_elems_x = '2'
+     n_elems_y = '1'
+
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/couette_flow_input_2d_y.in
+++ b/test/input_files/couette_flow_input_2d_y.in
@@ -1,11 +1,14 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 2 
-mesh_nx2 = 1
+[Mesh]
 
-domain_x1_max = 1.0
+   [./Generation]
+
+     dimension = '2'
+     element_type = 'QUAD9'
+     n_elems_x = '2'
+     n_elems_y = '1'
+
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/coupled_stokes_ns.in.in
+++ b/test/input_files/coupled_stokes_ns.in.in
@@ -1,7 +1,8 @@
 # Mesh related options
-[mesh-options]
-mesh_option = 'read_mesh_from_file'
-mesh_filename = '@abs_top_srcdir@/test/grids/coupled_stokes_ns.e'
+[Mesh]
+   [./Read]
+      filename = '@abs_top_srcdir@/test/grids/coupled_stokes_ns.e'
+[]
 
 #uniformly_refine = '2'
 

--- a/test/input_files/dirichlet_fem.in
+++ b/test/input_files/dirichlet_fem.in
@@ -1,10 +1,13 @@
 # Mesh related options
-[mesh-options]
-mesh_class = serial
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 10
-mesh_nx2 = 10
+[Mesh]
+   class = 'serial'
+
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '10'
+      n_elems_y = '10'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/dirichlet_nan.in
+++ b/test/input_files/dirichlet_nan.in
@@ -1,10 +1,13 @@
 # Mesh related options
-[mesh-options]
-mesh_class = serial
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 10
-mesh_nx2 = 10
+[Mesh]
+   class = 'serial'
+
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '10'
+      n_elems_y = '10'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/elastic_mooney_rivlin_circle_hookean_stiffeners_regression.in.in
+++ b/test/input_files/elastic_mooney_rivlin_circle_hookean_stiffeners_regression.in.in
@@ -1,10 +1,7 @@
 ##### Mesh related options #####
-[mesh-options]
-mesh_option = 'read_mesh_from_file'
-mesh_filename = '@abs_top_srcdir@/test/input_files/mixed_dim_circle.exo'
-
-#uniformly_refine = '2'
-
+[Mesh]
+   [./Read]
+      filename = '@abs_top_srcdir@/test/input_files/mixed_dim_circle.exo'
 []
 
 ##### Options related to all Physics #####

--- a/test/input_files/elastic_mooney_rivlin_inflating_sheet_regression.in.in
+++ b/test/input_files/elastic_mooney_rivlin_inflating_sheet_regression.in.in
@@ -35,12 +35,11 @@ C2 = '3.0'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'read_mesh_from_file'
-mesh_filename = '@abs_top_srcdir@/test/input_files/circular_sheet.e'
+[Mesh]
+    [./Read]
+       filename = '@abs_top_srcdir@/test/input_files/circular_sheet.e'
+[]
 
-#uniformly_refine = '1'
-                                                                                                                                                                                                                                           
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]
 relative_residual_tolerance = '1.0e-10'

--- a/test/input_files/elastic_mooney_rivlin_sheet_regression.in
+++ b/test/input_files/elastic_mooney_rivlin_sheet_regression.in
@@ -44,17 +44,18 @@ n_increments = '50'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_2D_mesh'
-element_type = 'QUAD4'
-                                                                                                                                                                                                                                           
-domain_x1_min = '0.0'
-domain_x1_max = '8.0'
-domain_x2_min = '0.0'
-domain_x2_max = '8.0'
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD4'
+      x_min = '0.0'
+      x_max = '8.0'
+      y_min = '0.0'
+      y_max = '8.0'
 
-mesh_nx1 = '10'
-mesh_nx2 = '10'
+      n_elems_x = '10'
+      n_elems_y = '10'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_regression.in.in
+++ b/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_regression.in.in
@@ -1,11 +1,9 @@
 ##### Mesh related options #####
-[mesh-options]
-mesh_option = 'read_mesh_from_file'
-mesh_filename = '@abs_top_srcdir@/test/input_files/mixed_dim_symmetric_square.exo'
-
-#uniformly_refine = '2'
-
+[Mesh]
+   [./Read]
+      filename = '@abs_top_srcdir@/test/input_files/mixed_dim_symmetric_square.exo'
 []
+
 
 ##### Options related to all Physics #####
 [Physics]

--- a/test/input_files/locally_refine.in.in
+++ b/test/input_files/locally_refine.in.in
@@ -55,10 +55,13 @@ tau_factor = '0.05'
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'read_mesh_from_file' 
-mesh_filename = '@abs_top_srcdir@/test/grids/backward_facing_step.e'
-locally_h_refine = '(9-x)/4.5+(abs(y)<.2)'
+[Mesh]
+   [./Read]
+      filename = '@abs_top_srcdir@/test/grids/backward_facing_step.e'
+
+   [../Refinement]
+      locally_h_refine = '(9-x)/4.5+(abs(y)<.2)'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/low_mach_cavity_benchmark_regression_input.in
+++ b/test/input_files/low_mach_cavity_benchmark_regression_input.in
@@ -115,17 +115,16 @@ cp = '1004.5' #[J/kg-K]
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      x_max = '0.067'
+      y_max = '0.067'
+      n_elems_x = '10'
+      n_elems_y = '10'
+[]
 
-domain_x1_min = 0.0
-domain_x1_max = 0.067
-domain_x2_min = 0.0
-domain_x2_max = 0.067
-
-mesh_nx1 = 10 
-mesh_nx2 = 10
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/penalty_poiseuille.in
+++ b/test/input_files/penalty_poiseuille.in
@@ -1,13 +1,14 @@
 # Mesh related options
-[mesh-options]
-mesh_class = serial
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 32
-mesh_nx2 = 16
+[Mesh]
+   class = 'serial'
 
-domain_x1_max = 5.0
-domain_x2_max = 1.0
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '32'
+      n_elems_y = '16'
+      x_max = '5.0'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/penalty_poiseuille_stab.in
+++ b/test/input_files/penalty_poiseuille_stab.in
@@ -1,13 +1,14 @@
 # Mesh related options
-[mesh-options]
-mesh_class = serial
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 32
-mesh_nx2 = 16
+[Mesh]
+   class = 'serial'
 
-domain_x1_max = 5.0
-domain_x2_max = 1.0
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '32'
+      n_elems_y = '16'
+      x_max = '5.0'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/poiseuille_flow_input.in
+++ b/test/input_files/poiseuille_flow_input.in
@@ -1,11 +1,13 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 2 
-mesh_nx2 = 1 
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '2'
+      n_elems_y = '1'
+      x_max = '5.0'
+[]
 
-domain_x1_max = 5.0
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_antioch_cea_constant_prandtl_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_cea_constant_prandtl_regression.in.in
@@ -97,17 +97,17 @@ pressure = 'p'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_antioch_cea_constant_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_cea_constant_regression.in.in
@@ -97,17 +97,17 @@ pressure = 'p'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in.in
@@ -91,17 +91,17 @@ pressure = 'p'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_catalytic_wall_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_catalytic_wall_regression.in.in
@@ -89,17 +89,17 @@ pressure = 'p'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_gassolid_catalytic_wall_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_gassolid_catalytic_wall_regression.in.in
@@ -95,17 +95,17 @@ pressure = 'p'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in.in
@@ -91,17 +91,17 @@ pressure = 'p'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_regression.in.in
@@ -83,17 +83,17 @@ pressure = 'p'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_constant_prandtl_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_constant_prandtl_regression.in.in
@@ -97,17 +97,17 @@ pressure = 'p'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_constant_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_constant_regression.in.in
@@ -97,17 +97,17 @@ pressure = 'p'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/reacting_low_mach_cantera_regression.in.in
+++ b/test/input_files/reacting_low_mach_cantera_regression.in.in
@@ -73,17 +73,17 @@ pin_pressure = 'false'
 #restart_file = 'cavity.xdr'
 
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-
-domain_x1_min = 0.0
-domain_x1_max = 50.0
-domain_x2_min = -1.0
-domain_x2_max = 1.0
-
-mesh_nx1 = 25 
-mesh_nx2 = 5
+[Mesh]
+   [./Generation]
+       dimension = '2'
+       element_type = 'QUAD9'
+       x_min = '0.0'
+       x_max = '50.0'
+       y_min = '-1.0'
+       y_max = '1.0'
+       n_elems_x = '25'
+       n_elems_y = '5'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/redistribute.in.in
+++ b/test/input_files/redistribute.in.in
@@ -56,11 +56,16 @@ tau_factor = '0.05'
 
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'read_mesh_from_file' 
-mesh_filename = '@abs_top_srcdir@/test/grids/backward_facing_step.e'
-locally_h_refine = '(9-x)/4.5+(abs(y)<.2)'
-redistribute = '{x+x*(x-30)/30}{y*2}{z}'
+[Mesh]
+   [./Read]
+      filename = '@abs_top_srcdir@/test/grids/backward_facing_step.e'
+
+   [../Refinement]
+      locally_h_refine = '(9-x)/4.5+(abs(y)<.2)'
+
+   [../Redistribution]
+      function = '{x+x*(x-30)/30}{y*2}{z}'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/simple_ode.in
+++ b/test/input_files/simple_ode.in
@@ -1,10 +1,12 @@
 # Mesh related options - can we use a null mesh for an ODE-only solve?
-[mesh-options]
-mesh_class = serial
-mesh_option = create_2D_mesh
-element_type = QUAD4
-mesh_nx1 = 1
-mesh_nx2 = 1
+[Mesh]
+   class = 'serial'
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD4'
+      n_elems_x = '1'
+      n_elems_y = '1'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/stokes_poiseuille_flow_input.in
+++ b/test/input_files/stokes_poiseuille_flow_input.in
@@ -1,11 +1,12 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 10
-mesh_nx2 = 10 
-
-domain_x1_max = 5.0
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '10'
+      n_elems_y = '10'
+      x_max = '5.0'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/stokes_poiseuille_flow_parsed_viscosity_input.in
+++ b/test/input_files/stokes_poiseuille_flow_parsed_viscosity_input.in
@@ -1,11 +1,12 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 10
-mesh_nx2 = 10 
-
-domain_x1_max = 5.0
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '10'
+      n_elems_y = '10'
+      x_max = '5.0'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity_input.in
+++ b/test/input_files/stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity_input.in
@@ -1,11 +1,12 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 10
-mesh_nx2 = 10 
-
-domain_x1_max = 5.0
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '10'
+      n_elems_y = '10'
+      x_max = '5.0'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/suspended_cable_test.in
+++ b/test/input_files/suspended_cable_test.in
@@ -42,14 +42,14 @@ E = '1.0e6'
 []
 
 # Mesh related options
-[mesh-options]
-mesh_option = 'create_1D_mesh'
-#element_type = 'EDGE2'
-                                                                                                                                                                                                                                           
-domain_x1_min = '0.0'
-domain_x1_max = '200.0'
-
-mesh_nx1 = '10'
+[Mesh]
+   [./Generation]
+      dimension = '1'
+      element_type = 'EDGE2'
+      x_min = '0.0'
+      x_max = '200.0'
+      n_elems_x = '10'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/thermally_driven_2d_flow.in
+++ b/test/input_files/thermally_driven_2d_flow.in
@@ -1,9 +1,11 @@
 # Mesh related options
-[mesh-options]
-mesh_option = create_2D_mesh
-element_type = QUAD9
-mesh_nx1 = 10
-mesh_nx2 = 10
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '10'
+      n_elems_y = '10'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/thermally_driven_3d_flow.in
+++ b/test/input_files/thermally_driven_3d_flow.in
@@ -1,11 +1,12 @@
 # Mesh related options
-[mesh-options]
-
-mesh_option = create_3D_mesh
-element_type = HEX27
-mesh_nx1 = 3 
-mesh_nx2 = 3
-mesh_nx3 = 3
+[Mesh]
+   [./Generation]
+      dimension = '3'
+      element_type = 'HEX27'
+      n_elems_x = '3'
+      n_elems_y = '3'
+      n_elems_z = '3'
+[]
 
 # Options for tiem solvers
 [unsteady-solver]

--- a/test/input_files/vorticity_qoi.in.in
+++ b/test/input_files/vorticity_qoi.in.in
@@ -1,8 +1,8 @@
 # Mesh related options
-[mesh-options]
-mesh_option = 'read_mesh_from_file'
-mesh_filename = '@abs_top_srcdir@/test/grids/poiseuille_verification.e'
-uniformly_refine = 0
+[Mesh]
+    [./Read]
+       filename = '@abs_top_srcdir@/test/grids/poiseuille_verification.e'
+[]
 
 # Options for time solvers
 [unsteady-solver]


### PR DESCRIPTION
See [this](https://groups.google.com/forum/#!topic/grins-devel/AGVvODmfzh8) thread.

If you want to generate the mesh, the new input specification looks like

```
[Mesh]

    class = 'serial'

    [./Generation]
        dimension = '1'
        n_elems_x = '10'
        x_min = '0.0'
        x_max = '1.0'
        element_type = 'EDGE2'
[]
```
etc.

If you want to read the mesh:
```
[Mesh]

      class = 'parallel'

      [./Read]
            filename = 'filename.exo'

[]
```

I need to update the regression tests and examples. I'm going to use this opportunity to make a master example input file with comments for all the options.

Now's your chance to complain if you don't like a section/variable name.

`make check` is passing and spitting out lots of deprecated warnings.

Note the diff is a little ugly because I introduced a helper function that threw off a lot of spacing.