### PR TITLE
Parsed bcid fix

### DIFF
--- a/src/qoi/src/parsed_boundary_qoi.C
+++ b/src/qoi/src/parsed_boundary_qoi.C
@@ -101,6 +101,19 @@ namespace GRINS
   void ParsedBoundaryQoI::side_qoi( AssemblyContext& context,
                                     const unsigned int qoi_index )
   {
+    bool on_correct_side = false;
+
+    for (std::set<libMesh::boundary_id_type>::const_iterator id =
+         _bc_ids.begin(); id != _bc_ids.end(); id++ )
+      if( context.has_side_boundary_id( (*id) ) )
+        {
+          on_correct_side = true;
+          break;
+        }
+
+    if (!on_correct_side)
+      return;
+
     libMesh::FEBase* side_fe;
     context.get_side_fe<libMesh::Real>(0, side_fe);
     const std::vector<libMesh::Real> &JxW = side_fe->get_JxW();

--- a/src/qoi/src/parsed_boundary_qoi.C
+++ b/src/qoi/src/parsed_boundary_qoi.C
@@ -47,6 +47,8 @@ namespace GRINS
   {
     if (original.qoi_functional.get())
       this->qoi_functional = original.qoi_functional->clone();
+
+    this->_bc_ids = original._bc_ids;
   }
 
   ParsedBoundaryQoI::~ParsedBoundaryQoI() {}


### PR DESCRIPTION
This should fix some nasty ParsedBoundaryQoI bugs; previously adjoint and sensitivity solves wouldn't work and even QoI evaluation only worked correctly if your parsed function was zero on non-specified boundaries.

@vikramvgarg has some more tests to run before merge.