### PR TITLE
Register parameters

### DIFF
--- a/src/physics/include/grins/axisym_heat_transfer.h
+++ b/src/physics/include/grins/axisym_heat_transfer.h
@@ -83,6 +83,13 @@ namespace GRINS
 				AssemblyContext& context,
 				CachedValues& cache );
 
+    // Registers all parameters in this physics and in its property
+    // class
+    virtual void register_parameter
+      ( const std::string & param_name,
+        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const;
+
   protected:
 
     //! Physical dimension of problem

--- a/src/physics/include/grins/boussinesq_buoyancy_adjoint_stab.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_adjoint_stab.h
@@ -57,6 +57,13 @@ namespace GRINS
                                      AssemblyContext& context,
                                      CachedValues& cache );
 
+    // Registers all parameters in this physics and in its property
+    // classes
+    virtual void register_parameter
+      ( const std::string & param_name,
+        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const;
+
   protected:
 
     libMesh::Number _rho;

--- a/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
@@ -64,6 +64,13 @@ namespace GRINS
                                 AssemblyContext& context,
                                 CachedValues& cache );
 
+    // Registers all parameters in this physics and in its property
+    // classes
+    virtual void register_parameter
+      ( const std::string & param_name,
+        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const;
+
   protected:
 
     IncompressibleNavierStokesStabilizationHelper _flow_stab_helper;

--- a/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
@@ -46,7 +46,9 @@ namespace GRINS
   {
   public:
     
-    BoussinesqBuoyancySPGSMStabilization( const std::string& physics_name, const GetPot& input );
+    BoussinesqBuoyancySPGSMStabilization
+      ( const std::string& physics_name,
+        const GetPot& input );
 
     ~BoussinesqBuoyancySPGSMStabilization();
 

--- a/src/physics/include/grins/heat_conduction.h
+++ b/src/physics/include/grins/heat_conduction.h
@@ -61,6 +61,13 @@ namespace GRINS
 				AssemblyContext& context,
 				CachedValues& cache );
 
+    // Registers all parameters in this physics and in its property
+    // classes
+    virtual void register_parameter
+      ( const std::string & param_name,
+        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const;
+
   protected:
 
     unsigned int _dim;

--- a/src/physics/include/grins/heat_transfer_base.h
+++ b/src/physics/include/grins/heat_transfer_base.h
@@ -59,6 +59,13 @@ namespace GRINS
     // Context initialization
     virtual void init_context( AssemblyContext& context );
 
+    // Registers all parameters in this physics and in its property
+    // classes
+    virtual void register_parameter
+      ( const std::string & param_name,
+        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const;
+
   protected:
 
     //! Physical dimension of problem

--- a/src/physics/include/grins/heat_transfer_stab_helper.h
+++ b/src/physics/include/grins/heat_transfer_stab_helper.h
@@ -40,7 +40,8 @@ namespace GRINS
   {
   public:
 
-    HeatTransferStabilizationHelper( const GetPot& input );
+    HeatTransferStabilizationHelper( const std::string & helper_name,
+                                     const GetPot& input );
 
     ~HeatTransferStabilizationHelper();
 

--- a/src/physics/include/grins/inc_navier_stokes_base.h
+++ b/src/physics/include/grins/inc_navier_stokes_base.h
@@ -65,6 +65,13 @@ namespace GRINS
     // Context initialization
     virtual void init_context( AssemblyContext& context );    
 
+    // Registers all parameters in this physics and in its property
+    // classes
+    virtual void register_parameter
+      ( const std::string & param_name,
+        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const;
+
   protected:
 
     //! Physical dimension of problem

--- a/src/physics/include/grins/inc_navier_stokes_stab_helper.h
+++ b/src/physics/include/grins/inc_navier_stokes_stab_helper.h
@@ -39,7 +39,9 @@ namespace GRINS
   {
   public:
 
-    IncompressibleNavierStokesStabilizationHelper( const GetPot& input );
+    IncompressibleNavierStokesStabilizationHelper
+      ( const std::string & helper_name,
+        const GetPot& input );
 
     ~IncompressibleNavierStokesStabilizationHelper();
 

--- a/src/physics/include/grins/low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_base.h
@@ -77,6 +77,13 @@ namespace GRINS
 
     libMesh::Real get_p0_transient( AssemblyContext& c, unsigned int qp ) const;
 
+    // Registers all parameters in this physics and in its property
+    // classes
+    virtual void register_parameter
+      ( const std::string & param_name,
+        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const;
+
   protected:
 
     //! Thermodynamic pressure divided by gas constant

--- a/src/physics/include/grins/low_mach_navier_stokes_stab_helper.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_stab_helper.h
@@ -34,7 +34,9 @@ namespace GRINS
   {
   public:
 
-    LowMachNavierStokesStabilizationHelper( const GetPot& input );
+    LowMachNavierStokesStabilizationHelper
+      ( const std::string& helper_name,
+        const GetPot& input);
 
     ~LowMachNavierStokesStabilizationHelper();
 

--- a/src/physics/include/grins/stab_helper.h
+++ b/src/physics/include/grins/stab_helper.h
@@ -25,6 +25,9 @@
 #ifndef GRINS_STAB_HELPER_H
 #define GRINS_STAB_HELPER_H
 
+// GRINS
+#include "grins/parameter_user.h"
+
 // libMesh
 #include "libmesh/vector_value.h"
 #include "libmesh/tensor_value.h"
@@ -36,10 +39,10 @@ namespace GRINS
   // GRINS forward declarations
   class AssemblyContext;
 
-  class StabilizationHelper
+  class StabilizationHelper : public ParameterUser
   {
   public:
-    StabilizationHelper();
+    StabilizationHelper( const std::string & helper_name );
     ~StabilizationHelper();
 
     /*! \todo Should we inline this? */

--- a/src/physics/include/grins/velocity_penalty_adjoint_stab.h
+++ b/src/physics/include/grins/velocity_penalty_adjoint_stab.h
@@ -59,8 +59,6 @@ namespace GRINS
 
   protected:
 
-    libMesh::Number _rho;
-
     Viscosity _mu;
 
     IncompressibleNavierStokesStabilizationHelper _stab_helper;

--- a/src/physics/src/averaged_fan.C
+++ b/src/physics/src/averaged_fan.C
@@ -41,8 +41,6 @@ namespace GRINS
   AveragedFan<Mu>::AveragedFan( const std::string& physics_name, const GetPot& input )
     : AveragedFanBase<Mu>(physics_name, input)
   {
-    this->read_input_options(input);
-
     return;
   }
 

--- a/src/physics/src/averaged_fan_adjoint_stab.C
+++ b/src/physics/src/averaged_fan_adjoint_stab.C
@@ -42,7 +42,7 @@ namespace GRINS
     : AveragedFanBase<Mu>(physics_name, input),
       _rho(1.0),
       _mu( input ),
-      _stab_helper( input )
+      _stab_helper( physics_name+"StabHelper", input )
   {
     this->set_parameter
       (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);

--- a/src/physics/src/averaged_fan_adjoint_stab.C
+++ b/src/physics/src/averaged_fan_adjoint_stab.C
@@ -40,11 +40,12 @@ namespace GRINS
   template<class Mu>
   AveragedFanAdjointStabilization<Mu>::AveragedFanAdjointStabilization( const std::string& physics_name, const GetPot& input )
     : AveragedFanBase<Mu>(physics_name, input),
-      _rho( input("Physics/"+incompressible_navier_stokes+"/rho", 1.0) ),
+      _rho(1.0),
       _mu( input ),
       _stab_helper( input )
   {
-    return;
+    this->set_parameter
+      (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);
   }
 
   template<class Mu>

--- a/src/physics/src/averaged_turbine.C
+++ b/src/physics/src/averaged_turbine.C
@@ -41,8 +41,6 @@ namespace GRINS
   AveragedTurbine<Mu>::AveragedTurbine( const std::string& physics_name, const GetPot& input )
     : AveragedTurbineBase<Mu>(physics_name, input)
   {
-    this->read_input_options(input);
-
     this->_ic_handler = new GenericICHandler( physics_name, input );
 
     return;

--- a/src/physics/src/averaged_turbine_adjoint_stab.C
+++ b/src/physics/src/averaged_turbine_adjoint_stab.C
@@ -40,11 +40,12 @@ namespace GRINS
   template<class Mu>
   AveragedTurbineAdjointStabilization<Mu>::AveragedTurbineAdjointStabilization( const std::string& physics_name, const GetPot& input )
     : AveragedTurbineBase<Mu>(physics_name, input),
-      _rho( input("Physics/"+incompressible_navier_stokes+"/rho", 1.0) ),
+      _rho(1.0),
       _mu( input ),
       _stab_helper( input )
   {
-    return;
+    this->set_parameter
+      (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);
   }
 
   template<class Mu>

--- a/src/physics/src/averaged_turbine_adjoint_stab.C
+++ b/src/physics/src/averaged_turbine_adjoint_stab.C
@@ -42,7 +42,7 @@ namespace GRINS
     : AveragedTurbineBase<Mu>(physics_name, input),
       _rho(1.0),
       _mu( input ),
-      _stab_helper( input )
+      _stab_helper( physics_name+"StabHelper", input )
   {
     this->set_parameter
       (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);

--- a/src/physics/src/averaged_turbine_base.C
+++ b/src/physics/src/averaged_turbine_base.C
@@ -164,16 +164,20 @@ namespace GRINS
     this->torque_function.reset
       (new libMesh::ParsedFunction<libMesh::Number>(torque_function_string));
 
-    this->moment_of_inertia = input("Physics/"+averaged_turbine+"/moment_of_inertia",
-                                    libMesh::Number(0));
+    this->set_parameter
+      (this->moment_of_inertia, input,
+       "Physics/"+averaged_turbine+"/moment_of_inertia",
+       libMesh::Number(0));
 
     if (!moment_of_inertia)
       libmesh_error_msg(
         "Error! Zero AveragedTurbine moment of inertia specified!" <<
         std::endl);
 
-    this->initial_speed = input("Physics/"+averaged_turbine+"/initial_speed",
-                                libMesh::Number(0));
+    this->set_parameter
+      (this->initial_speed, input,
+       "Physics/"+averaged_turbine+"/initial_speed",
+       libMesh::Number(0));
 
     this->_fan_speed_var_name = input("Physics/VariableNames/fan_speed",
                                       fan_speed_var_name_default);

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -72,9 +72,15 @@ namespace GRINS
     this->_u_z_var_name = input("Physics/VariableNames/z_velocity", u_z_var_name_default );
     this->_T_var_name = input("Physics/VariableNames/Temperature", T_var_name_default );
 
-    _rho_ref = input("Physics/"+axisymmetric_boussinesq_buoyancy+"/rho_ref", 1.0);
-    _T_ref = input("Physics/"+axisymmetric_boussinesq_buoyancy+"/T_ref", 1.0);
-    _beta_T = input("Physics/"+axisymmetric_boussinesq_buoyancy+"/beta_T", 1.0);
+    this->set_parameter
+      (_rho_ref, input,
+       "Physics/"+axisymmetric_boussinesq_buoyancy+"/rho_ref", 1.0);
+
+    this->set_parameter
+      (_T_ref, input, "Physics/"+axisymmetric_boussinesq_buoyancy+"/T_ref", 1.0);
+
+    this->set_parameter
+      (_beta_T, input, "Physics/"+axisymmetric_boussinesq_buoyancy+"/beta_T", 1.0);
 
     _g(0) = input("Physics/"+axisymmetric_boussinesq_buoyancy+"/g", 0.0, 0 );
     _g(1) = input("Physics/"+axisymmetric_boussinesq_buoyancy+"/g", 0.0, 1 );

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -367,6 +367,17 @@ namespace GRINS
     return;
   }
 
+  template< class Conductivity>
+  void AxisymmetricHeatTransfer<Conductivity>::register_parameter
+    ( const std::string & param_name,
+      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const
+  {
+    ParameterUser::register_parameter(param_name, param_pointer);
+    _k.register_parameter(param_name, param_pointer);
+  }
+
+
 } // namespace GRINS
 
 // Instantiate

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -79,8 +79,14 @@ namespace GRINS
     this->_V_order =
       libMesh::Utility::string_to_enum<GRINSEnums::Order>( input("Physics/"+incompressible_navier_stokes+"/V_order", "SECOND") );
 
-    this->_rho = input("Physics/"+axisymmetric_heat_transfer+"/rho", 1.0); //TODO: same as Incompressible NS
-    this->_Cp  = input("Physics/"+axisymmetric_heat_transfer+"/Cp", 1.0);
+    //TODO: same as Incompressible NS
+    this->set_parameter
+      (this->_rho, input,
+       "Physics/"+axisymmetric_heat_transfer+"/rho", 1.0);
+
+    this->set_parameter
+      (this->_Cp, input,
+       "Physics/"+axisymmetric_heat_transfer+"/Cp", 1.0);
 
     this->_T_var_name = input("Physics/VariableNames/Temperature", T_var_name_default );
 

--- a/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
@@ -43,11 +43,12 @@ namespace GRINS
   BoussinesqBuoyancyAdjointStabilization<Mu>::BoussinesqBuoyancyAdjointStabilization( const std::string& physics_name, const GetPot& input )
     : BoussinesqBuoyancyBase(physics_name,input),
       /* \todo Do we want to have these come from a BoussinesqBuoyancyAdjointStabilization section instead? */
-      _rho( input("Physics/"+incompressible_navier_stokes+"/rho", 1.0) ),
+      _rho(1.0),
       _mu(input),
       _stab_helper( input )
   {
-    return;
+    this->set_parameter
+      (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);
   }
 
   template<class Mu>

--- a/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
@@ -383,6 +383,17 @@ namespace GRINS
     return;
   }
 
+  template<class Mu>
+  void BoussinesqBuoyancyAdjointStabilization<Mu>::register_parameter
+    ( const std::string & param_name,
+      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const
+  {
+    ParameterUser::register_parameter(param_name, param_pointer);
+    _mu.register_parameter(param_name, param_pointer);
+  }
+
+
 } // namespace GRINS
 
 // Instantiate

--- a/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
@@ -45,7 +45,7 @@ namespace GRINS
       /* \todo Do we want to have these come from a BoussinesqBuoyancyAdjointStabilization section instead? */
       _rho(1.0),
       _mu(input),
-      _stab_helper( input )
+      _stab_helper( physics_name+"StabHelper", input )
   {
     this->set_parameter
       (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);

--- a/src/physics/src/boussinesq_buoyancy_base.C
+++ b/src/physics/src/boussinesq_buoyancy_base.C
@@ -39,10 +39,22 @@ namespace GRINS
     : Physics(physics_name,input),
       _flow_vars(input,incompressible_navier_stokes),
       _temp_vars(input,heat_transfer),
-      _rho_ref( input("Physics/"+boussinesq_buoyancy+"/rho_ref", 1.0) ),
-      _T_ref( input("Physics/"+boussinesq_buoyancy+"/T_ref", 1.0) ),
-      _beta_T( input("Physics/"+boussinesq_buoyancy+"/beta_T", 1.0) )
+      _rho_ref(1.0),
+      _T_ref(1.0),
+      _beta_T(1.0)
   {
+    this->set_parameter
+      (_rho_ref, input,
+       "Physics/"+boussinesq_buoyancy+"/rho_ref", _rho_ref);
+
+    this->set_parameter
+      (_T_ref, input,
+       "Physics/"+boussinesq_buoyancy+"/T_ref", _T_ref);
+
+    this->set_parameter
+      (_beta_T, input,
+       "Physics/"+boussinesq_buoyancy+"/beta_T", _beta_T);
+
     unsigned int g_dim = input.vector_variable_size("Physics/"+boussinesq_buoyancy+"/g");
 
     _g(0) = input("Physics/"+boussinesq_buoyancy+"/g", 0.0, 0 );

--- a/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
@@ -42,12 +42,20 @@ namespace GRINS
     : BoussinesqBuoyancyBase(physics_name,input),
       _flow_stab_helper(input),
       _temp_stab_helper(input),
-      _rho( input("Physics/"+incompressible_navier_stokes+"/rho", 1.0) ),
-      _Cp( input("Physics/"+heat_transfer+"/Cp", 1.0) ),
-      _k( input("Physics/"+heat_transfer+"/k", 1.0) ),
+      _rho(1.0),
+      _Cp(1.0),
+      _k(1.0),
       _mu(input)
   {
-    return;
+    this->set_parameter
+      (_rho, input,
+       "Physics/"+incompressible_navier_stokes+"/rho", _rho);
+
+    this->set_parameter
+      (_Cp, input, "Physics/"+heat_transfer+"/Cp", _Cp);
+
+    this->set_parameter
+      (_k, input, "Physics/"+heat_transfer+"/k", _k);
   }
 
   template<class Mu>

--- a/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
@@ -40,8 +40,8 @@ namespace GRINS
   template<class Mu>
   BoussinesqBuoyancySPGSMStabilization<Mu>::BoussinesqBuoyancySPGSMStabilization( const std::string& physics_name, const GetPot& input )
     : BoussinesqBuoyancyBase(physics_name,input),
-      _flow_stab_helper(input),
-      _temp_stab_helper(input),
+      _flow_stab_helper(physics_name+"FlowStabHelper", input),
+      _temp_stab_helper(physics_name+"TempStabHelper", input),
       _rho(1.0),
       _Cp(1.0),
       _k(1.0),

--- a/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
@@ -323,6 +323,17 @@ namespace GRINS
     return;
   }
 
+  template<class Mu>
+  void BoussinesqBuoyancySPGSMStabilization<Mu>::register_parameter
+    ( const std::string & param_name,
+      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const
+  {
+    ParameterUser::register_parameter(param_name, param_pointer);
+    _mu.register_parameter(param_name, param_pointer);
+  }
+
+
 } // namespace GRINS
 
 // Instantiate

--- a/src/physics/src/constant_source_term.C
+++ b/src/physics/src/constant_source_term.C
@@ -37,7 +37,7 @@ namespace GRINS
 {
   ConstantSourceTerm::ConstantSourceTerm( const std::string& physics_name, const GetPot& input )
     : SourceTermBase(physics_name,input),
-      _value( input("Physics/"+physics_name+"/Function/value",0.0) )
+      _value(0.0)
   {
     if( !input.have_variable("Physics/"+physics_name+"/Function/value") )
       {
@@ -46,7 +46,9 @@ namespace GRINS
         libmesh_error();
       }
 
-    return;
+    this->set_parameter
+      (_value, input,
+       "Physics/"+physics_name+"/Function/value", _value);
   }
 
   ConstantSourceTerm::~ConstantSourceTerm()

--- a/src/physics/src/elastic_cable.C
+++ b/src/physics/src/elastic_cable.C
@@ -47,7 +47,7 @@ namespace GRINS
                                                bool is_compressible )
     : ElasticCableBase(physics_name,input),
       _stress_strain_law(input),
-      _A( input("Physics/"+physics_name+"/A", 1.0 ) ),
+      _A( 1.0 ),
       _is_compressible(is_compressible)
   {
     // Force the user to set A
@@ -57,6 +57,9 @@ namespace GRINS
                   << "       Input the option Physics/"+physics_name+"/A" << std::endl;
         libmesh_error();
       }
+
+    this->set_parameter
+      (_A, input, "Physics/"+physics_name+"/A", _A );
 
     this->_bc_handler = new SolidMechanicsBCHandling( physics_name, input );
 

--- a/src/physics/src/elastic_cable_constant_gravity.C
+++ b/src/physics/src/elastic_cable_constant_gravity.C
@@ -39,32 +39,39 @@ namespace GRINS
 {
   ElasticCableConstantGravity::ElasticCableConstantGravity( const GRINS::PhysicsName& physics_name, const GetPot& input )
     : ElasticCableBase(physics_name,input),
-      _A( input("Physics/"+physics_name+"/A", 1.0 ) ),
-      _rho( input("Physics/"+physics_name+"/rho", 1.0 ) )
+      _A(1.0),
+      _rho(1.0)
   {
-    if( !input.have_variable("Physics/ElasticCableConstantGravity/A") )
+    if( !input.have_variable("Physics/"+physics_name+"/A") )
       {
-        std::cerr << "Error: Must input area for ElasticCableConstantGravity." << std::endl
-                  << "       Please set Physics/ElasticCableConstantGravity/A." << std::endl;
-        libmesh_error();
-      }
-    if( !input.have_variable("Physics/ElasticCableConstantGravity/rho") )
-      {
-        std::cerr << "Error: Must input density for ElasticCableConstantGravity." << std::endl
-                  << "       Please set Physics/ElasticCableConstantGravity/rho." << std::endl;
+        std::cerr << "Error: Must input area for "+physics_name+"." << std::endl
+                  << "       Please set Physics/"+physics_name+"/A." << std::endl;
         libmesh_error();
       }
 
-    int num_gravity =  input.vector_variable_size("Physics/ElasticCableConstantGravity/gravity");
+    this->set_parameter
+      (_A, input, "Physics/"+physics_name+"/A", _A );
+
+    if( !input.have_variable("Physics/"+physics_name+"/rho") )
+      {
+        std::cerr << "Error: Must input density for "+physics_name+"." << std::endl
+                  << "       Please set Physics/"+physics_name+"/rho." << std::endl;
+        libmesh_error();
+      }
+
+    this->set_parameter
+      (_rho, input, "Physics/"+physics_name+"/rho", _rho );
+
+    int num_gravity =  input.vector_variable_size("Physics/"+physics_name+"/gravity");
     if (num_gravity != 3)
       {
-        std::cerr << "Error: Must input three values for ElasticCableConstantGravity gravity." << std::endl
-                  << "       Please set Physics/ElasticCableConstantGravity/gravity." << std::endl;
+        std::cerr << "Error: Must input three values for "+physics_name+" gravity." << std::endl
+                  << "       Please set Physics/"+physics_name+"/gravity." << std::endl;
         libmesh_error();
       }
     for( int i = 0; i < num_gravity; i++ )
       {
-        _gravity(i)=( input("Physics/ElasticCableConstantGravity/gravity", 0.0 , i ) );
+        _gravity(i)=( input("Physics/"+physics_name+"/gravity", 0.0 , i ) );
       }
 
     return;

--- a/src/physics/src/elastic_membrane.C
+++ b/src/physics/src/elastic_membrane.C
@@ -48,7 +48,7 @@ namespace GRINS
                                                      bool is_compressible )
     : ElasticMembraneBase(physics_name,input),
       _stress_strain_law(input),
-      _h0( input("Physics/"+physics_name+"/h0", 1.0 ) ),
+      _h0(1.0),
       _is_compressible(is_compressible)
   {
     // Force the user to set h0
@@ -58,6 +58,9 @@ namespace GRINS
                   << "       Input the option Physics/"+physics_name+"/h0" << std::endl;
         libmesh_error();
       }
+
+    this->set_parameter
+      (_h0, input, "Physics/"+physics_name+"/h0", _h0 );
 
     this->_bc_handler = new SolidMechanicsBCHandling( physics_name, input );
 

--- a/src/physics/src/elastic_membrane_constant_pressure.C
+++ b/src/physics/src/elastic_membrane_constant_pressure.C
@@ -39,16 +39,17 @@ namespace GRINS
 {
   ElasticMembraneConstantPressure::ElasticMembraneConstantPressure( const GRINS::PhysicsName& physics_name, const GetPot& input )
     : ElasticMembraneBase(physics_name,input),
-      _pressure( input("Physics/ElasticMembraneConstantPressure/pressure", 0.0) )
+      _pressure(0.0)
   {
-    if( !input.have_variable("Physics/ElasticMembraneConstantPressure/pressure") )
+    if( !input.have_variable("Physics/"+physics_name+"/pressure") )
       {
-        std::cerr << "Error: Must input pressure for ElasticMembraneConstantPressure." << std::endl
-                  << "       Please set Physics/ElasticMembraneConstantPressure/pressure." << std::endl;
+        std::cerr << "Error: Must input pressure for "+physics_name+"." << std::endl
+                  << "       Please set Physics/"+physics_name+"/pressure." << std::endl;
         libmesh_error();
       }
 
-    return;
+    this->set_parameter
+      (_pressure, input, "Physics/"+physics_name+"/pressure", _pressure );
   }
 
   ElasticMembraneConstantPressure::~ElasticMembraneConstantPressure()

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -241,6 +241,17 @@ namespace GRINS
     return;
   }
 
+  template<class K>
+  void HeatConduction<K>::register_parameter
+    ( const std::string & param_name,
+      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const
+  {
+    ParameterUser::register_parameter(param_name, param_pointer);
+    _k.register_parameter(param_name, param_pointer);
+  }
+
+
 } // namespace GRINS
 
 // Instantiate

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -44,10 +44,17 @@ namespace GRINS
   HeatConduction<K>::HeatConduction( const GRINS::PhysicsName& physics_name, const GetPot& input )
     : Physics(physics_name,input),
       _temp_vars(input,heat_conduction),
-      _rho(  input("Physics/"+heat_conduction+"/rho", 1.0) ), /*! \todo same as Incompressible NS */
-      _Cp( input("Physics/"+heat_conduction+"/Cp", 1.0) ),
+      _rho(1.0),
+      _Cp(1.0),
       _k(input)
   {
+    // \todo same as Incompressible NS
+    this->set_parameter
+      (_rho, input, "Physics/"+heat_conduction+"/rho", _rho );
+
+    this->set_parameter
+      (_Cp, input, "Physics/"+heat_conduction+"/Cp", _Cp );
+
     // This is deleted in the base class
     this->_bc_handler = new HeatTransferBCHandling( physics_name, input );
     this->_ic_handler = new GenericICHandler( physics_name, input );

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -44,10 +44,18 @@ namespace GRINS
     : Physics(physics_name, input),
       _flow_vars(input,incompressible_navier_stokes),
       _temp_vars(input,heat_transfer),
-      _rho( input("Physics/"+heat_transfer+"/rho", 1.0) ),
-      _Cp( input("Physics/"+heat_transfer+"/Cp", 1.0) ),
+      _rho(1.0),
+      _Cp(1.0),
       _k(input)
   {
+    this->set_parameter
+      (this->_rho, input,
+       "Physics/"+heat_transfer+"/rho", _rho);
+
+    this->set_parameter
+      (this->_Cp, input,
+       "Physics/"+heat_transfer+"/Cp", _Cp);
+
     this->read_input_options(input);
 
     return;

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -107,6 +107,17 @@ namespace GRINS
     return;
   }
 
+  template<class K>
+  void HeatTransferBase<K>::register_parameter
+    ( const std::string & param_name,
+      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const
+  {
+    ParameterUser::register_parameter(param_name, param_pointer);
+    _k.register_parameter(param_name, param_pointer);
+  }
+
+
 } // namespace GRINS
 
 // Instantiate

--- a/src/physics/src/heat_transfer_stab_base.C
+++ b/src/physics/src/heat_transfer_stab_base.C
@@ -38,7 +38,7 @@ namespace GRINS
   HeatTransferStabilizationBase<K>::HeatTransferStabilizationBase( const std::string& physics_name, 
                                                                 const GetPot& input )
     : HeatTransferBase<K>(physics_name,input),
-      _stab_helper(input),
+      _stab_helper(physics_name+"StabHelper", input),
       _k(input)
   {
     this->read_input_options(input);

--- a/src/physics/src/heat_transfer_stab_helper.C
+++ b/src/physics/src/heat_transfer_stab_helper.C
@@ -34,8 +34,10 @@
 namespace GRINS
 {
 
-  HeatTransferStabilizationHelper::HeatTransferStabilizationHelper(const GetPot& input)
-    : StabilizationHelper(),
+  HeatTransferStabilizationHelper::HeatTransferStabilizationHelper
+    (const std::string & helper_name,
+     const GetPot& input)
+    : StabilizationHelper(helper_name),
       _C(1),
       _tau_factor(0.5),
       _temp_vars(input),

--- a/src/physics/src/heat_transfer_stab_helper.C
+++ b/src/physics/src/heat_transfer_stab_helper.C
@@ -36,12 +36,24 @@ namespace GRINS
 
   HeatTransferStabilizationHelper::HeatTransferStabilizationHelper(const GetPot& input)
     : StabilizationHelper(),
-      _C( input("Stabilization/tau_constant_T", input("Stabilization/tau_constant", 1 ) ) ),
-      _tau_factor( input("Stabilization/tau_factor_T", input("Stabilization/tau_factor", 0.5 ) ) ),
+      _C(1),
+      _tau_factor(0.5),
       _temp_vars(input),
       _flow_vars(input)
   {
-    return;
+    if (input.have_variable("Stabilization/tau_constant_T"))
+      this->set_parameter
+        (_C, input, "Stabilization/tau_constant_T", _C );
+    else
+      this->set_parameter
+        (_C, input, "Stabilization/tau_constant", _C );
+
+    if (input.have_variable("Stabilization/tau_factor_T"))
+      this->set_parameter
+        (_tau_factor, input, "Stabilization/tau_factor_T", _tau_factor );
+    else
+      this->set_parameter
+        (_tau_factor, input, "Stabilization/tau_factor", _tau_factor );
   }
 
   HeatTransferStabilizationHelper::~HeatTransferStabilizationHelper()

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -107,6 +107,17 @@ namespace GRINS
     return;
   }
 
+  template<class Mu>
+  void IncompressibleNavierStokesBase<Mu>::register_parameter
+    ( const std::string & param_name,
+      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const
+  {
+    ParameterUser::register_parameter(param_name, param_pointer);
+    _mu.register_parameter(param_name, param_pointer);
+  }
+
+
 } // namespace GRINS
 
 // Instantiate

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -45,10 +45,12 @@ namespace GRINS
                                                                      const GetPot& input )
     : Physics(my_physics_name, input),
       _flow_vars(input, core_physics_name),
-      _rho(input("Physics/"+core_physics_name+"/rho", 1.0)),
+      _rho(1.0),
       _mu(input)
   {
-    return;
+    this->set_parameter
+      (this->_rho, input,
+       "Physics/"+core_physics_name+"/rho", this->_rho);
   }
 
   template<class Mu>

--- a/src/physics/src/inc_navier_stokes_stab_base.C
+++ b/src/physics/src/inc_navier_stokes_stab_base.C
@@ -39,7 +39,7 @@ namespace GRINS
     : IncompressibleNavierStokesBase<Mu>(physics_name,
                                          incompressible_navier_stokes, /* "core" Physics name */
                                          input),
-      _stab_helper( input )
+      _stab_helper( physics_name+"StabHelper", input )
   {
     return;
   }

--- a/src/physics/src/inc_navier_stokes_stab_helper.C
+++ b/src/physics/src/inc_navier_stokes_stab_helper.C
@@ -36,10 +36,24 @@ namespace GRINS
 
   IncompressibleNavierStokesStabilizationHelper::IncompressibleNavierStokesStabilizationHelper(const GetPot& input)
     : StabilizationHelper(),
-      _C( input("Stabilization/tau_constant_vel", input("Stabilization/tau_constant", 1 ) ) ),
-      _tau_factor( input("Stabilization/tau_factor_vel", input("Stabilization/tau_factor", 0.5 ) ) ),
+      _C(1),
+      _tau_factor(0.5),
       _flow_vars(input)
   {
+    if (input.have_variable("Stabilization/tau_constant_vel"))
+      this->set_parameter
+        (_C, input, "Stabilization/tau_constant_vel", _C );
+    else
+      this->set_parameter
+        (_C, input, "Stabilization/tau_constant", _C );
+
+    if (input.have_variable("Stabilization/tau_factor_vel"))
+      this->set_parameter
+        (_tau_factor, input, "Stabilization/tau_factor_vel", _tau_factor );
+    else
+      this->set_parameter
+        (_tau_factor, input, "Stabilization/tau_factor", _tau_factor );
+
     return;
   }
 

--- a/src/physics/src/inc_navier_stokes_stab_helper.C
+++ b/src/physics/src/inc_navier_stokes_stab_helper.C
@@ -34,8 +34,10 @@
 namespace GRINS
 {
 
-  IncompressibleNavierStokesStabilizationHelper::IncompressibleNavierStokesStabilizationHelper(const GetPot& input)
-    : StabilizationHelper(),
+  IncompressibleNavierStokesStabilizationHelper::IncompressibleNavierStokesStabilizationHelper
+    (const std::string & helper_name,
+     const GetPot& input)
+    : StabilizationHelper(helper_name),
       _C(1),
       _tau_factor(0.5),
       _flow_vars(input)

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -89,9 +89,12 @@ namespace GRINS
     this->_T_var_name = input("Physics/VariableNames/temperature", T_var_name_default );
 
     // Read thermodynamic state info
-    _p0 = input("Physics/"+low_mach_navier_stokes+"/p0", 0.0 ); /* thermodynamic pressure */
-    _T0 = input("Physics/"+low_mach_navier_stokes+"/T0", 0.0 ); /* Reference temperature */
-    _R  = input("Physics/"+low_mach_navier_stokes+"/R", 0.0 ); /* gas constant */
+    this->set_parameter
+      (_p0, input, "Physics/"+low_mach_navier_stokes+"/p0", 0.0 ); /* thermodynamic pressure */
+    this->set_parameter
+      (_T0, input, "Physics/"+low_mach_navier_stokes+"/T0", 0.0 ); /* Reference temperature */
+    this->set_parameter
+      (_R, input, "Physics/"+low_mach_navier_stokes+"/R", 0.0 ); /* gas constant */
 
     if( _R <= 0.0 )
       {

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -193,6 +193,18 @@ namespace GRINS
     return;
   }
 
+  template<class Mu, class SH, class TC>
+  void LowMachNavierStokesBase<Mu,SH,TC>::register_parameter
+    ( const std::string & param_name,
+      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+    const
+  {
+    ParameterUser::register_parameter(param_name, param_pointer);
+    _mu.register_parameter(param_name, param_pointer);
+    _cp.register_parameter(param_name, param_pointer);
+    _k.register_parameter(param_name, param_pointer);
+  }
+
 } // namespace GRINS
 
 // Instantiate

--- a/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
@@ -42,9 +42,6 @@ namespace GRINS
 											  const GetPot& input )
     : LowMachNavierStokesStabilizationBase<Mu,SH,TC>(physics_name,input)
   {
-    this->read_input_options(input);
-
-    return;
   }
 
   template<class Mu, class SH, class TC>

--- a/src/physics/src/low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/low_mach_navier_stokes_stab_base.C
@@ -39,7 +39,7 @@ namespace GRINS
   LowMachNavierStokesStabilizationBase<Mu,SH,TC>::LowMachNavierStokesStabilizationBase( const std::string& physics_name, 
 											const GetPot& input )
     : LowMachNavierStokesBase<Mu,SH,TC>(physics_name,input),
-      _stab_helper( input )
+      _stab_helper( physics_name+"StabHelper", input )
   {
     return;
   }

--- a/src/physics/src/low_mach_navier_stokes_stab_helper.C
+++ b/src/physics/src/low_mach_navier_stokes_stab_helper.C
@@ -29,8 +29,10 @@
 namespace GRINS
 {
 
-  LowMachNavierStokesStabilizationHelper::LowMachNavierStokesStabilizationHelper(const GetPot& input)
-    : IncompressibleNavierStokesStabilizationHelper(input)
+  LowMachNavierStokesStabilizationHelper::LowMachNavierStokesStabilizationHelper
+    (const std::string & helper_name,
+     const GetPot& input)
+    : IncompressibleNavierStokesStabilizationHelper(helper_name, input)
   {
     return;
   }

--- a/src/physics/src/reacting_low_mach_navier_stokes_base.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_base.C
@@ -48,8 +48,12 @@ namespace GRINS
     : Physics(physics_name, input),
       _gas_mixture(input),
       _fixed_density( input("Physics/"+reacting_low_mach_navier_stokes+"/fixed_density", false ) ),
-      _fixed_rho_value( input("Physics/"+reacting_low_mach_navier_stokes+"/fixed_rho_value", 0.0 ) )
+      _fixed_rho_value(0.0)
   {
+    this->set_parameter
+      (_fixed_rho_value, input,
+       "Physics/"+reacting_low_mach_navier_stokes+"/fixed_rho_value", 0.0 );
+
     this->read_input_options(input);
     
     return;
@@ -100,7 +104,8 @@ namespace GRINS
     this->_T_var_name = input("Physics/VariableNames/temperature", GRINS::T_var_name_default );
 
     // Read thermodynamic state info
-    _p0 = input("Physics/"+reacting_low_mach_navier_stokes+"/p0", 0.0 ); /* thermodynamic pressure */
+    this->set_parameter
+      (_p0, input, "Physics/"+reacting_low_mach_navier_stokes+"/p0", 0.0 ); /* thermodynamic pressure */
 
     _enable_thermo_press_calc = input("Physics/"+reacting_low_mach_navier_stokes+"/enable_thermo_press_calc", false );
 

--- a/src/physics/src/stab_helper.C
+++ b/src/physics/src/stab_helper.C
@@ -32,7 +32,9 @@
 namespace GRINS
 {
 
-  StabilizationHelper::StabilizationHelper()
+  StabilizationHelper::StabilizationHelper
+    ( const std::string & helper_name ) :
+    ParameterUser(helper_name)
   {
     return;
   }

--- a/src/physics/src/velocity_drag_adjoint_stab.C
+++ b/src/physics/src/velocity_drag_adjoint_stab.C
@@ -40,11 +40,12 @@ namespace GRINS
   template<class Mu>
   VelocityDragAdjointStabilization<Mu>::VelocityDragAdjointStabilization( const std::string& physics_name, const GetPot& input )
     : VelocityDragBase<Mu>(physics_name, input),
-      _rho( input("Physics/"+incompressible_navier_stokes+"/rho", 1.0) ),
+      _rho( 1.0 ),
       _mu( input ),
       _stab_helper( input )
   {
-    return;
+    this->set_parameter
+      (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);
   }
 
   template<class Mu>

--- a/src/physics/src/velocity_drag_adjoint_stab.C
+++ b/src/physics/src/velocity_drag_adjoint_stab.C
@@ -42,7 +42,7 @@ namespace GRINS
     : VelocityDragBase<Mu>(physics_name, input),
       _rho( 1.0 ),
       _mu( input ),
-      _stab_helper( input )
+      _stab_helper( physics_name+"StabHelper", input )
   {
     this->set_parameter
       (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);

--- a/src/physics/src/velocity_drag_base.C
+++ b/src/physics/src/velocity_drag_base.C
@@ -55,7 +55,8 @@ namespace GRINS
   template<class Mu>
   void VelocityDragBase<Mu>::read_input_options( const GetPot& input )
   {
-    _exponent = input("Physics/"+velocity_drag+"/exponent", libMesh::Real(2));
+    this->set_parameter
+      (_exponent, input, "Physics/"+velocity_drag+"/exponent", 2);
 
     std::string coefficient_function =
       input("Physics/"+velocity_drag+"/coefficient",

--- a/src/physics/src/velocity_penalty_adjoint_stab.C
+++ b/src/physics/src/velocity_penalty_adjoint_stab.C
@@ -41,12 +41,9 @@ namespace GRINS
   template<class Mu>
   VelocityPenaltyAdjointStabilization<Mu>::VelocityPenaltyAdjointStabilization( const std::string& physics_name, const GetPot& input )
     : VelocityPenaltyBase<Mu>(physics_name,input),
-      _rho(1.0),
       _mu( input ),
       _stab_helper( physics_name+"StabHelper", input )
   {
-    this->set_parameter
-      (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);
   }
 
   template<class Mu>

--- a/src/physics/src/velocity_penalty_adjoint_stab.C
+++ b/src/physics/src/velocity_penalty_adjoint_stab.C
@@ -41,11 +41,12 @@ namespace GRINS
   template<class Mu>
   VelocityPenaltyAdjointStabilization<Mu>::VelocityPenaltyAdjointStabilization( const std::string& physics_name, const GetPot& input )
     : VelocityPenaltyBase<Mu>(physics_name,input),
-      _rho( input("Physics/"+incompressible_navier_stokes+"/rho", 1.0) ),
+      _rho(1.0),
       _mu( input ),
       _stab_helper( input )
   {
-    return;
+    this->set_parameter
+      (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);
   }
 
   template<class Mu>

--- a/src/physics/src/velocity_penalty_adjoint_stab.C
+++ b/src/physics/src/velocity_penalty_adjoint_stab.C
@@ -43,7 +43,7 @@ namespace GRINS
     : VelocityPenaltyBase<Mu>(physics_name,input),
       _rho(1.0),
       _mu( input ),
-      _stab_helper( input )
+      _stab_helper( physics_name+"StabHelper", input )
   {
     this->set_parameter
       (_rho, input, "Physics/"+incompressible_navier_stokes+"/rho", _rho);

--- a/src/properties/include/grins/constant_conductivity.h
+++ b/src/properties/include/grins/constant_conductivity.h
@@ -28,6 +28,7 @@
 
 //GRINS
 #include "grins/assembly_context.h"
+#include "grins/parameter_user.h"
 
 // libMesh
 #include "libmesh/libmesh_common.h"
@@ -36,7 +37,7 @@ class GetPot;
 
 namespace GRINS
 {
-  class ConstantConductivity
+  class ConstantConductivity : public ParameterUser
   {
   public:
 

--- a/src/properties/include/grins/constant_prandtl_conductivity.h
+++ b/src/properties/include/grins/constant_prandtl_conductivity.h
@@ -26,6 +26,9 @@
 #ifndef GRINS_CONSTANT_PRANDTL_CONDUCTIVITY_H
 #define GRINS_CONSTANT_PRANDTL_CONDUCTIVITY_H
 
+// GRINS
+#include "grins/parameter_user.h"
+
 // libMesh
 #include "libmesh/libmesh_common.h"
 
@@ -33,7 +36,7 @@ class GetPot;
 
 namespace GRINS
 {
-  class ConstantPrandtlConductivity
+  class ConstantPrandtlConductivity : public ParameterUser
   {
   public:
 
@@ -44,7 +47,7 @@ namespace GRINS
 
   private:
 
-    const libMesh::Real _Pr;
+    libMesh::Real _Pr;
 
   };
   

--- a/src/properties/include/grins/constant_source_func.h
+++ b/src/properties/include/grins/constant_source_func.h
@@ -26,6 +26,9 @@
 #ifndef CONSTANT_SOURCE_FUNC_H
 #define CONSTANT_SOURCE_FUNC_H
 
+// GRINS
+#include "grins/parameter_user.h"
+
 // libMesh
 #include "libmesh/getpot.h"
 #include "libmesh/point.h"
@@ -33,7 +36,7 @@
 
 namespace GRINS
 {
-  class ConstantSourceFunction
+  class ConstantSourceFunction : public ParameterUser
   {
   public:
 

--- a/src/properties/include/grins/constant_specific_heat.h
+++ b/src/properties/include/grins/constant_specific_heat.h
@@ -26,6 +26,9 @@
 #ifndef GRINS_CONSTANT_SPECIFIC_HEAT_H
 #define GRINS_CONSTANT_SPECIFIC_HEAT_H
 
+// GRINS
+#include "grins/parameter_user.h"
+
 // libMesh
 #include "libmesh/libmesh_common.h"
 
@@ -33,7 +36,7 @@ class GetPot;
 
 namespace GRINS
 {
-  class ConstantSpecificHeat
+  class ConstantSpecificHeat : public ParameterUser
   {
   public:
 

--- a/src/properties/include/grins/constant_viscosity.h
+++ b/src/properties/include/grins/constant_viscosity.h
@@ -28,6 +28,7 @@
 
 //GRINS
 #include "grins/assembly_context.h"
+#include "grins/parameter_user.h"
 
 // libMesh
 #include "libmesh/libmesh_common.h"
@@ -36,7 +37,7 @@ class GetPot;
 
 namespace GRINS
 {
-  class ConstantViscosity
+  class ConstantViscosity : public ParameterUser
   {
   public:
 

--- a/src/properties/include/grins/hookes_law.h
+++ b/src/properties/include/grins/hookes_law.h
@@ -26,8 +26,9 @@
 #define GRINS_HOOKES_LAW_H
 
 // GRINS
-#include "grins/stress_strain_law.h"
 #include "grins/elasticity_tensor.h"
+#include "grins/parameter_user.h"
+#include "grins/stress_strain_law.h"
 
 // Forward declarations
 class GetPot;
@@ -42,7 +43,8 @@ namespace GRINS
    * working with curvilinear coordinate systems, the user should call the
    * set_deformation method before calling operator().
    */
-  class HookesLaw : public StressStrainLaw<HookesLaw>
+  class HookesLaw : public StressStrainLaw<HookesLaw>,
+                    public ParameterUser
   {
   public:
 

--- a/src/properties/include/grins/hookes_law_1d.h
+++ b/src/properties/include/grins/hookes_law_1d.h
@@ -26,6 +26,7 @@
 #define GRINS_HOOKES_LAW_1D_H
 
 // GRINS
+#include "grins/parameter_user.h"
 #include "grins/stress_strain_law.h"
 
 // Forward declarations
@@ -39,7 +40,8 @@ namespace GRINS
    * General form is not conducive to one-dimensional problems
    * so this should be used in those cases.
    */
-  class HookesLaw1D : public StressStrainLaw<HookesLaw1D>
+  class HookesLaw1D : public StressStrainLaw<HookesLaw1D>,
+                      public ParameterUser
   {
   public:
 

--- a/src/properties/include/grins/mooney_rivlin.h
+++ b/src/properties/include/grins/mooney_rivlin.h
@@ -27,13 +27,15 @@
 
 // GRINS
 #include "grins/hyperelastic_strain_energy.h"
+#include "grins/parameter_user.h"
 
 // Forward declarations
 class GetPot;
 
 namespace GRINS
 {
-  class MooneyRivlin : public HyperelasticStrainEnergy<MooneyRivlin>
+  class MooneyRivlin : public HyperelasticStrainEnergy<MooneyRivlin>,
+                       public ParameterUser
   {
   public:
     MooneyRivlin( const GetPot& input );

--- a/src/properties/include/grins/parsed_conductivity.h
+++ b/src/properties/include/grins/parsed_conductivity.h
@@ -28,6 +28,7 @@
 
 //GRINS
 #include "grins/assembly_context.h"
+#include "grins/parameter_user.h"
 
 // libMesh
 #include "libmesh/libmesh_common.h"
@@ -40,7 +41,7 @@ class GetPot;
 
 namespace GRINS
 {
-  class ParsedConductivity
+  class ParsedConductivity : public ParameterUser
   {
   public:
 

--- a/src/properties/include/grins/parsed_viscosity.h
+++ b/src/properties/include/grins/parsed_viscosity.h
@@ -28,6 +28,7 @@
 
 //GRINS
 #include "grins/assembly_context.h"
+#include "grins/parameter_user.h"
 
 // libMesh
 #include "libmesh/libmesh_common.h"
@@ -40,7 +41,7 @@ class GetPot;
 
 namespace GRINS
 {
-  class ParsedViscosity
+  class ParsedViscosity : public ParameterUser
   {
   public:
 

--- a/src/properties/src/constant_conductivity.C
+++ b/src/properties/src/constant_conductivity.C
@@ -36,15 +36,20 @@ namespace GRINS
 {
 
   ConstantConductivity::ConstantConductivity( const GetPot& input )
-    : _k( input("Materials/Conductivity/k", 0.0) )
+    : ParameterUser("ConstantConductivity"),
+      _k(0.0)
   {
     if( !input.have_variable("Materials/Conductivity/k") )
       {
         libmesh_warning("No Materials/Conductivity/k specified!\n");
 
 	// Try and get the conductivity from other specifications
-	_k = input("Physics/"+incompressible_navier_stokes+"/k", 1.0);
+        this->set_parameter
+	  (_k, input, "Physics/"+incompressible_navier_stokes+"/k", _k);
       }
+    else
+      this->set_parameter
+        (_k, input, "Materials/Conductivity/k", _k);
     return;
   }
 

--- a/src/properties/src/constant_prandtl_conductivity.C
+++ b/src/properties/src/constant_prandtl_conductivity.C
@@ -33,14 +33,17 @@ namespace GRINS
 {
 
   ConstantPrandtlConductivity::ConstantPrandtlConductivity( const GetPot& input )
-    : _Pr( input("Materials/Conductivity/Pr", 0.0) )
+    : ParameterUser("ConstantPrandtlConductivity"),
+      _Pr(0.0)
   {
     if( !input.have_variable("Materials/Conductivity/Pr") )
       {
         std::cerr << "Error: Must specify Prandtl number for constant_prandtl conductivity model!" << std::endl;
         libmesh_error();
       }
-    return;
+
+    this->set_parameter
+      (_Pr, input, "Materials/Conductivity/Pr", _Pr);
   }
 
   ConstantPrandtlConductivity::~ConstantPrandtlConductivity()

--- a/src/properties/src/constant_source_func.C
+++ b/src/properties/src/constant_source_func.C
@@ -29,9 +29,11 @@ namespace GRINS
 {
 
   ConstantSourceFunction::ConstantSourceFunction( const GetPot& input )
-    : _value( input("Physics/SourceFunction/value", 0.0) )
+    : ParameterUser("ConstantSourceFunction"),
+      _value(0.0)
   {
-    return;
+    this->set_parameter
+      (_value, input, "Physics/SourceFunction/value", _value);
   }
 
   ConstantSourceFunction::~ConstantSourceFunction()

--- a/src/properties/src/constant_specific_heat.C
+++ b/src/properties/src/constant_specific_heat.C
@@ -33,7 +33,8 @@ namespace GRINS
 {
 
   ConstantSpecificHeat::ConstantSpecificHeat( const GetPot& input )
-    : _cp( input( "Materials/SpecificHeat/cp", 0.0 ) )
+    : ParameterUser("ConstantSpecificHeat"),
+      _cp(0.0)
   {
     if( !input.have_variable("Materials/SpecificHeat/cp") )
       {
@@ -41,7 +42,8 @@ namespace GRINS
         libmesh_error();
       }
 
-    return;
+    this->set_parameter
+      (_cp, input, "Materials/SpecificHeat/cp", _cp);
   }
 
   ConstantSpecificHeat::~ConstantSpecificHeat()

--- a/src/properties/src/constant_viscosity.C
+++ b/src/properties/src/constant_viscosity.C
@@ -36,18 +36,22 @@ namespace GRINS
 {
 
   ConstantViscosity::ConstantViscosity( const GetPot& input )
-    : _mu( input( "Materials/Viscosity/mu", 1.0 ) )
+    : ParameterUser("ConstantViscosity"),
+      _mu(1.0)
   {
     if( !input.have_variable("Materials/Viscosity/mu") )
       {
         libmesh_warning("No Materials/Viscosity/mu specified!\n");
 
 	// Try and get the viscosity from other specifications
-	_mu = input("Physics/"+incompressible_navier_stokes+"/mu", 1.0);
+        this->set_parameter
+	  (_mu, input,
+           "Physics/"+incompressible_navier_stokes+"/mu", _mu);
 	
       }
-
-    return;
+    else
+      this->set_parameter
+        (_mu, input, "Materials/Viscosity/mu", _mu);
   }
 
   ConstantViscosity::~ConstantViscosity()

--- a/src/properties/src/hookes_law.C
+++ b/src/properties/src/hookes_law.C
@@ -33,6 +33,7 @@ namespace GRINS
 {
   HookesLaw::HookesLaw(const GetPot& input)
     : StressStrainLaw<HookesLaw>(),
+      ParameterUser("HookesLaw"),
       _C(),
       _lambda(0.0),
       _mu(0.0)
@@ -61,14 +62,18 @@ namespace GRINS
       }
 
     if( input.have_variable("Physics/HookesLaw/lambda") )
-      _lambda = input("Physics/HookesLaw/lambda", 0.0 );
+      this->set_parameter
+        (_lambda, input, "Physics/HookesLaw/lambda", 0.0);
     
     if( input.have_variable("Physics/HookesLaw/mu") )
-      _mu = input("Physics/HookesLaw/mu", 0.0 );
+      this->set_parameter
+        (_mu, input, "Physics/HookesLaw/mu", 0.0);
         
     if( input.have_variable("Physics/HookesLaw/E") && 
         input.have_variable("Physics/HookesLaw/nu") )
       {
+        // FIXME - we'll need a special accessor to give parameter
+        // access to these
         libMesh::Real E  = input("Physics/HookesLaw/E", 0.0);
         libMesh::Real nu = input("Physics/HookesLaw/nu", 0.0);
         _lambda = nu*E/( (1+nu)*(1-2*nu) );

--- a/src/properties/src/hookes_law_1d.C
+++ b/src/properties/src/hookes_law_1d.C
@@ -36,6 +36,7 @@ namespace GRINS
 {
   HookesLaw1D::HookesLaw1D(const GetPot& input)
     : StressStrainLaw<HookesLaw1D>(),
+    ParameterUser("HookesLaw1D"),
     _E(0.0),
     _nu(0.0)
   {
@@ -62,22 +63,26 @@ namespace GRINS
         libmesh_error();
       }
 
-    if( input.have_variable("Physics/HookesLaw/E") )
-      _E = input("Physics/HookesLaw/E", 0.0 );
-
-    if( input.have_variable("Physics/HookesLaw/nu") )
-      _nu = input("Physics/HookesLaw/nu", 0.0 );
-
     if( input.have_variable("Physics/HookesLaw/lambda") &&
         input.have_variable("Physics/HookesLaw/mu") )
       {
+        // FIXME - we'll need a special accessor to give parameter
+        // access to these
         libMesh::Real lambda  = input("Physics/HookesLaw/lambda", 0.0);
         libMesh::Real mu = input("Physics/HookesLaw/mu", 0.0);
         _E  = mu*(3*lambda + 2*mu)/(lambda+mu);
         _nu = lambda/(2*(lambda+mu));
       }
+    else
+      {
+        if( input.have_variable("Physics/HookesLaw/E") )
+          this->set_parameter
+            (_E, input, "Physics/HookesLaw/E", 0.0);
 
-    return;
+        if( input.have_variable("Physics/HookesLaw/nu") )
+          this->set_parameter
+            (_nu, input, "Physics/HookesLaw/nu", 0.0);
+      }
   }
 
   void HookesLaw1D::compute_stress_imp( unsigned int /*dim*/,

--- a/src/properties/src/mooney_rivlin.C
+++ b/src/properties/src/mooney_rivlin.C
@@ -32,8 +32,9 @@ namespace GRINS
 {
   MooneyRivlin::MooneyRivlin( const GetPot& input )
     : HyperelasticStrainEnergy<MooneyRivlin>(),
-      _C1( input("Physics/MooneyRivlin/C1", -1.0) ),
-      _C2( input("Physics/MooneyRivlin/C2", -1.0) )
+      ParameterUser("MooneyRivlin"),
+      _C1(-1),
+      _C2(-1)
   {
     //Force the user to specify C1 and C2
     if( !input.have_variable("Physics/MooneyRivlin/C1") ||
@@ -44,6 +45,11 @@ namespace GRINS
         libmesh_error();
       }
 
+    this->set_parameter
+      (_C1, input, "Physics/MooneyRivlin/C1", _C1);
+
+    this->set_parameter
+      (_C2, input, "Physics/MooneyRivlin/C2", _C2);
     return;
   }
    

--- a/src/properties/src/parsed_conductivity.C
+++ b/src/properties/src/parsed_conductivity.C
@@ -26,7 +26,8 @@
 namespace GRINS
 {
 
-   ParsedConductivity::ParsedConductivity( const GetPot& input )    
+   ParsedConductivity::ParsedConductivity( const GetPot& input ) :
+     ParameterUser("ParsedConductivity")
     {
       if( !input.have_variable("Materials/Conductivity/k") )
        {

--- a/src/properties/src/parsed_viscosity.C
+++ b/src/properties/src/parsed_viscosity.C
@@ -26,7 +26,8 @@
 namespace GRINS
 {
 
-   ParsedViscosity::ParsedViscosity( const GetPot& input )    
+   ParsedViscosity::ParsedViscosity( const GetPot& input ) :
+     ParameterUser("ParsedViscosity")
     {
       if( !input.have_variable("Materials/Viscosity/mu") )
        {

--- a/src/qoi/src/average_nusselt_number.C
+++ b/src/qoi/src/average_nusselt_number.C
@@ -55,9 +55,11 @@ namespace GRINS
 
   void AverageNusseltNumber::init( const GetPot& input, const MultiphysicsSystem& system )
   {
-    _k = input( "QoI/NusseltNumber/thermal_conductivity", -1.0 );
+    this->set_parameter
+      ( _k, input, "QoI/NusseltNumber/thermal_conductivity", -1.0 );
 
-    _scaling = input( "QoI/NusseltNumber/scaling", 1.0 );
+    this->set_parameter
+      ( _scaling, input, "QoI/NusseltNumber/scaling", 1.0 );
 
     if( this->_k < 0.0 )
       {

--- a/src/solver/include/grins/grins_solver.h
+++ b/src/solver/include/grins/grins_solver.h
@@ -68,18 +68,18 @@ namespace GRINS
     virtual void solve( SolverContext& context )=0;
 
     virtual void adjoint_qoi_parameter_sensitivity
-      (SolverContext&                  context,
-       const libMesh::QoISet&          qoi_indices,
-       const libMesh::ParameterVector& parameters_in,
-       libMesh::SensitivityData&       sensitivities)
+      (SolverContext&                  /*context*/,
+       const libMesh::QoISet&          /*qoi_indices*/,
+       const libMesh::ParameterVector& /*parameters_in*/,
+       libMesh::SensitivityData&       /*sensitivities*/)
       const
     { libmesh_not_implemented(); }
 
     virtual void forward_qoi_parameter_sensitivity
-      (SolverContext&                  context,
-       const libMesh::QoISet&          qoi_indices,
-       const libMesh::ParameterVector& parameters_in,
-       libMesh::SensitivityData&       sensitivities)
+      (SolverContext&                  /*context*/,
+       const libMesh::QoISet&          /*qoi_indices*/,
+       const libMesh::ParameterVector& /*parameters_in*/,
+       libMesh::SensitivityData&       /*sensitivities*/)
       const
     { libmesh_not_implemented(); }
 

--- a/src/solver/include/grins/parameter_user.h
+++ b/src/solver/include/grins/parameter_user.h
@@ -74,6 +74,8 @@ namespace GRINS
         const std::string & param_name,
         libMesh::Number param_default );
 
+    // FIXME: add set_parameter for vectors
+
     //! Each subclass will register its copy of an independent
     //  variable when the library makes this call.
     //  If the subclass has more than one copy to register, or if the

--- a/src/solver/src/parameter_manager.C
+++ b/src/solver/src/parameter_manager.C
@@ -27,6 +27,7 @@
 #include "grins/parameter_manager.h"
 
 // GRINS
+#include "grins/composite_qoi.h"
 #include "grins/multiphysics_sys.h"
 #include "grins/solver_context.h"
 
@@ -61,6 +62,15 @@ namespace GRINS
           new libMesh::ParameterMultiPointer<libMesh::Number>();
 
         system.register_parameter(param_name, *next_param);
+
+        qoi.register_parameter(param_name, *next_param);
+
+        if (next_param->size() == 0)
+          {
+            std::cout << "No parameters named " << param_name <<
+              " found in active Physics or QoIs" << std::endl;
+            libmesh_error();
+          }
 
         this->parameter_vector.push_back
           (UniquePtr<libMesh::ParameterAccessor<libMesh::Number> >

--- a/src/solver/src/parameter_user.C
+++ b/src/solver/src/parameter_user.C
@@ -39,7 +39,9 @@ namespace GRINS
   {
     param_variable = input(param_name, param_default);
 
-    libmesh_assert_equal_to (_my_parameters.count(param_name), 0);
+    libmesh_assert_msg(!_my_parameters.count(param_name),
+      "ERROR: " << _my_name << " double-registered parameter " <<
+      param_name);
 
     _my_parameters[param_name] = &param_variable;
   }

--- a/test/input_files/3d_low_mach_jacobians_xy.in
+++ b/test/input_files/3d_low_mach_jacobians_xy.in
@@ -64,6 +64,8 @@ pressure = 'p'
 
 enabled_qois = 'average_nusselt_number'
 
+adjoint_sensitivity_parameters = 'Physics/LowMachNavierStokes/p0 Physics/LowMachNavierStokes/T0 Physics/LowMachNavierStokes/R Materials/Viscosity/mu Materials/Conductivity/k Materials/SpecificHeat/cp QoI/NusseltNumber/thermal_conductivity'
+
 [./NusseltNumber]
 
 thermal_conductivity = '0.041801' #[W/m-K]

--- a/test/input_files/parsed_qoi.in.in
+++ b/test/input_files/parsed_qoi.in.in
@@ -76,6 +76,10 @@ pin_pressure = 'false'
 [QoI]
 enabled_qois = 'parsed_interior'
 
+# All sensitivities should be zero
+adjoint_sensitivity_parameters = 'Physics/IncompressibleNavierStokes/mu Physics/Stokes/rho'
+forward_sensitivity_parameters = 'Physics/IncompressibleNavierStokes/mu Physics/Stokes/rho'
+
 [./ParsedInterior]
 qoi_functional = 'u'
 


### PR DESCRIPTION
This extends #262, by actually *using* the register_parameter() interface to register all the scalar parameters I can get my hands on.  Any Number that we read from a scalar entry in the GRINS input file is now registered under its fully-qualified input file name as a parameter.

I'm posting this for review now.  Once I add a few regression tests and make sure they work, I intend to merge libMesh/libmesh#520, then #262, then this.