### PR TITLE
0.6.0 prep

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,31 @@
 Version 0.6.0 (In progress)
-   * Added velocitypenalty2 + velocitypenalty3, to support 3d constraints 
-
+   * Refactored SplitString function and renamed split_string.
+     String utilities now in StringUtilities namespace.
+   * Bugfix for variable index initialization. Now if a variable
+     doesn't get properly initialized, an assert should be thrown.
+   * Bugfix for axisymmetric case of ReactingLowMachNavierStokes
+   * New SpalartAllmaras turbulence Physics (thanks to Vikram Garg).
+   * New ParameterManager capability in development. In conjunction
+     with computing parameter sensitivities. This is still experimental.
+   * Fixes for viscosity handling in some stabilization classes.
+   * Added LIBMESH_RUN capability to test suite. Now, test suite
+     can be run with MPI.
+   * Added new SourceFunction Physics for specifying source functions
+     from the input file (as opposed to manually subclassing).
+   * Refactored Simulation constructor to take GetPot/command line
+     object. Previous constructor is deprecated.
+   * Bug fix in postprocessing
+   * Refactored mesh specification section of input file. Previous
+     specification is deprecated. Added example input file in examples.
+   * Added velocitypenalty2 + velocitypenalty3, to support 3d constraints
    * Added 'continue_after_max_iterations' option to parser
-   * Added velocitypenalty2 + velocitypenalty3, to support 3d constraints 
+   * Added velocitypenalty2 + velocitypenalty3, to support 3d constraints
+   * Added unused input variable detection. Errors by default for any
+     detected unused input variables.
+   * Fix for FlowVariables parsing
+   * Symmetry boundary conditions for ElasticMembrane
+   * Bugfixes for mixed ElasticMembrane/Cable case, added regression test
+   * Refactoring of ElasticCable, HookesLaw for better 1D support
 
 Version 0.5.0
 https://github.com/grinsfem/grins/releases/tag/v0.5.0

--- a/src/bc_handling/src/spalart_allmaras_bc_handling.C
+++ b/src/bc_handling/src/spalart_allmaras_bc_handling.C
@@ -36,7 +36,7 @@ namespace GRINS
 {
 
   SpalartAllmarasBCHandling::SpalartAllmarasBCHandling(const std::string& physics_name,
-						 const GetPot& input)
+                                                       const GetPot& input)
     : BCHandlingBase(physics_name),
       _turb_vars(input)
   {
@@ -46,7 +46,7 @@ namespace GRINS
     std::string val_str = "Physics/"+_physics_name+"/bc_values";
 
     this->read_bc_data( input, id_str, bc_str, var_str, val_str );
-    
+
     return;
   }
 
@@ -61,12 +61,12 @@ namespace GRINS
 
     if( bc_type == "general_viscosity" )
       {
-	bc_type_out = GENERAL_VISCOSITY;
+        bc_type_out = GENERAL_VISCOSITY;
       }
     else
       {
-	// Call base class to detect any physics-common boundary conditions
-	bc_type_out = BCHandlingBase::string_to_int( bc_type );
+        // Call base class to detect any physics-common boundary conditions
+        bc_type_out = BCHandlingBase::string_to_int( bc_type );
       }
 
     return bc_type_out;
@@ -78,49 +78,49 @@ namespace GRINS
 
     return;
   }
-  
-  void SpalartAllmarasBCHandling::init_bc_types( const BoundaryID bc_id, 
-					      const std::string& bc_id_string, 
-					      const int bc_type, 
-					      const std::string& bc_vars, 
-					      const std::string& bc_value, 
-					      const GetPot& input )
-  { 
+
+  void SpalartAllmarasBCHandling::init_bc_types( const BoundaryID bc_id,
+                                                 const std::string& bc_id_string,
+                                                 const int bc_type,
+                                                 const std::string& bc_vars,
+                                                 const std::string& bc_value,
+                                                 const GetPot& input )
+  {
     switch(bc_type)
       {
       case(GENERAL_VISCOSITY):
-	{
-	  this->set_dirichlet_bc_type( bc_id, bc_type);
-	}
-	break;
-	
+        {
+          this->set_dirichlet_bc_type( bc_id, bc_type);
+        }
+        break;
+
       default:
-	{
-	  // Call base class to detect any physics-common boundary conditions
-	  BCHandlingBase::init_bc_types( bc_id, bc_id_string, bc_type,
-                                         bc_vars, bc_value, input );	
-	}
+        {
+          // Call base class to detect any physics-common boundary conditions
+          BCHandlingBase::init_bc_types( bc_id, bc_id_string, bc_type,
+                                         bc_vars, bc_value, input );
+        }
       } // End switch(bc_type)
     return;
   }
-  
-   void SpalartAllmarasBCHandling::user_init_dirichlet_bcs( libMesh::FEMSystem* system,
-								      libMesh::DofMap& dof_map,
-								      BoundaryID bc_id,
-								      BCType bc_type ) const
+
+  void SpalartAllmarasBCHandling::user_init_dirichlet_bcs( libMesh::FEMSystem* /*system*/,
+                                                           libMesh::DofMap& /*dof_map*/,
+                                                           BoundaryID /*bc_id*/,
+                                                           BCType bc_type ) const
   {
     switch( bc_type )
       {
-	case(GENERAL_VISCOSITY):
-	// This case is handled in the init_dirichlet_bc_func_objs
-	break;
-	
+      case(GENERAL_VISCOSITY):
+        // This case is handled in the init_dirichlet_bc_func_objs
+        break;
+
       default:
-	{
-	  std::cerr << "Invalid BCType " << bc_type << std::endl;
-	  libmesh_error();
-	}
-      
+        {
+          std::cerr << "Invalid BCType " << bc_type << std::endl;
+          libmesh_error();
+        }
+
       }// end switch
   }
 

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -127,9 +127,6 @@ namespace GRINS
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
       context.get_element_fe(_temp_vars.T_var())->get_dphi();
 
-    const std::vector<libMesh::Point>& q_points = 
-      context.get_element_fe(_temp_vars.T_var())->get_xyz();
-
     // The subvectors and submatrices we need to fill:
     //
     // K_{\alpha \beta} = R_{\alpha},{\beta} = \partial{ R_{\alpha} } / \partial{ {\beta} } (where R denotes residual)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -39,7 +39,7 @@ check_PROGRAMS += generic_solution_regression
 check_PROGRAMS += axisym_reacting_low_mach_regression
 check_PROGRAMS += split_string_unit
 
-AM_CPPFLAGS = 
+AM_CPPFLAGS =
 AM_CPPFLAGS += -I$(top_srcdir)/src/bc_handling/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/boundary_conditions/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/common/include
@@ -58,7 +58,7 @@ AM_CPPFLAGS += $(GRVY_CFLAGS)
 LIBS =
 LIBS += $(LIBGRINS_LIBS)
 
-AM_LDFLAGS = 
+AM_LDFLAGS =
 
 #----------------
 # Cantera support
@@ -281,7 +281,7 @@ if CODE_COVERAGE_ENABLED
 endif
 
 # If we have tests fail, libmesh_error() may leave output
-CLEANFILES += traceout*.txt temp_print_trace.*
+CLEANFILES += traceout*.txt temp_print_trace.* *.exo *.xdr
 
 # Required for AX_AM_MACROS
 ###@INC_AMINCLUDE@


### PR DESCRIPTION
Builds off of #284.

Removed a few more unused variable warnings. Now the only warnings that are emitted should be from new Antioch and Cantera. `make distcheck` passes for me. Updated CHANGES.

Chime in now if there's anything else you want to try and squeeze in. Otherwise I'll tag and release tonight.

Closes #283.