### PR TITLE
Catch "print_qoi with no QoIs" error earlier

### DIFF
--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -181,6 +181,12 @@ namespace GRINS
            it will be cloned in _multiphysics_system and all the calculations are done there. */
         _multiphysics_system->attach_qoi( qois.get() );
       }
+    else if (_print_qoi)
+      {
+        std::cout << "Error: print_qoi is specified but\n" <<
+          "no QoIs have been specified.\n" << std::endl;
+        libmesh_error();
+      }
 
     return;
   }


### PR DESCRIPTION
We just got a segfault (opt) or a cast failure (devel) before.

Tested and working.