### PR TITLE
Remove redundant protected member from HeatTransferStabBase

### DIFF
--- a/src/physics/include/grins/heat_transfer_stab_base.h
+++ b/src/physics/include/grins/heat_transfer_stab_base.h
@@ -50,8 +50,6 @@ namespace GRINS
   protected:
 
     HeatTransferStabilizationHelper _stab_helper;
-    
-    Conductivity _k;
 
   private:
 

--- a/src/physics/src/heat_transfer_stab_base.C
+++ b/src/physics/src/heat_transfer_stab_base.C
@@ -35,11 +35,10 @@
 namespace GRINS
 {
   template<class K>
-  HeatTransferStabilizationBase<K>::HeatTransferStabilizationBase( const std::string& physics_name, 
+  HeatTransferStabilizationBase<K>::HeatTransferStabilizationBase( const std::string& physics_name,
                                                                 const GetPot& input )
     : HeatTransferBase<K>(physics_name,input),
-      _stab_helper(physics_name+"StabHelper", input),
-      _k(input)
+      _stab_helper(physics_name+"StabHelper", input)
   {
     this->read_input_options(input);
 


### PR DESCRIPTION
Came across this in the `input-materials-redo` branch. The member in question is in `HeatTransferBase`. Do we disable `-Wshadow`? Supposedly gcc 4.8 is better with this.

I tested this locally so I'm going to go ahead and merge right away.