### PR TITLE
Adaptivity printqoi fix

### DIFF
--- a/src/solver/include/grins/solver_context.h
+++ b/src/solver/include/grins/solver_context.h
@@ -62,6 +62,7 @@ namespace GRINS
     bool output_residual;
     bool print_perflog;
     bool print_scalars;
+    bool print_qoi;
 
     std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> > postprocessing;
 

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -158,6 +158,7 @@ namespace GRINS
     context.print_perflog = _print_log_info;
     context.postprocessing = _postprocessing;
     context.error_estimator = _error_estimator;
+    context.print_qoi = _print_qoi;
 
     _solver->solve( context );
 

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -162,10 +162,15 @@ namespace GRINS
                           << " active dofs" << std::endl
                           << "==========================================================" << std::endl;
 
-                context.system->assemble_qoi();
-                const CompositeQoI* my_qoi = libMesh::libmesh_cast_ptr<const CompositeQoI*>(context.system->get_qoi());
-                my_qoi->output_qoi( std::cout );
-                std::cout << std::endl;
+                // It's helpful to print the qoi along the way, but only do it if the user
+                // asks for it
+                if( context.print_qoi )
+                  {
+                    context.system->assemble_qoi();
+                    const CompositeQoI* my_qoi = libMesh::libmesh_cast_ptr<const CompositeQoI*>(context.system->get_qoi());
+                    my_qoi->output_qoi( std::cout );
+                    std::cout << std::endl;
+                  }
               }
           }
 


### PR DESCRIPTION
Only print the QoI if the user requests it in the adaptivity solver.

Really, we need to do additional checking on if the user has actually set a QoI to handle cases were they set print_qoi = 'true', but don't actually have a QoI; will open a ticket for that. For now, this is a quick fix.