### PR TITLE
VelocityPenalty3 to constrain all components of velocity

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 Version 0.6.0 (In progress)
+   * Added velocitypenalty2 + velocitypenalty3, to support 3d constraints 
 
 Version 0.5.0
 https://github.com/grinsfem/grins/releases/tag/v0.5.0

--- a/src/physics/include/grins/grins_physics_names.h
+++ b/src/physics/include/grins/grins_physics_names.h
@@ -42,8 +42,10 @@ namespace GRINS
   const PhysicsName velocity_drag_adjoint_stab = "VelocityDragAdjointStabilization";
   const PhysicsName velocity_penalty = "VelocityPenalty";
   const PhysicsName velocity_penalty2 = "VelocityPenalty2";
+  const PhysicsName velocity_penalty3 = "VelocityPenalty3";
   const PhysicsName velocity_penalty_adjoint_stab  = "VelocityPenaltyAdjointStabilization";
   const PhysicsName velocity_penalty2_adjoint_stab = "VelocityPenalty2AdjointStabilization";
+  const PhysicsName velocity_penalty3_adjoint_stab = "VelocityPenalty3AdjointStabilization";
   const PhysicsName averaged_fan = "AveragedFan";
   const PhysicsName averaged_fan_adjoint_stab = "AveragedFanAdjointStabilization";
   const PhysicsName averaged_turbine = "AveragedTurbine";

--- a/src/physics/src/physics_factory.C
+++ b/src/physics/src/physics_factory.C
@@ -292,15 +292,17 @@ namespace GRINS
           new_mu_class<VelocityDragAdjointStabilization>
             (physics_to_add, input);
       }
-    else if( physics_to_add == velocity_penalty ||
-             physics_to_add == velocity_penalty2 )
+    else if( physics_to_add == velocity_penalty  ||
+             physics_to_add == velocity_penalty2 ||
+             physics_to_add == velocity_penalty3)
       {
 	physics_list[physics_to_add] =
           new_mu_class<VelocityPenalty>
             (physics_to_add, input);
       }
-    else if( physics_to_add == velocity_penalty_adjoint_stab ||
-             physics_to_add == velocity_penalty2_adjoint_stab )
+    else if( physics_to_add == velocity_penalty_adjoint_stab  ||
+             physics_to_add == velocity_penalty2_adjoint_stab ||
+             physics_to_add == velocity_penalty3_adjoint_stab )
       {
 	physics_list[physics_to_add] =
           new_mu_class<VelocityPenaltyAdjointStabilization>

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -68,6 +68,9 @@ namespace GRINS
     if (this->_physics_name == "VelocityPenalty2")
       vel_penalty += '2';
 
+    if (this->_physics_name == "VelocityPenalty3")
+      vel_penalty += '3';
+
     if( input.have_variable(section) )
       {
         unsigned int n_vars = input.vector_variable_size(section);

--- a/src/physics/src/velocity_penalty_base.C
+++ b/src/physics/src/velocity_penalty_base.C
@@ -62,6 +62,10 @@ namespace GRINS
         this->_physics_name == velocity_penalty2_adjoint_stab)
       base_physics_name.push_back('2');
 
+    if (this->_physics_name == velocity_penalty3 ||
+        this->_physics_name == velocity_penalty3_adjoint_stab)
+      base_physics_name.push_back('3');
+
     std::string penalty_function =
       input("Physics/"+base_physics_name+"/penalty_function",
         std::string("0"));


### PR DESCRIPTION
The pull request adds the option for a third velocity penalty definition. This is necessary in order to create walls, where the all three velocity components are constrained to zero. 

This largely parrots @roystgnr work from #160. 
