### PR TITLE
Continue after max iterations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 Version 0.6.0 (In progress)
+
+   * Added 'continue_after_max_iterations' option to parser
    * Added velocitypenalty2 + velocitypenalty3, to support 3d constraints 
 
 Version 0.5.0

--- a/src/solver/include/grins/grins_solver.h
+++ b/src/solver/include/grins/grins_solver.h
@@ -77,6 +77,7 @@ namespace GRINS
     double _minimum_linear_tolerance;
     unsigned int _max_linear_iterations;
     bool _continue_after_backtrack_failure;
+    bool _continue_after_max_iterations;
 
     // Screen display options
     bool _solver_quiet;

--- a/src/solver/src/grins_solver.C
+++ b/src/solver/src/grins_solver.C
@@ -42,7 +42,6 @@ namespace GRINS
 
   Solver::Solver( const GetPot& input )
     : _max_nonlinear_iterations( input("linear-nonlinear-solver/max_nonlinear_iterations", 10 ) ),
-      _continue_after_max_iterations( input("linear-nonlinear-solver/continue_after_max_iterations", false ) ),
       _relative_step_tolerance( input("linear-nonlinear-solver/relative_step_tolerance", 1.e-6 ) ),
       _absolute_step_tolerance( input("linear-nonlinear-solver/absolute_step_tolerance", 0.0 ) ),
       _relative_residual_tolerance( input("linear-nonlinear-solver/relative_residual_tolerance", 1.e-15 ) ),
@@ -51,6 +50,7 @@ namespace GRINS
       _minimum_linear_tolerance( input("linear-nonlinear-solver/minimum_linear_tolerance", 1.e-3 ) ),
       _max_linear_iterations( input("linear-nonlinear-solver/max_linear_iterations", 500 ) ),
       _continue_after_backtrack_failure( input("linear-nonlinear-solver/continue_after_backtrack_failure", false ) ),
+      _continue_after_max_iterations( input("linear-nonlinear-solver/continue_after_max_iterations", false ) ),
       _solver_quiet( input("screen-options/solver_quiet", false ) ),
       _solver_verbose( input("screen-options/solver_verbose", false ) )
   {

--- a/src/solver/src/grins_solver.C
+++ b/src/solver/src/grins_solver.C
@@ -42,6 +42,7 @@ namespace GRINS
 
   Solver::Solver( const GetPot& input )
     : _max_nonlinear_iterations( input("linear-nonlinear-solver/max_nonlinear_iterations", 10 ) ),
+      _continue_after_max_iterations( input("linear-nonlinear-solver/continue_after_max_iterations", false ) ),
       _relative_step_tolerance( input("linear-nonlinear-solver/relative_step_tolerance", 1.e-6 ) ),
       _absolute_step_tolerance( input("linear-nonlinear-solver/absolute_step_tolerance", 0.0 ) ),
       _relative_residual_tolerance( input("linear-nonlinear-solver/relative_residual_tolerance", 1.e-15 ) ),
@@ -95,6 +96,7 @@ namespace GRINS
     solver.continue_after_backtrack_failure = this->_continue_after_backtrack_failure;
     solver.initial_linear_tolerance    = this->_initial_linear_tolerance;
     solver.minimum_linear_tolerance    = this->_minimum_linear_tolerance;
+    solver.continue_after_max_iterations    = this->_continue_after_max_iterations;
 
     return;
   }


### PR DESCRIPTION
This pull request adds a new input line to the parser, permitting the user to dictate that the routine either throws an exception or continues when the non-linear solver does not converge. In particular, in the latest GRINS, the default behaviour is to continue on the merry way, such as,
<pre>
 Nonlinear solver reached maximum step 10, latest evaluated residual
0.291611                                                    
  Continuing...           
</pre>

Now, the default behaviour is to throw an exception, unless the flag, 'continue_after_max_iterations' is set to true. I would prefer this to be the case, as I want to know this is happening and explicitly give permission, but this is admittedly a change from the previous GRINS settings, and I'm happy to switch it back to 'true' (and therefore continuing even without convergence) if that is preferred. 

However, I do feel slightly bad, as this appears to be introducing a warning at compilation, namely:
<pre>
make[2]: Entering directory `/scratch/nick/sov_libs/nick_grins/build/src'
  CXX      solver/src/grins_solver.lo
../../src/solver/include/grins/grins_solver.h: In constructor 'GRINS::Solver::Solver(const GetPot&)':
../../src/solver/include/grins/grins_solver.h:80:10: warning: 'GRINS::Solver::_continue_after_max_iterations' will be initialized after [-Wreorder]
</pre>

Not totally sure what is causing this. Otherwise the feature is working as expected for me. 