### PR TITLE
Initialize libMesh earlier

### DIFF
--- a/src/solver/src/grins.C
+++ b/src/solver/src/grins.C
@@ -57,6 +57,9 @@ int main(int argc, char* argv[])
   // libMesh input file should be first argument
   std::string libMesh_input_filename = argv[1];
   
+  // Initialize libMesh library.
+  libMesh::LibMeshInit libmesh_init(argc, argv);
+
   // Create our GetPot object.
   GetPot libMesh_inputfile( libMesh_input_filename );
 
@@ -75,9 +78,6 @@ int main(int argc, char* argv[])
   grvy_timer.BeginTimer("Initialize Solver");
 #endif
 
-  // Initialize libMesh library.
-  libMesh::LibMeshInit libmesh_init(argc, argv);
- 
   libMesh::out << "Starting GRINS with command:\n";
   for (int i=0; i != argc; ++i)
     libMesh::out << argv[i] << ' ';


### PR DESCRIPTION
Otherwise we aren't ready for any libmesh_error() calls from the GetPot initialization.

That was originally an infinite loop prompting https://github.com/libMesh/libmesh/pull/503 but even with that fixed we can't query the libMesh command line for gdb version until after LibMeshInit construction.