### PR TITLE
More consistent var index initialization

### DIFF
--- a/src/physics/include/grins/var_typedefs.h
+++ b/src/physics/include/grins/var_typedefs.h
@@ -28,6 +28,7 @@
 // C++
 #include <string>
 #include <map>
+#include <limits>
 #include "boost/tr1/memory.hpp"
 
 // libMesh
@@ -40,6 +41,11 @@ namespace GRINS
 
   //! More descriptive name of the type used for variable indices
   typedef unsigned int VariableIndex;
+
+  //! Invalid varaible index id.
+  /*! We can't use negative values, so we use the max to be able to initialize VariableIndex quantities
+    since we're much more unlikely to hit the max than 0. */
+  const unsigned int invalid_var_index = std::numeric_limits<unsigned int>::max();
 
   typedef std::string VariableName;
 

--- a/src/physics/src/primitive_flow_variables.C
+++ b/src/physics/src/primitive_flow_variables.C
@@ -35,7 +35,11 @@
 namespace GRINS
 {
   PrimitiveFlowVariables::PrimitiveFlowVariables( const GetPot& input )
-    :  _u_var_name( input("Physics/VariableNames/u_velocity", u_var_name_default ) ),
+    :  _u_var(invalid_var_index),
+       _v_var(invalid_var_index),
+       _w_var(invalid_var_index),
+       _p_var(invalid_var_index),
+       _u_var_name( input("Physics/VariableNames/u_velocity", u_var_name_default ) ),
        _v_var_name( input("Physics/VariableNames/v_velocity", v_var_name_default ) ),
        _w_var_name( input("Physics/VariableNames/w_velocity", w_var_name_default ) ),
        _p_var_name( input("Physics/VariableNames/pressure",   p_var_name_default ) )

--- a/src/physics/src/primitive_temp_variables.C
+++ b/src/physics/src/primitive_temp_variables.C
@@ -35,7 +35,8 @@
 namespace GRINS
 {
   PrimitiveTempVariables::PrimitiveTempVariables( const GetPot& input )
-    : _T_var_name( input("Physics/VariableNames/Temperature", T_var_name_default ) )
+    : _T_var(invalid_var_index),
+      _T_var_name( input("Physics/VariableNames/Temperature", T_var_name_default ) )
   {
     return;
   }

--- a/src/physics/src/solid_mechanics_variables.C
+++ b/src/physics/src/solid_mechanics_variables.C
@@ -37,9 +37,9 @@ namespace GRINS
   SolidMechanicsVariables::SolidMechanicsVariables( const GetPot& input )
     : _have_v(false),
       _have_w(false),
-      _u_var(2^30), // These are unsigned, so initialize to absurdly large value
-      _v_var(2^30),
-      _w_var(2^20),
+      _u_var(invalid_var_index), // These are unsigned, so initialize to absurdly large value
+      _v_var(invalid_var_index),
+      _w_var(invalid_var_index),
       _u_var_name( input("Physics/VariableNames/u_displacment", u_disp_name_default ) ),
       _v_var_name( input("Physics/VariableNames/v_displacment", v_disp_name_default ) ),
       _w_var_name( input("Physics/VariableNames/w_displacment", w_disp_name_default ) )

--- a/src/physics/src/turbulence_variables.C
+++ b/src/physics/src/turbulence_variables.C
@@ -35,7 +35,8 @@
 namespace GRINS
 {
   TurbulenceVariables::TurbulenceVariables( const GetPot& input )
-    :  _nu_var_name( input("Physics/VariableNames/turbulent_viscosity", nu_var_name_default ) )
+    :  _nu_var(invalid_var_index),
+       _nu_var_name( input("Physics/VariableNames/turbulent_viscosity", nu_var_name_default ) )
   {
     return;
   }


### PR DESCRIPTION
In some cases we initializing variable indices, in some cases we weren't. This is problematic for development cases like forgetting to initialize variables with libMesh since the `VariableIndex` is an `unsigned int` and can often default to 0. This PR defines `GRINS::invalid_var_index` and, for the cases where we've wrapped up the variable indices, use this to initialize the var indices. Note I'm using `std::numeric_limits<unsigned int>::max()` as the invalid value since we can't use negative values. If there's a better suggestion, I welcome it.