### PR TITLE
Plot_forcing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Version 0.6.0 (In progress)
+   * permit output forcing calculated by velocity penalty
    * Added velocitypenalty2 + velocitypenalty3, to support 3d constraints 
-
    * Added 'continue_after_max_iterations' option to parser
    * Added velocitypenalty2 + velocitypenalty3, to support 3d constraints 
 

--- a/src/physics/include/grins/velocity_penalty.h
+++ b/src/physics/include/grins/velocity_penalty.h
@@ -94,6 +94,15 @@ namespace GRINS
     //! Index from registering this quantity
     unsigned int _velocity_penalty_base_z_index;
 
+    //! Index from registering this quantity
+    unsigned int _velocity_penalty_force_x;
+
+    //! Index from registering this quantity
+    unsigned int _velocity_penalty_force_y;
+
+    //! Index from registering this quantity
+    unsigned int _velocity_penalty_force_z;
+
     VelocityPenalty();
   };
 

--- a/src/physics/include/grins/velocity_penalty.h
+++ b/src/physics/include/grins/velocity_penalty.h
@@ -95,13 +95,13 @@ namespace GRINS
     unsigned int _velocity_penalty_base_z_index;
 
     //! Index from registering this quantity
-    unsigned int _velocity_penalty_force_x;
+    unsigned int _velocity_penalty_force_x_index;
 
     //! Index from registering this quantity
-    unsigned int _velocity_penalty_force_y;
+    unsigned int _velocity_penalty_force_y_index;
 
     //! Index from registering this quantity
-    unsigned int _velocity_penalty_force_z;
+    unsigned int _velocity_penalty_force_z_index;
 
     VelocityPenalty();
   };

--- a/src/physics/include/grins/velocity_penalty_base.h
+++ b/src/physics/include/grins/velocity_penalty_base.h
@@ -64,8 +64,8 @@ namespace GRINS
     bool _quadratic_scaling;
 
     libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > normal_vector_function;
-
     libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > base_velocity_function;
+    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > force_velocity_function;
 
   private:
 

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -45,9 +45,9 @@ namespace GRINS
     _velocity_penalty_base_x_index(0),
     _velocity_penalty_base_y_index(0),
     _velocity_penalty_base_z_index(0),
-    _velocity_penalty_force_x(0),  
-    _velocity_penalty_force_y(0),  
-    _velocity_penalty_force_z(0)
+    _velocity_penalty_force_x_index(0),  
+    _velocity_penalty_force_y_index(0),  
+    _velocity_penalty_force_z_index(0)
   {
     return;
   }
@@ -101,13 +101,13 @@ namespace GRINS
 
 		// adding force to postprocessing
 		//
-                _velocity_penalty_force_x =
+                _velocity_penalty_force_x_index =
                   postprocessing.register_quantity( vel_penalty+"_force_x" );
 
-                _velocity_penalty_force_y =
+                _velocity_penalty_force_y_index =
                   postprocessing.register_quantity( vel_penalty+"_force_y" );
 
-                _velocity_penalty_force_z =
+                _velocity_penalty_force_z_index =
                   postprocessing.register_quantity( vel_penalty+"_force_z" );
               }
             else if( name == std::string("velocity_penalty_base") )
@@ -296,19 +296,19 @@ namespace GRINS
         value = output_vec(2);
       }
     // adding forcing
-    else if( quantity_index == this->_velocity_penalty_force_x )
+    else if( quantity_index == this->_velocity_penalty_force_x_index )
       {
         (*this->base_velocity_function)(point, context.time, output_vec);
 
         value = output_vec(0);
       }
-    else if( quantity_index == this->_velocity_penalty_force_y )
+    else if( quantity_index == this->_velocity_penalty_force_y_index )
       {
         (*this->base_velocity_function)(point, context.time, output_vec);
 
         value = output_vec(1);
       }
-    else if( quantity_index == this->_velocity_penalty_force_y )
+    else if( quantity_index == this->_velocity_penalty_force_y_index )
       {
         (*this->base_velocity_function)(point, context.time, output_vec);
 

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -295,6 +295,25 @@ namespace GRINS
 
         value = output_vec(2);
       }
+    // adding forcing
+    else if( quantity_index == this->_velocity_penalty_force_x )
+      {
+        (*this->base_velocity_function)(point, context.time, output_vec);
+
+        value = output_vec(0);
+      }
+    else if( quantity_index == this->_velocity_penalty_force_y )
+      {
+        (*this->base_velocity_function)(point, context.time, output_vec);
+
+        value = output_vec(1);
+      }
+    else if( quantity_index == this->_velocity_penalty_force_y )
+      {
+        (*this->base_velocity_function)(point, context.time, output_vec);
+
+        value = output_vec(2);
+      }
 
     return;
   }

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -298,19 +298,19 @@ namespace GRINS
     // adding forcing
     else if( quantity_index == this->_velocity_penalty_force_x_index )
       {
-        (*this->base_velocity_function)(point, context.time, output_vec);
+        (*this->force_velocity_function)(point, context.time, output_vec);
 
         value = output_vec(0);
       }
     else if( quantity_index == this->_velocity_penalty_force_y_index )
       {
-        (*this->base_velocity_function)(point, context.time, output_vec);
+        (*this->force_velocity_function)(point, context.time, output_vec);
 
         value = output_vec(1);
       }
     else if( quantity_index == this->_velocity_penalty_force_z_index )
       {
-        (*this->base_velocity_function)(point, context.time, output_vec);
+        (*this->force_velocity_function)(point, context.time, output_vec);
 
         value = output_vec(2);
       }

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -44,7 +44,10 @@ namespace GRINS
     _velocity_penalty_z_index(0),
     _velocity_penalty_base_x_index(0),
     _velocity_penalty_base_y_index(0),
-    _velocity_penalty_base_z_index(0)
+    _velocity_penalty_base_z_index(0),
+    _velocity_penalty_force_x(0),  
+    _velocity_penalty_force_y(0),  
+    _velocity_penalty_force_z(0)
   {
     return;
   }

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -95,6 +95,17 @@ namespace GRINS
 
                 _velocity_penalty_z_index =
                   postprocessing.register_quantity( vel_penalty+"_z" );
+
+		// adding force to postprocessing
+		//
+                _velocity_penalty_force_x =
+                  postprocessing.register_quantity( vel_penalty+"_force_x" );
+
+                _velocity_penalty_force_y =
+                  postprocessing.register_quantity( vel_penalty+"_force_y" );
+
+                _velocity_penalty_force_z =
+                  postprocessing.register_quantity( vel_penalty+"_force_z" );
               }
             else if( name == std::string("velocity_penalty_base") )
               {

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -308,7 +308,7 @@ namespace GRINS
 
         value = output_vec(1);
       }
-    else if( quantity_index == this->_velocity_penalty_force_y_index )
+    else if( quantity_index == this->_velocity_penalty_force_z_index )
       {
         (*this->base_velocity_function)(point, context.time, output_vec);
 

--- a/src/physics/src/velocity_penalty_base.C
+++ b/src/physics/src/velocity_penalty_base.C
@@ -108,6 +108,7 @@ namespace GRINS
     // value
     libmesh_assert(normal_vector_function.get());
     libmesh_assert(base_velocity_function.get());
+    libmesh_assert(force_velocity_function.get());
 
     libMesh::DenseVector<libMesh::Number> output_vec(3);
 
@@ -126,6 +127,10 @@ namespace GRINS
                                          output_vec(2));
 
     const libMesh::NumberVectorValue U_Rel = U-U_B;
+
+    // adding forcing to output
+    (*force_velocity_function)(point, time,
+			       output_vec);
 
     // Old code
     // const libMesh::NumberVectorValue F1 = (U_Rel*U_N)*U_N; //


### PR DESCRIPTION
This update permits outputting the forcing calculated by the velocity penalty. This closely follows the recommendations generously provided by @pbauman in #243. No major deviations. Update is not too large, should be easy to digest.

However, this is a *do not merge* at present. The latest revision is building and working, but fails when using "output_vars = 'velocity_penalty'" in a velocity_penalty section. I think, however, we are close. My only point of confusion occurs in velocity_penalty_base.C in the method 'compute_force' (line 99). I've added a boost autoptr named, 'force_velocity_function' which will be accessed in 'velocity_penalty.C' in compute_postprocessed_quantity (line 255). 

However, @roystgnr 's approach for the other quantities followed, 
<pre>
(*base_velocity_function)(point, time,
                              output_vec);
</pre>
Where, output_vec is a DenseVector, e.g. libMesh::DenseVector<libMesh::Number> output_vec(3);
What I want is to do the same thing for F, our forcing vector. However, this is not in a DenseVector, so,
<pre>
    (*force_velocity_function)(point, time,
                               F);
</pre> isnt working for me.

Any eyes that can be spared are appreciated. 