### PR TITLE
Fix Postprocessing Index Heisenbug

### DIFF
--- a/src/physics/src/heat_transfer.C
+++ b/src/physics/src/heat_transfer.C
@@ -44,7 +44,8 @@ namespace GRINS
 
   template<class K>
   HeatTransfer<K>::HeatTransfer( const std::string& physics_name, const GetPot& input )
-    : HeatTransferBase<K>(physics_name, input)
+    : HeatTransferBase<K>(physics_name, input),
+    _k_index(0)
   {
     this->read_input_options(input);
 

--- a/src/physics/src/inc_navier_stokes.C
+++ b/src/physics/src/inc_navier_stokes.C
@@ -44,7 +44,8 @@ namespace GRINS
     : IncompressibleNavierStokesBase<Mu>(physics_name,
                                          incompressible_navier_stokes, /* "core" Physics name */
                                          input),
-      _p_pinning(input,physics_name)
+    _p_pinning(input,physics_name),
+    _mu_index(0)
   {
     this->read_input_options(input);
 

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -46,7 +46,7 @@ namespace GRINS
   LowMachNavierStokes<Mu,SH,TC>::LowMachNavierStokes(const std::string& physics_name, const GetPot& input)
     : LowMachNavierStokesBase<Mu,SH,TC>(physics_name,input),
       _p_pinning(input,physics_name),
-      _rho_index(2^30) // Initialize to absurd value
+      _rho_index(0) // Initialize to zero
   {
     this->read_input_options(input);
 

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -42,7 +42,11 @@ namespace GRINS
   template<typename Mixture, typename Evaluator>
   ReactingLowMachNavierStokes<Mixture,Evaluator>::ReactingLowMachNavierStokes(const PhysicsName& physics_name, const GetPot& input)
     : ReactingLowMachNavierStokesBase<Mixture,Evaluator>(physics_name,input),
-      _p_pinning(input,physics_name)
+    _p_pinning(input,physics_name),
+    _rho_index(0),
+    _mu_index(0),
+    _k_index(0),
+    _cp_index(0)
   {
     this->read_input_options(input);
 

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -38,7 +38,13 @@ namespace GRINS
 
   template<class Mu>
   VelocityPenalty<Mu>::VelocityPenalty( const std::string& physics_name, const GetPot& input )
-    : VelocityPenaltyBase<Mu>(physics_name, input)
+    : VelocityPenaltyBase<Mu>(physics_name, input),
+    _velocity_penalty_x_index(0),
+    _velocity_penalty_y_index(0),
+    _velocity_penalty_z_index(0),
+    _velocity_penalty_base_x_index(0),
+    _velocity_penalty_base_y_index(0),
+    _velocity_penalty_base_z_index(0)
   {
     return;
   }

--- a/src/visualization/src/postprocessed_quantities.C
+++ b/src/visualization/src/postprocessed_quantities.C
@@ -64,7 +64,10 @@ namespace GRINS
         libmesh_error();
       }
 
-    unsigned int new_index = _quantity_name_index_map.size();
+    /* We add 1 so that the locally cached indices in each of the Physics
+       can safely initialize the index to zero. In particular this ensures
+       we count starting from 1. */
+    unsigned int new_index = _quantity_name_index_map.size()+1;
 
     _quantity_name_index_map.insert( std::make_pair( name, new_index ) );
 

--- a/src/visualization/src/postprocessed_quantities.C
+++ b/src/visualization/src/postprocessed_quantities.C
@@ -145,6 +145,8 @@ namespace GRINS
 
     libMesh::Real value = 0.0;
 
+    // Quantity we want had better be there.
+    libmesh_assert(_quantity_index_var_map.find(component) != _quantity_index_var_map.end());
     unsigned int quantity_index = _quantity_index_var_map.find(component)->second;
 
     _multiphysics_sys->compute_postprocessed_quantity( quantity_index,


### PR DESCRIPTION
Each Physics class is responsible for its own postprocessing variables (following #167) by registering with PostprocessedQuantities and getting an `unsigned int` back so that PostprocessedQuantities can later request the evaluation of that quantity without using string comparisons. There were 2 issues here and I can't believe they didn't bite us earlier in much worse ways.

1. Many of the index variables weren't initialized in the Physics classes so we were getting uncertain behavior. This is why things changed based on the order requested, number of processors, etc.

2. PostprocessedQuantities was counting from zero so if the default for the `unsigned int`s was zero, and the 0 variable was requested, you would've gotten the first quantity that was indexed at zero, whether you requested it or not.

I think this is still a design problem (I'll create an issue for discussion on this point), but this PR fixes the issue by 1. having PostprocessedQuantities count from 1 for the indices referenced in the Physics and 2. Initializing the bloody variables (somewhere Scott Meyers is dying inside).

@nicholasmalaya can you confirm this fixes your conductivity plotting issue? This fixed my plotting issue.

Sorry for the trouble.