### PR TITLE
Switch to ParameterMultiAccessor

### DIFF
--- a/src/physics/include/grins/axisym_heat_transfer.h
+++ b/src/physics/include/grins/axisym_heat_transfer.h
@@ -87,7 +87,7 @@ namespace GRINS
     // class
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/include/grins/boussinesq_buoyancy_adjoint_stab.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_adjoint_stab.h
@@ -61,7 +61,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
@@ -68,7 +68,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/include/grins/heat_conduction.h
+++ b/src/physics/include/grins/heat_conduction.h
@@ -65,7 +65,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/include/grins/heat_transfer_base.h
+++ b/src/physics/include/grins/heat_transfer_base.h
@@ -63,7 +63,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/include/grins/inc_navier_stokes_base.h
+++ b/src/physics/include/grins/inc_navier_stokes_base.h
@@ -69,7 +69,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
     // A getter function for the Viscosity object

--- a/src/physics/include/grins/low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_base.h
@@ -81,7 +81,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -50,7 +50,7 @@ namespace libMesh
   class DiffContext;
 
   template <typename Scalar>
-  class ParameterMultiPointer;
+  class ParameterMultiAccessor;
 }
 
 namespace GRINS
@@ -112,7 +112,7 @@ namespace GRINS
     //  named in this call.
     void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number>& param_pointer );
+        libMesh::ParameterMultiAccessor<libMesh::Number>& param_pointer );
 
     //! Override FEMSystem::build_context in order to use our own AssemblyContext
     virtual libMesh::AutoPtr<libMesh::DiffContext> build_context();

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -57,7 +57,7 @@ namespace libMesh
   class Elem;
 
   template <typename Scalar>
-  class ParameterMultiPointer;
+  class ParameterMultiAccessor;
 }
 
 //! GRINS namespace

--- a/src/physics/include/grins/spalart_allmaras.h
+++ b/src/physics/include/grins/spalart_allmaras.h
@@ -88,7 +88,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/include/grins/spalart_allmaras_spgsm_stab.h
+++ b/src/physics/include/grins/spalart_allmaras_spgsm_stab.h
@@ -55,7 +55,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   private:

--- a/src/physics/include/grins/spalart_allmaras_stab_base.h
+++ b/src/physics/include/grins/spalart_allmaras_stab_base.h
@@ -51,7 +51,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/include/grins/spalart_allmaras_stab_helper.h
+++ b/src/physics/include/grins/spalart_allmaras_stab_helper.h
@@ -129,7 +129,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/include/grins/turbulence_models_base.h
+++ b/src/physics/include/grins/turbulence_models_base.h
@@ -59,7 +59,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -370,7 +370,7 @@ namespace GRINS
   template< class Conductivity>
   void AxisymmetricHeatTransfer<Conductivity>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
@@ -386,7 +386,7 @@ namespace GRINS
   template<class Mu>
   void BoussinesqBuoyancyAdjointStabilization<Mu>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
@@ -326,7 +326,7 @@ namespace GRINS
   template<class Mu>
   void BoussinesqBuoyancySPGSMStabilization<Mu>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -241,7 +241,7 @@ namespace GRINS
   template<class K>
   void HeatConduction<K>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -110,7 +110,7 @@ namespace GRINS
   template<class K>
   void HeatTransferBase<K>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -118,7 +118,7 @@ namespace GRINS
   template<class Mu>
   void IncompressibleNavierStokesBase<Mu>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -196,7 +196,7 @@ namespace GRINS
   template<class Mu, class SH, class TC>
   void LowMachNavierStokesBase<Mu,SH,TC>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -32,7 +32,7 @@
 // libMesh
 #include "libmesh/composite_function.h"
 #include "libmesh/getpot.h"
-#include "libmesh/parameter_multipointer.h"
+#include "libmesh/parameter_multiaccessor.h"
 
 namespace GRINS
 {
@@ -195,7 +195,7 @@ namespace GRINS
 
   void MultiphysicsSystem::register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number>& param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number>& param_pointer )
   {
     //Loop over each physics to ask each for the requested parameter
     for( PhysicsListIter physics_iter = _physics_list.begin();

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -356,7 +356,7 @@ namespace GRINS
   template<class Mu>
   void SpalartAllmaras<Mu>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/physics/src/spalart_allmaras_spgsm_stab.C
+++ b/src/physics/src/spalart_allmaras_spgsm_stab.C
@@ -65,7 +65,7 @@ namespace GRINS
 
   template<class Mu>
   void SpalartAllmarasSPGSMStabilization<Mu>::register_parameter
-  ( const std::string &param_name, libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer)
+  ( const std::string &param_name, libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer)
   const
   {
     // Register base class parameters

--- a/src/physics/src/spalart_allmaras_stab_base.C
+++ b/src/physics/src/spalart_allmaras_stab_base.C
@@ -77,7 +77,7 @@ namespace GRINS
    template<class Mu>
   void SpalartAllmarasStabilizationBase<Mu>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     SpalartAllmaras<Mu>::register_parameter(param_name, param_pointer);

--- a/src/physics/src/spalart_allmaras_stab_helper.C
+++ b/src/physics/src/spalart_allmaras_stab_helper.C
@@ -49,7 +49,7 @@ namespace GRINS
   }
 
   void SpalartAllmarasStabilizationHelper::register_parameter
-  ( const std::string &param_name, libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer)
+  ( const std::string &param_name, libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer)
   const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/physics/src/turbulence_models_base.C
+++ b/src/physics/src/turbulence_models_base.C
@@ -70,7 +70,7 @@ namespace GRINS
   template<class Mu>
   void TurbulenceModelsBase<Mu>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/properties/include/grins/spalart_allmaras_viscosity.h
+++ b/src/properties/include/grins/spalart_allmaras_viscosity.h
@@ -67,7 +67,7 @@ namespace GRINS
     // classes
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   protected:

--- a/src/properties/src/spalart_allmaras_viscosity.C
+++ b/src/properties/src/spalart_allmaras_viscosity.C
@@ -47,7 +47,7 @@ namespace GRINS
   template<class Mu>
   void SpalartAllmarasViscosity<Mu>::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     ParameterUser::register_parameter(param_name, param_pointer);

--- a/src/qoi/include/grins/composite_qoi.h
+++ b/src/qoi/include/grins/composite_qoi.h
@@ -73,7 +73,7 @@ namespace GRINS
     //  named in this call.
     void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number>& param_pointer)
+        libMesh::ParameterMultiAccessor<libMesh::Number>& param_pointer)
     const;
 
     /*!

--- a/src/qoi/include/grins/qoi_base.h
+++ b/src/qoi/include/grins/qoi_base.h
@@ -39,12 +39,6 @@
 // libMesh forward declarations
 class GetPot;
 
-namespace libMesh
-{
-  template <typename Scalar>
-  class ParameterMultiPointer;
-}
-
 namespace GRINS
 {
   // Forward declarations

--- a/src/qoi/src/composite_qoi.C
+++ b/src/qoi/src/composite_qoi.C
@@ -112,7 +112,7 @@ namespace GRINS
 
   void CompositeQoI::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number>& param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number>& param_pointer )
   const
   {
     for( unsigned int q = 0; q < _qois.size(); q++ )

--- a/src/solver/include/grins/parameter_user.h
+++ b/src/solver/include/grins/parameter_user.h
@@ -44,7 +44,7 @@ class GetPot;
 namespace libMesh
 {
   template <typename Scalar>
-  class ParameterMultiPointer;
+  class ParameterMultiAccessor;
 }
 
 //! GRINS namespace
@@ -84,7 +84,7 @@ namespace GRINS
     //  need to be overridden.
     virtual void register_parameter
       ( const std::string & param_name,
-        libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+        libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const;
 
   private:

--- a/src/solver/src/parameter_manager.C
+++ b/src/solver/src/parameter_manager.C
@@ -34,7 +34,7 @@
 // libMesh
 #include "libmesh/auto_ptr.h"
 #include "libmesh/getpot.h"
-#include "libmesh/parameter_multipointer.h"
+#include "libmesh/parameter_multiaccessor.h"
 
 
 namespace GRINS
@@ -58,8 +58,8 @@ namespace GRINS
 
         this->parameter_name_list[i] = param_name;
 
-        libMesh::ParameterMultiPointer<libMesh::Number> *next_param =
-          new libMesh::ParameterMultiPointer<libMesh::Number>();
+        libMesh::ParameterMultiAccessor<libMesh::Number> *next_param =
+          new libMesh::ParameterMultiAccessor<libMesh::Number>();
 
         // We always have Physics solving for u
         system.register_parameter(param_name, *next_param);

--- a/src/solver/src/parameter_user.C
+++ b/src/solver/src/parameter_user.C
@@ -28,7 +28,8 @@
 
 // libMesh
 #include "libmesh/getpot.h"
-#include "libmesh/parameter_multipointer.h"
+#include "libmesh/parameter_multiaccessor.h"
+#include "libmesh/parameter_pointer.h"
 
 namespace GRINS
 {
@@ -48,7 +49,7 @@ namespace GRINS
 
   void ParameterUser::register_parameter
     ( const std::string & param_name,
-      libMesh::ParameterMultiPointer<libMesh::Number> & param_pointer )
+      libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )
     const
   {
     std::map<std::string, libMesh::Number*>::const_iterator it =
@@ -58,7 +59,8 @@ namespace GRINS
       {
         std::cout << _my_name << " uses parameter " << param_name
                   << std::endl;
-        param_pointer.push_back(it->second);
+        param_pointer.push_back
+          (libMesh::ParameterPointer<libMesh::Number>(it->second));
       }
   }
 


### PR DESCRIPTION
ParameterMultiPointer won't be flexible enough to handle the
non-pointer parameters in Antioch.

This is going in a separate PR so I can use the new API before the whole of #291 is done testing, and so avoid setting up future conflicts.