### PR TITLE
Simulation constructor refactor

### DIFF
--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -98,6 +98,10 @@ namespace GRINS
     //! Helper function
     void init_qois( const GetPot& input, SimulationBuilder& sim_builder );
 
+    //! Helper function
+    void init_restart( const GetPot& input, SimulationBuilder& sim_builder,
+                       const libMesh::Parallel::Communicator &comm );
+
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 
     std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -103,7 +103,7 @@ namespace GRINS
                        const libMesh::Parallel::Communicator &comm );
 
     //! Helper function
-    void check_for_unused_vars( const GetPot& input );
+    void check_for_unused_vars( const GetPot& input, bool warning_only );
 
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -91,6 +91,10 @@ namespace GRINS
     void attach_dirichlet_bc_funcs( std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > dbc_map,
 				    GRINS::MultiphysicsSystem* system );
 
+    //! Helper function
+    void init_multiphysics_system( const GetPot& input,
+                                   SimulationBuilder& sim_builder );
+
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 
     std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -61,10 +61,16 @@ namespace GRINS
   class Simulation
   {
   public:
-    
+
     Simulation( const GetPot& input,
 		SimulationBuilder& sim_builder,
-                const libMesh::Parallel::Communicator &comm 
+                const libMesh::Parallel::Communicator &comm
+                LIBMESH_CAN_DEFAULT_TO_COMMWORLD );
+
+    Simulation( const GetPot& input,
+                GetPot& command_line, /* Has to be non-const for search() */
+		SimulationBuilder& sim_builder,
+                const libMesh::Parallel::Communicator &comm
                 LIBMESH_CAN_DEFAULT_TO_COMMWORLD );
 
     virtual ~Simulation();

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -95,6 +95,9 @@ namespace GRINS
     void init_multiphysics_system( const GetPot& input,
                                    SimulationBuilder& sim_builder );
 
+    //! Helper function
+    void init_qois( const GetPot& input, SimulationBuilder& sim_builder );
+
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 
     std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -102,6 +102,9 @@ namespace GRINS
     void init_restart( const GetPot& input, SimulationBuilder& sim_builder,
                        const libMesh::Parallel::Communicator &comm );
 
+    //! Helper function
+    void check_for_unused_vars( const GetPot& input );
+
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 
     std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -71,7 +71,7 @@ namespace GRINS
         this->init_restart(input,sim_builder,comm);
       }
 
-    this->check_for_unused_vars(input);
+    this->check_for_unused_vars(input, false /*warning only*/);
 
     return;
   }
@@ -150,7 +150,7 @@ namespace GRINS
     return;
   }
 
-  void Simulation::check_for_unused_vars( const GetPot& input )
+  void Simulation::check_for_unused_vars( const GetPot& input, bool warning_only )
   {
     /* Everything should be set up now, so check if there's any unused variables
        in the input file. If so, then tell the user what they were and error out. */
@@ -159,14 +159,22 @@ namespace GRINS
     if( !unused_vars.empty() )
       {
         libMesh::err << "==========================================================" << std::endl;
-        libMesh::err << "Error: Found unused variables!" << std::endl;
+        if( warning_only )
+          libMesh::err << "Warning: ";
+        else
+          libMesh::err << "Error: ";
+
+        libMesh::err << "Found unused variables!" << std::endl;
+
         for( std::vector<std::string>::const_iterator it = unused_vars.begin();
              it != unused_vars.end(); ++it )
           {
             libMesh::err << *it << std::endl;
           }
         libMesh::err << "==========================================================" << std::endl;
-        libmesh_error();
+
+        if( !warning_only )
+          libmesh_error();
       }
 
     return;

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -61,17 +61,7 @@ namespace GRINS
   {
     this->init_multiphysics_system(input,sim_builder);
 
-    // If the user actually asks for a QoI, then we add it.
-    std::tr1::shared_ptr<CompositeQoI> qois = sim_builder.build_qoi( input );
-    if( qois->n_qois() > 0 )
-      {
-        // This *must* be done after equation_system->init in order to get variable indices
-        qois->init(input, *_multiphysics_system );
-      
-        /* Note that we are effectively transfering ownership of the qoi pointer because
-           it will be cloned in _multiphysics_system and all the calculations are done there. */
-        _multiphysics_system->attach_qoi( qois.get() );
-      }
+    this->init_qois(input,sim_builder);
 
     // Must be called after setting QoI on the MultiphysicsSystem
     _error_estimator = sim_builder.build_error_estimator( input, libMesh::QoISet(*_multiphysics_system) );
@@ -150,6 +140,22 @@ namespace GRINS
     return;
   }
 
+  void Simulation::init_qois( const GetPot& input, SimulationBuilder& sim_builder )
+  {
+    // If the user actually asks for a QoI, then we add it.
+    std::tr1::shared_ptr<CompositeQoI> qois = sim_builder.build_qoi( input );
+    if( qois->n_qois() > 0 )
+      {
+        // This *must* be done after equation_system->init in order to get variable indices
+        qois->init(input, *_multiphysics_system );
+
+        /* Note that we are effectively transfering ownership of the qoi pointer because
+           it will be cloned in _multiphysics_system and all the calculations are done there. */
+        _multiphysics_system->attach_qoi( qois.get() );
+      }
+
+    return;
+  }
   void Simulation::run()
   {
     this->print_sim_info();

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -68,15 +68,7 @@ namespace GRINS
 
     if( input.have_variable("restart-options/restart_file") )
       {
-        this->read_restart( input );
-
-        /* We do this here only if there's a restart file. Otherwise, this was done
-           at mesh construction time */
-        sim_builder.mesh_builder().do_mesh_refinement_from_input( input, comm, *_mesh );
-
-        /* \todo Any way to tell if the mesh got refined so we don't unnecessarily
-                 call reinit()? */
-        _equation_system->reinit();
+        this->init_restart(input,sim_builder,comm);
       }
 
     /* Everything should be set up now, so check if there's any unused variables
@@ -156,6 +148,23 @@ namespace GRINS
 
     return;
   }
+
+  void Simulation::init_restart( const GetPot& input, SimulationBuilder& sim_builder,
+                                 const libMesh::Parallel::Communicator &comm )
+  {
+    this->read_restart( input );
+
+    /* We do this here only if there's a restart file. Otherwise, this was done
+       at mesh construction time */
+    sim_builder.mesh_builder().do_mesh_refinement_from_input( input, comm, *_mesh );
+
+    /* \todo Any way to tell if the mesh got refined so we don't unnecessarily
+       call reinit()? */
+    _equation_system->reinit();
+
+    return;
+  }
+
   void Simulation::run()
   {
     this->print_sim_info();

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -71,22 +71,7 @@ namespace GRINS
         this->init_restart(input,sim_builder,comm);
       }
 
-    /* Everything should be set up now, so check if there's any unused variables
-       in the input file. If so, then tell the user what they were and error out. */
-    std::vector<std::string> unused_vars = input.unidentified_variables();
-
-    if( !unused_vars.empty() )
-      {
-        libMesh::err << "==========================================================" << std::endl;
-        libMesh::err << "Error: Found unused variables!" << std::endl;
-        for( std::vector<std::string>::const_iterator it = unused_vars.begin();
-             it != unused_vars.end(); ++it )
-          {
-            libMesh::err << *it << std::endl;
-          }
-        libMesh::err << "==========================================================" << std::endl;
-        libmesh_error();
-      }
+    this->check_for_unused_vars(input);
 
     return;
   }
@@ -161,6 +146,28 @@ namespace GRINS
     /* \todo Any way to tell if the mesh got refined so we don't unnecessarily
        call reinit()? */
     _equation_system->reinit();
+
+    return;
+  }
+
+  void Simulation::check_for_unused_vars( const GetPot& input )
+  {
+    /* Everything should be set up now, so check if there's any unused variables
+       in the input file. If so, then tell the user what they were and error out. */
+    std::vector<std::string> unused_vars = input.unidentified_variables();
+
+    if( !unused_vars.empty() )
+      {
+        libMesh::err << "==========================================================" << std::endl;
+        libMesh::err << "Error: Found unused variables!" << std::endl;
+        for( std::vector<std::string>::const_iterator it = unused_vars.begin();
+             it != unused_vars.end(); ++it )
+          {
+            libMesh::err << *it << std::endl;
+          }
+        libMesh::err << "==========================================================" << std::endl;
+        libmesh_error();
+      }
 
     return;
   }


### PR DESCRIPTION
Created several helper functions to condense code in the constructor. Created a new constructor that additionally takes a GetPot& for the command line parsing. Deprecated the previous constructor.

This is in preparation for adding command line flag to warning instead of error on UFO detection. I went this route because it looked unsafe to have a single GetPot object parse both the input file and command line. Also didn't like the idea of shoving it in the SimulationBuilder. And it's probably a good idea to have access to the command line anyway.