### PR TITLE
Enable only warnings for UFO detection with command line option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -422,6 +422,8 @@ AC_CONFIG_FILES(test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners
 AC_CONFIG_FILES(test/elastic_mooney_rivlin_square_hookean_stiffeners_unifref_regression.sh, [chmod +x test/elastic_mooney_rivlin_square_hookean_stiffeners_unifref_regression.sh])
 AC_CONFIG_FILES(test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_unifref_regression.in)
 
+AC_CONFIG_FILES(test/warn_only_ufo_unit.sh, [chmod +x test/warn_only_ufo_unit.sh])
+
 dnl-----------------------------------------------
 dnl Generate run scripts for examples
 dnl-----------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -423,6 +423,7 @@ AC_CONFIG_FILES(test/elastic_mooney_rivlin_square_hookean_stiffeners_unifref_reg
 AC_CONFIG_FILES(test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_unifref_regression.in)
 
 AC_CONFIG_FILES(test/warn_only_ufo_unit.sh, [chmod +x test/warn_only_ufo_unit.sh])
+AC_CONFIG_FILES(test/error_ufo_unit.sh, [chmod +x test/error_ufo_unit.sh])
 
 dnl-----------------------------------------------
 dnl Generate run scripts for examples

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -98,6 +98,10 @@ namespace GRINS
     //! Helper function
     void init_qois( const GetPot& input, SimulationBuilder& sim_builder );
 
+    //! Helper function
+    void init_restart( const GetPot& input, SimulationBuilder& sim_builder,
+                       const libMesh::Parallel::Communicator &comm );
+
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 
     std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -103,7 +103,7 @@ namespace GRINS
                        const libMesh::Parallel::Communicator &comm );
 
     //! Helper function
-    void check_for_unused_vars( const GetPot& input );
+    void check_for_unused_vars( const GetPot& input, bool warning_only );
 
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -91,6 +91,10 @@ namespace GRINS
     void attach_dirichlet_bc_funcs( std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > dbc_map,
 				    GRINS::MultiphysicsSystem* system );
 
+    //! Helper function
+    void init_multiphysics_system( const GetPot& input,
+                                   SimulationBuilder& sim_builder );
+
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 
     std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -61,10 +61,16 @@ namespace GRINS
   class Simulation
   {
   public:
-    
+
     Simulation( const GetPot& input,
 		SimulationBuilder& sim_builder,
-                const libMesh::Parallel::Communicator &comm 
+                const libMesh::Parallel::Communicator &comm
+                LIBMESH_CAN_DEFAULT_TO_COMMWORLD );
+
+    Simulation( const GetPot& input,
+                GetPot& command_line, /* Has to be non-const for search() */
+		SimulationBuilder& sim_builder,
+                const libMesh::Parallel::Communicator &comm
                 LIBMESH_CAN_DEFAULT_TO_COMMWORLD );
 
     virtual ~Simulation();

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -95,6 +95,9 @@ namespace GRINS
     void init_multiphysics_system( const GetPot& input,
                                    SimulationBuilder& sim_builder );
 
+    //! Helper function
+    void init_qois( const GetPot& input, SimulationBuilder& sim_builder );
+
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 
     std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -102,6 +102,9 @@ namespace GRINS
     void init_restart( const GetPot& input, SimulationBuilder& sim_builder,
                        const libMesh::Parallel::Communicator &comm );
 
+    //! Helper function
+    void check_for_unused_vars( const GetPot& input );
+
     std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
 
     std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;

--- a/src/solver/src/grins.C
+++ b/src/solver/src/grins.C
@@ -88,6 +88,7 @@ int main(int argc, char* argv[])
   GRINS::SimulationBuilder sim_builder;
 
   GRINS::Simulation grins( libMesh_inputfile,
+                           command_line,
 			   sim_builder,
                            libmesh_init.comm() );
 

--- a/src/solver/src/grins.C
+++ b/src/solver/src/grins.C
@@ -63,6 +63,8 @@ int main(int argc, char* argv[])
   // Create our GetPot object.
   GetPot libMesh_inputfile( libMesh_input_filename );
 
+  GetPot command_line(argc,argv);
+
   // GetPot doesn't throw an error for a nonexistent file?
   {
     std::ifstream i(libMesh_input_filename.c_str());

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -71,7 +71,7 @@ namespace GRINS
         this->init_restart(input,sim_builder,comm);
       }
 
-    this->check_for_unused_vars(input);
+    this->check_for_unused_vars(input, false /*warning only*/);
 
     return;
   }
@@ -150,7 +150,7 @@ namespace GRINS
     return;
   }
 
-  void Simulation::check_for_unused_vars( const GetPot& input )
+  void Simulation::check_for_unused_vars( const GetPot& input, bool warning_only )
   {
     /* Everything should be set up now, so check if there's any unused variables
        in the input file. If so, then tell the user what they were and error out. */
@@ -159,14 +159,22 @@ namespace GRINS
     if( !unused_vars.empty() )
       {
         libMesh::err << "==========================================================" << std::endl;
-        libMesh::err << "Error: Found unused variables!" << std::endl;
+        if( warning_only )
+          libMesh::err << "Warning: ";
+        else
+          libMesh::err << "Error: ";
+
+        libMesh::err << "Found unused variables!" << std::endl;
+
         for( std::vector<std::string>::const_iterator it = unused_vars.begin();
              it != unused_vars.end(); ++it )
           {
             libMesh::err << *it << std::endl;
           }
         libMesh::err << "==========================================================" << std::endl;
-        libmesh_error();
+
+        if( !warning_only )
+          libmesh_error();
       }
 
     return;

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -79,7 +79,7 @@ namespace GRINS
   }
 
   Simulation::Simulation( const GetPot& input,
-                          GetPot& /*command_line*/,
+                          GetPot& command_line,
                           SimulationBuilder& sim_builder,
                           const libMesh::Parallel::Communicator &comm )
     :  _mesh( sim_builder.build_mesh(input, comm) ),
@@ -112,7 +112,8 @@ namespace GRINS
         this->init_restart(input,sim_builder,comm);
       }
 
-    this->check_for_unused_vars(input, false /*warning only*/);
+    bool warning_only = command_line.search("--warn-only-unused-var");
+    this->check_for_unused_vars(input, warning_only );
 
     return;
   }

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -61,17 +61,7 @@ namespace GRINS
   {
     this->init_multiphysics_system(input,sim_builder);
 
-    // If the user actually asks for a QoI, then we add it.
-    std::tr1::shared_ptr<CompositeQoI> qois = sim_builder.build_qoi( input );
-    if( qois->n_qois() > 0 )
-      {
-        // This *must* be done after equation_system->init in order to get variable indices
-        qois->init(input, *_multiphysics_system );
-      
-        /* Note that we are effectively transfering ownership of the qoi pointer because
-           it will be cloned in _multiphysics_system and all the calculations are done there. */
-        _multiphysics_system->attach_qoi( qois.get() );
-      }
+    this->init_qois(input,sim_builder);
 
     // Must be called after setting QoI on the MultiphysicsSystem
     _error_estimator = sim_builder.build_error_estimator( input, libMesh::QoISet(*_multiphysics_system) );
@@ -150,6 +140,22 @@ namespace GRINS
     return;
   }
 
+  void Simulation::init_qois( const GetPot& input, SimulationBuilder& sim_builder )
+  {
+    // If the user actually asks for a QoI, then we add it.
+    std::tr1::shared_ptr<CompositeQoI> qois = sim_builder.build_qoi( input );
+    if( qois->n_qois() > 0 )
+      {
+        // This *must* be done after equation_system->init in order to get variable indices
+        qois->init(input, *_multiphysics_system );
+
+        /* Note that we are effectively transfering ownership of the qoi pointer because
+           it will be cloned in _multiphysics_system and all the calculations are done there. */
+        _multiphysics_system->attach_qoi( qois.get() );
+      }
+
+    return;
+  }
   void Simulation::run()
   {
     this->print_sim_info();

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -68,15 +68,7 @@ namespace GRINS
 
     if( input.have_variable("restart-options/restart_file") )
       {
-        this->read_restart( input );
-
-        /* We do this here only if there's a restart file. Otherwise, this was done
-           at mesh construction time */
-        sim_builder.mesh_builder().do_mesh_refinement_from_input( input, comm, *_mesh );
-
-        /* \todo Any way to tell if the mesh got refined so we don't unnecessarily
-                 call reinit()? */
-        _equation_system->reinit();
+        this->init_restart(input,sim_builder,comm);
       }
 
     /* Everything should be set up now, so check if there's any unused variables
@@ -156,6 +148,23 @@ namespace GRINS
 
     return;
   }
+
+  void Simulation::init_restart( const GetPot& input, SimulationBuilder& sim_builder,
+                                 const libMesh::Parallel::Communicator &comm )
+  {
+    this->read_restart( input );
+
+    /* We do this here only if there's a restart file. Otherwise, this was done
+       at mesh construction time */
+    sim_builder.mesh_builder().do_mesh_refinement_from_input( input, comm, *_mesh );
+
+    /* \todo Any way to tell if the mesh got refined so we don't unnecessarily
+       call reinit()? */
+    _equation_system->reinit();
+
+    return;
+  }
+
   void Simulation::run()
   {
     this->print_sim_info();

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -71,22 +71,7 @@ namespace GRINS
         this->init_restart(input,sim_builder,comm);
       }
 
-    /* Everything should be set up now, so check if there's any unused variables
-       in the input file. If so, then tell the user what they were and error out. */
-    std::vector<std::string> unused_vars = input.unidentified_variables();
-
-    if( !unused_vars.empty() )
-      {
-        libMesh::err << "==========================================================" << std::endl;
-        libMesh::err << "Error: Found unused variables!" << std::endl;
-        for( std::vector<std::string>::const_iterator it = unused_vars.begin();
-             it != unused_vars.end(); ++it )
-          {
-            libMesh::err << *it << std::endl;
-          }
-        libMesh::err << "==========================================================" << std::endl;
-        libmesh_error();
-      }
+    this->check_for_unused_vars(input);
 
     return;
   }
@@ -161,6 +146,28 @@ namespace GRINS
     /* \todo Any way to tell if the mesh got refined so we don't unnecessarily
        call reinit()? */
     _equation_system->reinit();
+
+    return;
+  }
+
+  void Simulation::check_for_unused_vars( const GetPot& input )
+  {
+    /* Everything should be set up now, so check if there's any unused variables
+       in the input file. If so, then tell the user what they were and error out. */
+    std::vector<std::string> unused_vars = input.unidentified_variables();
+
+    if( !unused_vars.empty() )
+      {
+        libMesh::err << "==========================================================" << std::endl;
+        libMesh::err << "Error: Found unused variables!" << std::endl;
+        for( std::vector<std::string>::const_iterator it = unused_vars.begin();
+             it != unused_vars.end(); ++it )
+          {
+            libMesh::err << *it << std::endl;
+          }
+        libMesh::err << "==========================================================" << std::endl;
+        libmesh_error();
+      }
 
     return;
   }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -137,6 +137,8 @@ TESTS += constant_catalycity_unit
 TESTS += arrhenius_catalycity_unit
 TESTS += power_law_catalycity_unit
 TESTS += warn_only_ufo_unit.sh
+TESTS += error_ufo_unit.sh
+XFAIL_TESTS += error_ufo_unit.sh
 
 TESTS += test_ns_couette_flow_2d_x.sh
 TESTS += test_ns_couette_flow_2d_y.sh
@@ -248,6 +250,7 @@ shellfiles_src += 3d_low_mach_jacobians_xz.sh
 shellfiles_src += 3d_low_mach_jacobians_yz.sh
 shellfiles_src += suspended_cable_test.sh
 shellfiles_src += warn_only_ufo_unit.sh
+shellfiles_src += error_ufo_unit.sh
 
 # Want these put with the distro so we can run make check
 EXTRA_DIST = $(shellfiles_src) input_files test_data grids

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -136,6 +136,7 @@ TESTS += gas_solid_catalytic_wall_unit_cantera.sh
 TESTS += constant_catalycity_unit
 TESTS += arrhenius_catalycity_unit
 TESTS += power_law_catalycity_unit
+TESTS += warn_only_ufo_unit.sh
 
 TESTS += test_ns_couette_flow_2d_x.sh
 TESTS += test_ns_couette_flow_2d_y.sh
@@ -246,6 +247,7 @@ shellfiles_src += 3d_low_mach_jacobians_xy.sh
 shellfiles_src += 3d_low_mach_jacobians_xz.sh
 shellfiles_src += 3d_low_mach_jacobians_yz.sh
 shellfiles_src += suspended_cable_test.sh
+shellfiles_src += warn_only_ufo_unit.sh
 
 # Want these put with the distro so we can run make check
 EXTRA_DIST = $(shellfiles_src) input_files test_data grids

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -116,6 +116,8 @@ suspended_cable_regression_SOURCES = suspended_cable_regression.C
 
 #Define tests to actually be run
 TESTS =
+XFAIL_TESTS =
+
 TESTS += gaussian_profiles
 TESTS += cantera_mixture_unit.sh
 TESTS += cantera_chem_thermo_test.sh
@@ -162,7 +164,7 @@ TESTS += redistribute_regression.sh
 TESTS += coupled_stokes_ns.sh
 
 TESTS += reacting_low_mach_cantera_regression.sh
-XFAIL_TESTS = reacting_low_mach_cantera_regression.sh
+XFAIL_TESTS += reacting_low_mach_cantera_regression.sh
 
 TESTS += reacting_low_mach_antioch_statmech_constant_regression.sh
 TESTS += reacting_low_mach_antioch_statmech_constant_prandtl_regression.sh

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -33,6 +33,7 @@ check_PROGRAMS += 3d_low_mach_jacobians_xy
 check_PROGRAMS += 3d_low_mach_jacobians_xz
 check_PROGRAMS += 3d_low_mach_jacobians_yz
 check_PROGRAMS += suspended_cable_regression
+check_PROGRAMS += ufo_unit
 
 AM_CPPFLAGS = 
 AM_CPPFLAGS += -I$(top_srcdir)/src/bc_handling/include
@@ -113,6 +114,7 @@ elastic_sheet_regression_SOURCES = elastic_sheet_regression.C
 3d_low_mach_jacobians_xz_SOURCES = 3d_low_mach_jacobians.C
 3d_low_mach_jacobians_yz_SOURCES = 3d_low_mach_jacobians.C
 suspended_cable_regression_SOURCES = suspended_cable_regression.C
+ufo_unit_SOURCES = ufo_unit.C
 
 #Define tests to actually be run
 TESTS =

--- a/test/error_ufo_unit.sh.in
+++ b/test/error_ufo_unit.sh.in
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PROG="@top_builddir@/test/ufo_unit"
+
+INPUT="@top_srcdir@/test/input_files/ufo_unit.in"
+
+PETSC_OPTIONS="-pc_type ilu"
+
+# -pc_factor_mat_solver_package mumps"
+
+$PROG $INPUT $PETSC_OPTIONS 

--- a/test/input_files/ufo_unit.in
+++ b/test/input_files/ufo_unit.in
@@ -1,0 +1,164 @@
+# THIS INPUT FILE IS DUMMY. WE'RE ONLY TESTING FOR UNUSED VARIABLES.
+[UnusedSection]
+   unused_var = 'blah'
+[]
+
+
+# Material section
+[Materials]
+
+[./Conductivity]
+
+k = '1.0'
+
+
+# Options related to all Physics
+[Physics]
+
+enabled_physics = 'IncompressibleNavierStokes IncompressibleNavierStokesAdjointStabilization HeatTransfer HeatTransferAdjointStabilization BoussinesqBuoyancy BoussinesqBuoyancyAdjointStabilization'
+
+# Options for Incompressible Navier-Stokes physics
+[./IncompressibleNavierStokes]
+
+V_FE_family = 'LAGRANGE'
+P_FE_family = 'LAGRANGE'
+
+V_order = 'FIRST'
+P_order = 'FIRST'
+
+rho = '1.77'
+mu = '1.846e-5'
+
+# Boundary ids:
+# j = bottom -> 0
+# j = top    -> 2
+# i = bottom -> 3
+# i = top    -> 1
+
+bc_ids = '0 1 2 3'
+bc_types = 'no_slip no_slip no_slip no_slip'
+
+pin_pressure = true
+pin_location = '0.0 0.0'
+pin_value = '0.0'
+
+ic_ids = '0'
+ic_types = 'parsed'
+ic_variables = 'v'
+ic_values = '(abs(x)<=2)*0.001'
+
+[../HeatTransfer]
+
+T_FE_family = 'LAGRANGE'
+T_order = 'FIRST'
+
+# Boundary ids:
+# j = bottom -> 0
+# j = top    -> 2
+# i = bottom -> 3
+# i = top    -> 1
+
+bc_ids = '0 1 2 3'
+bc_types = 'parsed_dirichlet adiabatic_wall isothermal_wall adiabatic_wall'
+bc_variables = 'T na na na'
+bc_values = '{340.0+(abs(x)<=2)*30} na na na'
+
+T_wall_2 = '280.0'
+
+ic_ids = '0'
+ic_types = 'constant'
+ic_variables = 'T'
+ic_values = '300.0'
+
+rho = '1.77'
+Cp = '1004.9'
+
+conductivity_model = 'constant'
+
+[../BoussinesqBuoyancy]
+
+# Reference temperature
+T_ref = '300' #[K]
+
+rho_ref = '1.77'
+
+beta_T = '0.003333333333'
+
+# Gravity vector
+g = '0.0 -9.81' #[m/s^2]
+
+[Stabilization]
+
+tau_constant_vel = '1.0'
+tau_factor_vel = '1.0'
+
+tau_constant_T = '1.0'
+tau_factor_T = '3.0'
+
+
+[]
+
+[restart-options]
+
+#restart_file = 'convection_cell.xdr'
+
+[]
+
+
+
+# Mesh related options
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      x_min = '-10.0'
+      x_max = '10.0'
+      y_max = '4.0'
+      n_elems_x = '20'
+      n_elems_y = '8'
+[]
+
+# Options for tiem solvers
+[unsteady-solver]
+transient = 'true' 
+theta = 1.0
+n_timesteps = '10'
+deltat = '1.0'
+
+#Linear and nonlinear solver options
+[linear-nonlinear-solver]
+max_nonlinear_iterations =  30
+max_linear_iterations = 5000
+
+relative_residual_tolerance = '1.0e-10'
+
+verify_analytic_jacobians = 0.0
+
+initial_linear_tolerance = 1.0e-10
+
+use_numerical_jacobians_only = 'true'
+
+# Visualization options
+[vis-options]
+output_vis = 'false' 
+
+vis_output_file_prefix = 'convection_cell' 
+
+output_residual = 'false' 
+
+output_format = 'ExodusII'
+
+# Options for print info to the screen
+[screen-options]
+
+system_name = 'GRINS'
+
+print_equation_system_info = true
+print_mesh_info = true
+print_log_info = true
+solver_verbose = true
+solver_quiet = false
+
+print_element_jacobians = 'false'
+
+[]

--- a/test/ufo_unit.C
+++ b/test/ufo_unit.C
@@ -1,0 +1,76 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#include <iostream>
+
+// GRINS
+#include "grins/simulation_builder.h"
+#include "grins/simulation.h"
+
+// libMesh
+#include "libmesh/parallel.h"
+
+int main(int argc, char* argv[])
+{
+  // Check command line count.
+  if( argc < 2 )
+    {
+      // TODO: Need more consistent error handling.
+      std::cerr << "Error: Must specify libMesh input file." << std::endl;
+      exit(1); // TODO: something more sophisticated for parallel runs?
+    }
+
+  // libMesh input file should be first argument
+  std::string libMesh_input_filename = argv[1];
+
+  // Initialize libMesh library.
+  libMesh::LibMeshInit libmesh_init(argc, argv);
+
+  // Create our GetPot object.
+  GetPot libMesh_inputfile( libMesh_input_filename );
+
+  GetPot command_line(argc,argv);
+
+  // GetPot doesn't throw an error for a nonexistent file?
+  {
+    std::ifstream i(libMesh_input_filename.c_str());
+    if (!i)
+      {
+        std::cerr << "Error: Could not read from libMesh input file "
+                << libMesh_input_filename << std::endl;
+        exit(1);
+      }
+  }
+
+  GRINS::SimulationBuilder sim_builder;
+
+  GRINS::Simulation grins( libMesh_inputfile,
+                           command_line,
+			   sim_builder,
+                           libmesh_init.comm() );
+
+  return 0;
+}

--- a/test/warn_only_ufo_unit.sh.in
+++ b/test/warn_only_ufo_unit.sh.in
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+PROG="@top_builddir@/test/ufo_unit"
+
+INPUT="@top_srcdir@/test/input_files/ufo_unit.in"
+
+GRINS_OPTIONS="--warn-only-unused-var"
+
+PETSC_OPTIONS="-pc_type ilu"
+
+# -pc_factor_mat_solver_package mumps"
+
+$PROG $INPUT $GRINS_OPTIONS $PETSC_OPTIONS 


### PR DESCRIPTION
Following some complaints about the lack of this option, this PR enables only warnings, instead of errors, if UFOs are detection. Namely, add the option "--warn-only-unused-var" on the command line sometime after the input file (the input file must be the first option listed after the grins executable (we should probably add some flexibility here)) and any detected UFOs will only illicit a warning and the list of UFOs instead of an error. I've also added unit tests for both the warning and the error versions.

This builds off of #248 (for command line access in `Simulation`).