### PR TITLE
Actually test vorticity qoi

### DIFF
--- a/test/input_files/vorticity_qoi.in.in
+++ b/test/input_files/vorticity_qoi.in.in
@@ -13,7 +13,7 @@ transient = false
 max_nonlinear_iterations = 10 
 max_linear_iterations = 2500
 
-initial_linear_tolerance = 1.0e-12
+relative_step_tolerance = 1.0e-12
 
 verify_analytic_jacobians = 1.e-6
 

--- a/test/test_vorticity_qoi.C
+++ b/test/test_vorticity_qoi.C
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
   int return_flag = 0;
   const libMesh::Number exact_value = -0.5;
   const libMesh::Number rel_error = std::fabs( (qoi - exact_value )/exact_value );
-  const libMesh::Number tol = 1.0e-15;
+  const libMesh::Number tol = 1.0e-11;
   if( rel_error > tol )
     {
       std::cerr << "Computed voriticity QoI mismatch greater than tolerance." << std::endl

--- a/test/test_vorticity_qoi.sh.in
+++ b/test/test_vorticity_qoi.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PROG="@top_builddir@/src/grins"
+PROG="@top_builddir@/test/vorticity_qoi"
 
 INPUT="@top_builddir@/test/input_files/vorticity_qoi.in"
 


### PR DESCRIPTION
Discovered this while adding the Parsed QoI run case.  It turns out that all this time, make check has been verifying that the Vorticity QoI *runs* but hasn't actually been calling the test harness that verifies the output is correct.

We should probably generalize that test harness to use for other QoI cases too, but for now we can at least turn it on for Vorticity.