### PR TITLE
Parsed function variable sensitivities

### DIFF
--- a/src/physics/include/grins/averaged_fan_base.h
+++ b/src/physics/include/grins/averaged_fan_base.h
@@ -31,8 +31,8 @@
 #include "grins/inc_navier_stokes_base.h"
 
 // libMesh
-#include "libmesh/function_base.h"
 #include "libmesh/getpot.h"
+#include "libmesh/parsed_function.h"
 #include "libmesh/tensor_value.h"
 
 // C++
@@ -64,33 +64,33 @@ namespace GRINS
     // Velocity of the moving fan blades as a function of x,y,z
     // Iff there are no fan blades moving past a location, the
     // velocity there is specified as zero.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > base_velocity_function;
+    libMesh::ParsedFunction<libMesh::Number> base_velocity_function;
 
     // "Up" direction of fan airflow, as a function of x,y,z
     // For most fans this will be a constant, the axis of rotation.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > local_vertical_function;
+    libMesh::ParsedFunction<libMesh::Number> local_vertical_function;
 
     // Coefficients of lift and drag as a function of angle "t" in
     // radians.  Should be well defined on [-pi, pi].
     //
     // No, "t" is not time in these functions.
     // Yes, I'm abusing FunctionBase.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > lift_function;
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > drag_function;
+    libMesh::ParsedFunction<libMesh::Number> lift_function;
+    libMesh::ParsedFunction<libMesh::Number> drag_function;
 
     // The chord length of the fan wing cross-section.  For fan blades
     // with constant cross-section this will be a constant.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > chord_function;
+    libMesh::ParsedFunction<libMesh::Number> chord_function;
 
     // The area swept out by the local fan wing cross-section.  For
     // cylindrical areas swept out by N fan blades, this is just
     // pi*r^2*h/N
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > area_swept_function;
+    libMesh::ParsedFunction<libMesh::Number> area_swept_function;
 
     // The angle-of-attack between the fan wing chord line and the fan
     // velocity vector, in radians.  For fan blades with no "twist"
     // this will be a constant.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > aoa_function;
+    libMesh::ParsedFunction<libMesh::Number> aoa_function;
 
   private:
 

--- a/src/physics/include/grins/averaged_turbine_base.h
+++ b/src/physics/include/grins/averaged_turbine_base.h
@@ -31,8 +31,8 @@
 #include "grins/inc_navier_stokes_base.h"
 
 // libMesh
-#include "libmesh/function_base.h"
 #include "libmesh/getpot.h"
+#include "libmesh/parsed_function.h"
 #include "libmesh/tensor_value.h"
 
 // C++
@@ -83,19 +83,19 @@ namespace GRINS
     // therefore correspond to a fan speed of 1 radian per second.
     // Iff there are no fan blades moving past a location, the
     // base velocity there is specified as zero.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > base_velocity_function;
+    libMesh::ParsedFunction<libMesh::Number> base_velocity_function;
 
     // "Up" direction of fan airflow, as a function of x,y,z
     // For most fans this will be a constant, the axis of rotation.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > local_vertical_function;
+    libMesh::ParsedFunction<libMesh::Number> local_vertical_function;
 
     // Coefficients of lift and drag as a function of angle "t" in
     // radians.  Should be well defined on [-pi, pi].
     //
     // No, "t" is not time in these functions.
     // Yes, I'm abusing FunctionBase.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > lift_function;
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > drag_function;
+    libMesh::ParsedFunction<libMesh::Number> lift_function;
+    libMesh::ParsedFunction<libMesh::Number> drag_function;
 
     // Mechanical driving torque function (*including* non-fluid
     // friction losses!) on the turbine (signed, measured in
@@ -111,7 +111,7 @@ namespace GRINS
     //
     // No, "t" is not time or angle of attack in this function.
     // Yes, I'm really abusing FunctionBase.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > torque_function;
+    libMesh::ParsedFunction<libMesh::Number> torque_function;
 
     // Moment of inertia of the spinning component of the turbine
     // (measured in kg-m^2)
@@ -123,17 +123,17 @@ namespace GRINS
 
     // The chord length of the fan wing cross-section.  For fan blades
     // with constant cross-section this will be a constant.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > chord_function;
+    libMesh::ParsedFunction<libMesh::Number> chord_function;
 
     // The area swept out by the local fan wing cross-section.  For
     // cylindrical areas swept out by N fan blades, this is just
     // pi*r^2*h/N
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > area_swept_function;
+    libMesh::ParsedFunction<libMesh::Number> area_swept_function;
 
     // The angle-of-attack between the fan wing chord line and the fan
     // velocity vector, in radians.  For fan blades with no "twist"
     // this will be a constant.
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > aoa_function;
+    libMesh::ParsedFunction<libMesh::Number> aoa_function;
 
     VariableIndex _fan_speed_var; /* Index for turbine speed scalar */
 

--- a/src/physics/include/grins/parsed_velocity_source_base.h
+++ b/src/physics/include/grins/parsed_velocity_source_base.h
@@ -50,9 +50,6 @@ namespace GRINS
 
     ~ParsedVelocitySourceBase();
 
-    //! Read options from GetPot input file.
-    virtual void read_input_options( const GetPot& input );
-
     void set_time_evolving_vars (libMesh::FEMSystem* system);
 
     bool compute_force ( const libMesh::Point& point,
@@ -63,12 +60,12 @@ namespace GRINS
    
   protected:
 
-    std::string source_function_string;
-
     libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
       velocity_source_function;
 
   private:
+
+    const GetPot & _input;
 
     ParsedVelocitySourceBase();
   };

--- a/src/physics/include/grins/scalar_ode.h
+++ b/src/physics/include/grins/scalar_ode.h
@@ -91,12 +91,6 @@ namespace GRINS
 
   private:
 
-    // strings describing the mass, time derivative, and
-    // constraint components of an ODE.
-    std::string time_deriv_function_string,
-                constraint_function_string,
-                mass_residual_function_string;
-
     // ParsedFEMFunctions evaluating the mass, time derivative, and
     // constraint components of an ODE.
     libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
@@ -114,6 +108,8 @@ namespace GRINS
     VariableIndex _scalar_ode_var; /* Index for turbine speed scalar */
 
     std::string _scalar_ode_var_name;
+
+    const GetPot & _input;
 
     ScalarODE();
   };

--- a/src/physics/include/grins/velocity_drag_base.h
+++ b/src/physics/include/grins/velocity_drag_base.h
@@ -31,8 +31,8 @@
 #include "grins/inc_navier_stokes_base.h"
 
 // libMesh
-#include "libmesh/function_base.h"
 #include "libmesh/getpot.h"
+#include "libmesh/parsed_function.h"
 #include "libmesh/tensor_value.h"
 
 // C++
@@ -62,7 +62,7 @@ namespace GRINS
   protected:
 
     libMesh::Real _exponent;
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > _coefficient;
+    libMesh::ParsedFunction<libMesh::Number> _coefficient;
 
   private:
 

--- a/src/physics/include/grins/velocity_penalty_base.h
+++ b/src/physics/include/grins/velocity_penalty_base.h
@@ -31,7 +31,7 @@
 #include "grins/inc_navier_stokes_base.h"
 
 // libMesh
-#include "libmesh/function_base.h"
+#include "libmesh/parsed_function.h"
 #include "libmesh/getpot.h"
 #include "libmesh/tensor_value.h"
 
@@ -63,9 +63,9 @@ namespace GRINS
 
     bool _quadratic_scaling;
 
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > normal_vector_function;
+    libMesh::ParsedFunction<libMesh::Number> normal_vector_function;
 
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > base_velocity_function;
+    libMesh::ParsedFunction<libMesh::Number> base_velocity_function;
 
   private:
 

--- a/src/physics/src/averaged_turbine.C
+++ b/src/physics/src/averaged_turbine.C
@@ -265,7 +265,7 @@ namespace GRINS
       context.get_system().current_solution(dof_indices[0]);
 
     const libMesh::Number output_torque =
-      (*this->torque_function)(libMesh::Point(0), fan_speed);
+      this->torque_function(libMesh::Point(0), fan_speed);
 
     Fs(0) += output_torque;
 
@@ -274,8 +274,8 @@ namespace GRINS
         // FIXME: we should replace this FEM with a hook to the AD fparser stuff
         const libMesh::Number epsilon = 1e-6;
         const libMesh::Number output_torque_deriv =
-          ((*this->torque_function)(libMesh::Point(0), fan_speed+epsilon) -
-           (*this->torque_function)(libMesh::Point(0), fan_speed-epsilon)) / (2*epsilon);
+          (this->torque_function(libMesh::Point(0), fan_speed+epsilon) -
+           this->torque_function(libMesh::Point(0), fan_speed-epsilon)) / (2*epsilon);
 
         Kss(0,0) += output_torque_deriv * context.get_elem_solution_derivative();
       }

--- a/src/physics/src/averaged_turbine_base.C
+++ b/src/physics/src/averaged_turbine_base.C
@@ -29,10 +29,6 @@
 // GRINS
 #include "grins/inc_nav_stokes_macro.h"
 
-// libMesh
-#include "libmesh/parsed_function.h"
-#include "libmesh/zero_function.h"
-
 namespace GRINS
 {
 
@@ -40,7 +36,15 @@ namespace GRINS
   AveragedTurbineBase<Mu>::AveragedTurbineBase( const std::string& physics_name, const GetPot& input )
     : IncompressibleNavierStokesBase<Mu>(physics_name,
                                          incompressible_navier_stokes, /* "core" Physics name */
-                                         input)
+                                         input),
+      base_velocity_function(""),
+      local_vertical_function(""),
+      lift_function(""),
+      drag_function(""),
+      torque_function(""),
+      chord_function(""),
+      area_swept_function(""),
+      aoa_function("")
   {
     this->read_input_options(input);
 
@@ -75,94 +79,66 @@ namespace GRINS
   template<class Mu>
   void AveragedTurbineBase<Mu>::read_input_options( const GetPot& input )
   {
-    std::string base_function =
-      input("Physics/"+averaged_turbine+"/base_velocity",
-        std::string("0"));
+    this->set_parameter(base_velocity_function, input,
+                        "Physics/"+averaged_turbine+"/base_velocity",
+                        this->zero_vector_function);
 
-    if (base_function == "0")
+    if (base_velocity_function.expression() == this->zero_vector_function)
       libmesh_error_msg("Error! Zero AveragedTurbine specified!" <<
                         std::endl);
 
-    if (base_function == "0")
-      this->base_velocity_function.reset
-        (new libMesh::ZeroFunction<libMesh::Number>());
-    else
-      this->base_velocity_function.reset
-        (new libMesh::ParsedFunction<libMesh::Number>(base_function));
+    this->set_parameter(local_vertical_function, input,
+                        "Physics/"+averaged_turbine+"/local_vertical",
+                        this->zero_vector_function);
 
-    std::string vertical_function =
-      input("Physics/"+averaged_turbine+"/local_vertical",
-        std::string("0"));
-
-    if (vertical_function == "0")
-      libmesh_error_msg("Warning! Zero LocalVertical specified!" <<
+    if (local_vertical_function.expression() == this->zero_vector_function)
+      libmesh_error_msg("Error! Zero LocalVertical specified!" <<
                         std::endl);
 
-    this->local_vertical_function.reset
-      (new libMesh::ParsedFunction<libMesh::Number>(vertical_function));
+    this->set_parameter(lift_function, input,
+                        "Physics/"+averaged_turbine+"/lift",
+                        "0");
 
-    std::string lift_function_string =
-      input("Physics/"+averaged_turbine+"/lift",
-        std::string("0"));
-
-    if (lift_function_string == "0")
+    if (lift_function.expression() == "0")
       std::cout << "Warning! Zero lift function specified!" << std::endl;
 
-    this->lift_function.reset
-      (new libMesh::ParsedFunction<libMesh::Number>(lift_function_string));
+    this->set_parameter(drag_function, input,
+                        "Physics/"+averaged_turbine+"/drag",
+                        "0");
 
-    std::string drag_function_string =
-      input("Physics/"+averaged_turbine+"/drag",
-        std::string("0"));
-
-    if (drag_function_string == "0")
+    if (drag_function.expression() == "0")
       std::cout << "Warning! Zero drag function specified!" << std::endl;
 
-    this->drag_function.reset
-      (new libMesh::ParsedFunction<libMesh::Number>(drag_function_string));
+    this->set_parameter(chord_function, input,
+                        "Physics/"+averaged_turbine+"/chord_length",
+                        "0");
 
-    std::string chord_function_string =
-      input("Physics/"+averaged_turbine+"/chord_length",
-        std::string("0"));
-
-    if (chord_function_string == "0")
-      libmesh_error_msg("Warning! Zero chord function specified!" <<
+    if (chord_function.expression() == "0")
+      libmesh_error_msg("Error! Zero chord function specified!" <<
                         std::endl);
 
-    this->chord_function.reset
-      (new libMesh::ParsedFunction<libMesh::Number>(chord_function_string));
+    this->set_parameter(area_swept_function, input,
+                        "Physics/"+averaged_turbine+"/area_swept",
+                        "0");
 
-    std::string area_function_string =
-      input("Physics/"+averaged_turbine+"/area_swept",
-        std::string("0"));
-
-    if (area_function_string == "0")
-      libmesh_error_msg("Warning! Zero area_swept_function specified!" <<
+    if (area_swept_function.expression() == "0")
+      libmesh_error_msg("Error! Zero area_swept_function specified!" <<
                         std::endl);
 
-    this->area_swept_function.reset
-      (new libMesh::ParsedFunction<libMesh::Number>(area_function_string));
+    this->set_parameter(aoa_function, input,
+                        "Physics/"+averaged_turbine+"/angle_of_attack",
+                        "00000");
 
-    std::string aoa_function_string =
-      input("Physics/"+averaged_turbine+"/angle_of_attack",
-        std::string("00000"));
-
-    if (aoa_function_string == "00000")
-      libmesh_error_msg("Warning! No angle-of-attack specified!" <<
+    if (aoa_function.expression() == "00000")
+      libmesh_error_msg("Error! No angle-of-attack specified!" <<
                         std::endl);
 
-    this->aoa_function.reset
-      (new libMesh::ParsedFunction<libMesh::Number>(aoa_function_string));
+    this->set_parameter(torque_function, input,
+                        "Physics/"+averaged_turbine+"/torque",
+                        "0");
 
-    std::string torque_function_string =
-      input("Physics/"+averaged_turbine+"/torque",
-        std::string("0"));
-
-    if (torque_function_string == "0")
+    if (torque_function.expression() == "0")
       std::cout << "Warning! Zero torque function specified!" << std::endl;
-
-    this->torque_function.reset
-      (new libMesh::ParsedFunction<libMesh::Number>(torque_function_string));
 
     this->set_parameter
       (this->moment_of_inertia, input,
@@ -196,12 +172,9 @@ namespace GRINS
       libMesh::NumberVectorValue *dFds)
   {
     // Find base velocity of moving fan at this point
-    libmesh_assert(base_velocity_function.get());
-
     libMesh::DenseVector<libMesh::Number> output_vec(3);
 
-    (*base_velocity_function)(point, time,
-                              output_vec);
+    base_velocity_function(point, time, output_vec);
 
     U_B_1(0) = output_vec(0);
     U_B_1(1) = output_vec(1);
@@ -219,8 +192,7 @@ namespace GRINS
     const libMesh::NumberVectorValue N_B =
       libMesh::NumberVectorValue(U_B/U_B_size);
 
-    (*local_vertical_function)(point, time,
-                               output_vec);
+    local_vertical_function(point, time, output_vec);
 
     // Normal in fan vertical direction
     const libMesh::NumberVectorValue N_V(output_vec(0),
@@ -264,13 +236,13 @@ namespace GRINS
 
     // Angle WRT fan chord
     const libMesh::Number angle = part_angle +
-      (*aoa_function)(point, time);
+      aoa_function(point, time);
 
-    const libMesh::Number C_lift  = (*lift_function)(point, angle);
-    const libMesh::Number C_drag  = (*drag_function)(point, angle);
+    const libMesh::Number C_lift  = lift_function(point, angle);
+    const libMesh::Number C_drag  = drag_function(point, angle);
 
-    const libMesh::Number chord = (*chord_function)(point, time);
-    const libMesh::Number area  = (*area_swept_function)(point, time);
+    const libMesh::Number chord = chord_function(point, time);
+    const libMesh::Number area  = area_swept_function(point, time);
 
     const libMesh::Number v_sq = U_P*U_P;
 

--- a/src/physics/src/parsed_source_term.C
+++ b/src/physics/src/parsed_source_term.C
@@ -37,16 +37,11 @@ namespace GRINS
 {
   ParsedSourceTerm::ParsedSourceTerm( const std::string& physics_name, const GetPot& input )
     : SourceTermBase(physics_name,input),
-      _value( input("Physics/"+physics_name+"/Function/value","DIE!") )
+      _value("")
   {
-    if( !input.have_variable("Physics/"+physics_name+"/Function/value") )
-      {
-        libMesh::err << "Error: Must specify value for ParsedSourceTerm." << std::endl
-                     << "       Please specify Physics/"+physics_name+"/Function/value" << std::endl;
-        libmesh_error();
-      }
-
-    return;
+    this->set_parameter(_value, input,
+                        "Physics/"+physics_name+"/Function/value",
+                        "DIE!");
   }
 
   ParsedSourceTerm::~ParsedSourceTerm()

--- a/src/physics/src/parsed_velocity_source_base.C
+++ b/src/physics/src/parsed_velocity_source_base.C
@@ -59,10 +59,7 @@ namespace GRINS
 
     source_function_string =
       input("Physics/"+base_physics_name+"/source_function",
-        std::string("0"));
-
-    if (source_function_string == "0")
-      std::cout << "Warning! Zero ParsedVelocitySource specified!" << std::endl;
+        "DIE!");
   }
 
   template<class Mu>  

--- a/src/physics/src/parsed_velocity_source_base.C
+++ b/src/physics/src/parsed_velocity_source_base.C
@@ -39,11 +39,9 @@ namespace GRINS
   ParsedVelocitySourceBase<Mu>::ParsedVelocitySourceBase( const std::string& physics_name, const GetPot& input )
     : IncompressibleNavierStokesBase<Mu>(physics_name,
                                          incompressible_navier_stokes, /* "core" Physics name */
-                                         input)
+                                         input),
+      _input(input)
   {
-    this->read_input_options(input);
-
-    return;
   }
 
   template<class Mu>
@@ -53,21 +51,17 @@ namespace GRINS
   }
   
   template<class Mu>  
-  void ParsedVelocitySourceBase<Mu>::read_input_options( const GetPot& input )
+  void ParsedVelocitySourceBase<Mu>::set_time_evolving_vars ( libMesh::FEMSystem* system)
   {
     std::string base_physics_name = "ParsedVelocitySource";
 
-    source_function_string =
-      input("Physics/"+base_physics_name+"/source_function",
-        "DIE!");
-  }
+    libMesh::ParsedFEMFunction<libMesh::Number> *vsf
+      (new libMesh::ParsedFEMFunction<libMesh::Number> (*system, ""));
+    this->velocity_source_function.reset(vsf);
 
-  template<class Mu>  
-  void ParsedVelocitySourceBase<Mu>::set_time_evolving_vars ( libMesh::FEMSystem* system)
-  {
-    this->velocity_source_function.reset
-      (new libMesh::ParsedFEMFunction<libMesh::Number>
-        (*system, this->source_function_string));
+    this->set_parameter(*vsf, _input,
+                        "Physics/"+base_physics_name+"/source_function",
+                        "DIE!");
   }
 
   template<class Mu>

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -248,37 +248,37 @@ namespace GRINS
 
     if( quantity_index == this->_velocity_penalty_x_index )
       {
-        (*this->normal_vector_function)(point, context.time, output_vec);
+        this->normal_vector_function(point, context.time, output_vec);
 
         value = output_vec(0);
       }
     else if( quantity_index == this->_velocity_penalty_y_index )
       {
-        (*this->normal_vector_function)(point, context.time, output_vec);
+        this->normal_vector_function(point, context.time, output_vec);
 
         value = output_vec(1);
       }
     else if( quantity_index == this->_velocity_penalty_z_index )
       {
-        (*this->normal_vector_function)(point, context.time, output_vec);
+        this->normal_vector_function(point, context.time, output_vec);
 
         value = output_vec(2);
       }
     else if( quantity_index == this->_velocity_penalty_base_x_index )
       {
-        (*this->base_velocity_function)(point, context.time, output_vec);
+        this->base_velocity_function(point, context.time, output_vec);
 
         value = output_vec(0);
       }
     else if( quantity_index == this->_velocity_penalty_base_y_index )
       {
-        (*this->base_velocity_function)(point, context.time, output_vec);
+        this->base_velocity_function(point, context.time, output_vec);
 
         value = output_vec(1);
       }
     else if( quantity_index == this->_velocity_penalty_base_z_index )
       {
-        (*this->base_velocity_function)(point, context.time, output_vec);
+        this->base_velocity_function(point, context.time, output_vec);
 
         value = output_vec(2);
       }

--- a/src/properties/include/grins/parsed_property_base.h
+++ b/src/properties/include/grins/parsed_property_base.h
@@ -32,8 +32,8 @@
 // libMesh
 #include "libmesh/libmesh_common.h"
 #include "libmesh/fem_system.h"
+#include "libmesh/parsed_function.h"
 #include "libmesh/point.h"
-#include "libmesh/function_base.h"
 
 // C++
 #include <string>
@@ -48,7 +48,7 @@ namespace GRINS
   {
   public:
 
-    ParsedPropertyBase(){};
+    ParsedPropertyBase() : _func("") {};
     virtual ~ParsedPropertyBase(){};
 
     libMesh::Real operator()(AssemblyContext& context, unsigned int qp) const;
@@ -66,7 +66,7 @@ namespace GRINS
     bool check_func_nonzero( const std::string& function ) const;
 
     // User specified parsed function
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > _func;
+    libMesh::ParsedFunction<libMesh::Number> _func;
 
   };
 
@@ -80,7 +80,10 @@ namespace GRINS
 
     const libMesh::Point& x_qp = x[qp];
 
-    libMesh::Number value = (*_func)(x_qp,context.time);
+    // libMesh API here sucks - RHS
+    libMesh::ParsedFunction<libMesh::Number> & mutable_func =
+      const_cast<libMesh::ParsedFunction<libMesh::Number> &>(_func);
+    libMesh::Number value = mutable_func(x_qp,context.time);
 
     return value;
   }
@@ -88,7 +91,7 @@ namespace GRINS
   inline
   libMesh::Real ParsedPropertyBase::operator()( const libMesh::Point& p, const libMesh::Real time )
   {
-    return (*_func)(p,time);
+    return _func(p,time);
   }
 
 } // end namespace GRINS

--- a/src/properties/src/parsed_conductivity.C
+++ b/src/properties/src/parsed_conductivity.C
@@ -18,7 +18,6 @@
 
 // libMesh
 #include "libmesh/getpot.h"
-#include "libmesh/parsed_function.h"
 
 namespace GRINS
 {
@@ -27,21 +26,9 @@ namespace GRINS
     : ParsedPropertyBase(),
       ParameterUser("ParsedConductivity")
   {
-    if( !input.have_variable("Materials/Conductivity/k") )
-      {
-        libmesh_error_msg("ERROR: No conductivity has been specified!");
-      }
-    else
-      {
-        std::string conductivity_function = input("Materials/Conductivity/k",std::string("0"));
-
-        if( !this->check_func_nonzero(conductivity_function) )
-          {
-            libmesh_error_msg("ERROR: Detected '0' function for ParsedConductivity!");
-          }
-
-        this->_func.reset(new libMesh::ParsedFunction<libMesh::Number>(conductivity_function));
-      }
+    this->set_parameter(this->_func, input,
+                        "Materials/Conductivity/k",
+                        "DIE!");
   }
 
   ParsedConductivity::~ParsedConductivity()

--- a/src/properties/src/parsed_viscosity.C
+++ b/src/properties/src/parsed_viscosity.C
@@ -28,31 +28,18 @@
 
 // libMesh
 #include "libmesh/getpot.h"
-#include "libmesh/parsed_function.h"
 
 namespace GRINS
 {
 
-   ParsedViscosity::ParsedViscosity( const GetPot& input )
-     : ParsedPropertyBase(),
-       ParameterUser("ParsedViscosity")
-   {
-     if( !input.have_variable("Materials/Viscosity/mu") )
-       {
-         libmesh_error_msg("ERROR: No viscosity has been specified!");
-       }
-     else
-       {
-         std::string viscosity_function = input("Materials/Viscosity/mu",std::string("0"));
-
-         this->_func.reset(new libMesh::ParsedFunction<libMesh::Number>(viscosity_function));
-
-         if( !this->check_func_nonzero(viscosity_function) )
-           {
-             libmesh_error_msg("ERROR: Detected '0' function for ParsedConductivity!");
-           }
-       }
-   }
+  ParsedViscosity::ParsedViscosity( const GetPot& input )
+    : ParsedPropertyBase(),
+      ParameterUser("ParsedViscosity")
+  {
+    this->set_parameter(this->_func, input,
+                        "Materials/Viscosity/mu",
+                        "DIE!");
+  }
 
   ParsedViscosity::~ParsedViscosity()
   {

--- a/src/qoi/src/average_nusselt_number.C
+++ b/src/qoi/src/average_nusselt_number.C
@@ -50,7 +50,10 @@ namespace GRINS
 
   QoIBase* AverageNusseltNumber::clone() const
   {
-    return new AverageNusseltNumber( *this );
+    AverageNusseltNumber *returnval = new AverageNusseltNumber( *this );
+    returnval->move_parameter(_k, returnval->_k);
+    returnval->move_parameter(_scaling, returnval->_scaling);
+    return returnval;
   }
 
   void AverageNusseltNumber::init

--- a/src/qoi/src/parsed_boundary_qoi.C
+++ b/src/qoi/src/parsed_boundary_qoi.C
@@ -43,10 +43,17 @@ namespace GRINS
     : QoIBase(qoi_name) {}
 
   ParsedBoundaryQoI::ParsedBoundaryQoI( const ParsedBoundaryQoI& original )
-    : QoIBase(original.name())
+    : QoIBase(original)
   {
     if (original.qoi_functional.get())
-      this->qoi_functional = original.qoi_functional->clone();
+      {
+        this->qoi_functional = original.qoi_functional->clone();
+        this->move_parameter
+          (*libMesh::libmesh_cast_ptr<libMesh::ParsedFEMFunction<libMesh::Number>*>
+             (original.qoi_functional.get()),
+           *libMesh::libmesh_cast_ptr<libMesh::ParsedFEMFunction<libMesh::Number>*>
+             (this->qoi_functional.get()));
+      }
 
     this->_bc_ids = original._bc_ids;
   }

--- a/src/qoi/src/parsed_boundary_qoi.C
+++ b/src/qoi/src/parsed_boundary_qoi.C
@@ -78,16 +78,13 @@ namespace GRINS
         _bc_ids.insert( input("QoI/ParsedBoundary/bc_ids", -1, i ) );
       }
 
-    std::string qoi_functional_string =
-      input("QoI/ParsedBoundary/qoi_functional", std::string("0"));
-
-    if (qoi_functional_string == "0")
-      libmesh_error_msg("Error! Zero ParsedBoundaryQoI specified!" <<
-                        std::endl);
-
-    this->qoi_functional.reset
+    libMesh::ParsedFEMFunction<libMesh::Number> *qf
       (new libMesh::ParsedFEMFunction<libMesh::Number>
-       (system, qoi_functional_string));
+         (system, ""));
+    this->qoi_functional.reset(qf);
+
+    this->set_parameter(*qf, input,
+                        "QoI/ParsedBoundary/qoi_functional", "DIE!");
   }
 
   void ParsedBoundaryQoI::init_context( AssemblyContext& context )

--- a/src/qoi/src/parsed_interior_qoi.C
+++ b/src/qoi/src/parsed_interior_qoi.C
@@ -61,16 +61,13 @@ namespace GRINS
      const MultiphysicsSystem& system,
      unsigned int /*qoi_num*/ )
   {
-    std::string qoi_functional_string =
-      input("QoI/ParsedInterior/qoi_functional", std::string("0"));
-
-    if (qoi_functional_string == "0")
-      libmesh_error_msg("Error! Zero ParsedInteriorQoI specified!" <<
-                        std::endl);
-
-    this->qoi_functional.reset
+    libMesh::ParsedFEMFunction<libMesh::Number> *qf
       (new libMesh::ParsedFEMFunction<libMesh::Number>
-       (system, qoi_functional_string));
+         (system, ""));
+    this->qoi_functional.reset(qf);
+
+    this->set_parameter(*qf, input,
+                        "QoI/ParsedInterior/qoi_functional", "DIE!");
   }
 
   void ParsedInteriorQoI::init_context( AssemblyContext& context )

--- a/src/qoi/src/parsed_interior_qoi.C
+++ b/src/qoi/src/parsed_interior_qoi.C
@@ -43,10 +43,17 @@ namespace GRINS
     : QoIBase(qoi_name) {}
 
   ParsedInteriorQoI::ParsedInteriorQoI( const ParsedInteriorQoI& original )
-    : QoIBase(original.name())
+    : QoIBase(original)
   {
     if (original.qoi_functional.get())
-      this->qoi_functional = original.qoi_functional->clone();
+      {
+        this->qoi_functional = original.qoi_functional->clone();
+        this->move_parameter
+          (*libMesh::libmesh_cast_ptr<libMesh::ParsedFEMFunction<libMesh::Number>*>
+             (original.qoi_functional.get()),
+           *libMesh::libmesh_cast_ptr<libMesh::ParsedFEMFunction<libMesh::Number>*>
+             (this->qoi_functional.get()));
+      }
   }
 
   ParsedInteriorQoI::~ParsedInteriorQoI() {}

--- a/src/solver/include/grins/parameter_user.h
+++ b/src/solver/include/grins/parameter_user.h
@@ -103,7 +103,10 @@ namespace GRINS
         const std::string & func_param_name,
         const std::string & param_default);
 
-    // FIXME: add set_parameter for vectors
+    //! A parseable function string with LIBMESH_DIM components, all 0
+    static std::string zero_vector_function;
+
+    // FIXME: add set_parameter overloads for vectors
 
     //! Each subclass will register its copy of an independent
     //  variable when the library makes this call.

--- a/src/solver/include/grins/parameter_user.h
+++ b/src/solver/include/grins/parameter_user.h
@@ -74,7 +74,7 @@ namespace GRINS
     virtual ~ParameterUser() {}
 
     //! Each subclass can simultaneously read a parameter value from
-    //file and prepare it for registration with this call.
+    // file and prepare it for registration with this call.
     virtual void set_parameter
       ( libMesh::Number & param_variable,
         const GetPot & input,
@@ -82,7 +82,10 @@ namespace GRINS
         libMesh::Number param_default );
 
     //! Each subclass can simultaneously read a parsed function from
-    //file and prepare its inline variables for registration with this call.
+    // file and prepare its inline variables for registration with this call.
+    //
+    // Pass a default value of "DIE!" to assert that the input file
+    // contains a value for this parameter.
     virtual void set_parameter
       ( libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> & func,
         const GetPot & input,
@@ -90,7 +93,10 @@ namespace GRINS
         const std::string & param_default);
 
     //! Each subclass can simultaneously read a parsed function from
-    //file and prepare its inline variables for registration with this call.
+    // file and prepare its inline variables for registration with this call.
+    //
+    // Pass a default value of "DIE!" to assert that the input file
+    // contains a value for this parameter.
     virtual void set_parameter
       ( libMesh::ParsedFEMFunction<libMesh::Number> & func,
         const GetPot & input,

--- a/src/solver/include/grins/parameter_user.h
+++ b/src/solver/include/grins/parameter_user.h
@@ -86,14 +86,16 @@ namespace GRINS
     virtual void set_parameter
       ( libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> & func,
         const GetPot & input,
-        const std::string & func_param_name);
+        const std::string & func_param_name,
+        const std::string & param_default);
 
     //! Each subclass can simultaneously read a parsed function from
     //file and prepare its inline variables for registration with this call.
     virtual void set_parameter
       ( libMesh::ParsedFEMFunction<libMesh::Number> & func,
         const GetPot & input,
-        const std::string & func_param_name);
+        const std::string & func_param_name,
+        const std::string & param_default);
 
     // FIXME: add set_parameter for vectors
 

--- a/src/solver/include/grins/parameter_user.h
+++ b/src/solver/include/grins/parameter_user.h
@@ -34,6 +34,7 @@
 
 //libMesh
 #include "libmesh/libmesh.h"
+#include "libmesh/vector_value.h" // forward declare Gradient instead?
 
 //C++
 #include <map>
@@ -45,6 +46,12 @@ namespace libMesh
 {
   template <typename Scalar>
   class ParameterMultiAccessor;
+
+  template <typename Output, typename OutputGradient>
+  class ParsedFunction;
+
+  template <typename Output>
+  class ParsedFEMFunction;
 }
 
 //! GRINS namespace
@@ -74,12 +81,25 @@ namespace GRINS
         const std::string & param_name,
         libMesh::Number param_default );
 
+    //! Each subclass can simultaneously read a parsed function from
+    //file and prepare its inline variables for registration with this call.
+    virtual void set_parameter
+      ( libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> & func,
+        const GetPot & input,
+        const std::string & func_param_name);
+
+    //! Each subclass can simultaneously read a parsed function from
+    //file and prepare its inline variables for registration with this call.
+    virtual void set_parameter
+      ( libMesh::ParsedFEMFunction<libMesh::Number> & func,
+        const GetPot & input,
+        const std::string & func_param_name);
+
     // FIXME: add set_parameter for vectors
 
     //! Each subclass will register its copy of an independent
     //  variable when the library makes this call.
-    //  If the subclass has more than one copy to register, or if the
-    //  subclass needs to register a parameter which was not
+    //  If the subclass needs to register a parameter which was not
     //  previously assigned with set_parameter, then this method will
     //  need to be overridden.
     virtual void register_parameter
@@ -89,6 +109,14 @@ namespace GRINS
 
   private:
     std::map<std::string, libMesh::Number*> _my_parameters;
+
+    std::map<std::string,
+             libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient>*>
+      _my_parsed_functions;
+
+    std::map<std::string,
+             libMesh::ParsedFEMFunction<libMesh::Number>*>
+      _my_parsed_fem_functions;
 
     // This could be more efficient as a reference now, but we'd
     // probably inadvertently break it later.

--- a/src/solver/include/grins/parameter_user.h
+++ b/src/solver/include/grins/parameter_user.h
@@ -103,6 +103,24 @@ namespace GRINS
         const std::string & func_param_name,
         const std::string & param_default);
 
+    //! When cloning an object, we need to update parameter pointers
+    //to point to the clone
+    virtual void move_parameter
+      (const libMesh::Number & old_parameter,
+       libMesh::Number & new_parameter);
+
+    //! When cloning an object, we need to update parameter pointers
+    //to point to the clone
+    virtual void move_parameter
+      (const libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> & old_func,
+       libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> & new_func);
+
+    //! When cloning an object, we need to update parameter pointers
+    //to point to the clone
+    virtual void move_parameter
+      (const libMesh::ParsedFEMFunction<libMesh::Number> & old_func,
+       libMesh::ParsedFEMFunction<libMesh::Number> & new_func);
+
     //! A parseable function string with LIBMESH_DIM components, all 0
     static std::string zero_vector_function;
 

--- a/src/solver/src/parameter_user.C
+++ b/src/solver/src/parameter_user.C
@@ -30,6 +30,8 @@
 #include "libmesh/getpot.h"
 #include "libmesh/parameter_multiaccessor.h"
 #include "libmesh/parameter_pointer.h"
+#include "libmesh/parsed_fem_function.h"
+#include "libmesh/parsed_function.h"
 
 namespace GRINS
 {
@@ -45,6 +47,52 @@ namespace GRINS
       param_name);
 
     _my_parameters[param_name] = &param_variable;
+  }
+
+  void ParameterUser::set_parameter
+    ( libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> & func,
+      const GetPot & input,
+      const std::string & func_param_name)
+  {
+    if( !input.have_variable(func_param_name) )
+      {
+        libMesh::err << "Error: Must specify parsed function for " <<
+                        _my_name << std::endl
+                     << "       Please specify " << func_param_name << std::endl;
+        libmesh_error();
+      }
+
+    static const std::string die("DIE!");
+    func.reparse(input(func_param_name, die));
+
+    libmesh_assert_msg(!_my_parsed_functions.count(func_param_name),
+      "ERROR: " << _my_name << " double-registered parameter " <<
+      func_param_name);
+
+    _my_parsed_functions[func_param_name] = &func;
+  }
+
+  void ParameterUser::set_parameter
+    ( libMesh::ParsedFEMFunction<libMesh::Number> & func,
+      const GetPot & input,
+      const std::string & func_param_name)
+  {
+    if( !input.have_variable(func_param_name) )
+      {
+        libMesh::err << "Error: Must specify parsed (fem) function for " <<
+                        _my_name << std::endl
+                     << "       Please specify " << func_param_name << std::endl;
+        libmesh_error();
+      }
+
+    static const std::string die("DIE!");
+    func.reparse(input(func_param_name, die));
+
+    libmesh_assert_msg(!_my_parsed_fem_functions.count(func_param_name),
+      "ERROR: " << _my_name << " double-registered parameter " <<
+      func_param_name);
+
+    _my_parsed_fem_functions[func_param_name] = &func;
   }
 
   void ParameterUser::register_parameter

--- a/src/solver/src/parameter_user.C
+++ b/src/solver/src/parameter_user.C
@@ -55,7 +55,8 @@ namespace GRINS
       const std::string & func_param_name,
       const std::string & param_default)
   {
-    if( !input.have_variable(func_param_name) )
+    if((param_default == "DIE!") &&
+       (!input.have_variable(func_param_name)))
       {
         libMesh::err << "Error: Must specify parsed function for " <<
                         _my_name << std::endl
@@ -78,7 +79,8 @@ namespace GRINS
       const std::string & func_param_name,
       const std::string & param_default)
   {
-    if( !input.have_variable(func_param_name) )
+    if((param_default == "DIE!") &&
+       (!input.have_variable(func_param_name)))
       {
         libMesh::err << "Error: Must specify parsed (fem) function for " <<
                         _my_name << std::endl

--- a/src/solver/src/parameter_user.C
+++ b/src/solver/src/parameter_user.C
@@ -108,6 +108,63 @@ namespace GRINS
     _my_parsed_fem_functions[func_param_name] = &func;
   }
 
+  void ParameterUser::move_parameter
+    (const libMesh::Number & old_parameter,
+     libMesh::Number & new_parameter)
+    {
+      std::map<std::string, libMesh::Number*>::iterator it =
+              _my_parameters.begin();
+      const std::map<std::string, libMesh::Number*>::iterator end =
+              _my_parameters.end();
+      for (; it != end; ++it)
+        if (it->second == &old_parameter)
+          {
+            it->second = &new_parameter;
+            break;
+          }
+    }
+
+  void ParameterUser::move_parameter
+    (const libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> & old_func,
+     libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> & new_func)
+    {
+      std::map
+        <std::string,
+         libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> *
+        >::iterator it = _my_parsed_functions.begin();
+      const std::map
+        <std::string,
+         libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> *
+        >::iterator end = _my_parsed_functions.end();
+      for (; it != end; ++it)
+        if (it->second == &old_func)
+          {
+            it->second = &new_func;
+            break;
+          }
+    }
+
+  void ParameterUser::move_parameter
+    (const libMesh::ParsedFEMFunction<libMesh::Number> & old_func,
+     libMesh::ParsedFEMFunction<libMesh::Number> & new_func)
+    {
+      std::map
+        <std::string,
+         libMesh::ParsedFEMFunction<libMesh::Number> *
+        >::iterator it = _my_parsed_fem_functions.begin();
+      const std::map
+        <std::string,
+         libMesh::ParsedFEMFunction<libMesh::Number> *
+        >::iterator end = _my_parsed_fem_functions.end();
+      for (; it != end; ++it)
+        if (it->second == &old_func)
+          {
+            it->second = &new_func;
+            break;
+          }
+    }
+
+
   void ParameterUser::register_parameter
     ( const std::string & param_name,
       libMesh::ParameterMultiAccessor<libMesh::Number> & param_pointer )

--- a/src/solver/src/parameter_user.C
+++ b/src/solver/src/parameter_user.C
@@ -35,6 +35,15 @@
 
 namespace GRINS
 {
+#if LIBMESH_DIM == 3
+  std::string ParameterUser::zero_vector_function = std::string("{0}{0}{0}");
+#elif LIBMESH_DIM == 2
+  std::string ParameterUser::zero_vector_function = std::string("{0}{0}");
+#else
+  std::string ParameterUser::zero_vector_function = std::string("{0}");
+#endif
+
+
   void ParameterUser::set_parameter( libMesh::Number & param_variable,
                                      const GetPot& input,
                                      const std::string & param_name,

--- a/src/solver/src/parameter_user.C
+++ b/src/solver/src/parameter_user.C
@@ -52,7 +52,8 @@ namespace GRINS
   void ParameterUser::set_parameter
     ( libMesh::ParsedFunction<libMesh::Number,libMesh::Gradient> & func,
       const GetPot & input,
-      const std::string & func_param_name)
+      const std::string & func_param_name,
+      const std::string & param_default)
   {
     if( !input.have_variable(func_param_name) )
       {
@@ -62,8 +63,7 @@ namespace GRINS
         libmesh_error();
       }
 
-    static const std::string die("DIE!");
-    func.reparse(input(func_param_name, die));
+    func.reparse(input(func_param_name, param_default));
 
     libmesh_assert_msg(!_my_parsed_functions.count(func_param_name),
       "ERROR: " << _my_name << " double-registered parameter " <<
@@ -75,7 +75,8 @@ namespace GRINS
   void ParameterUser::set_parameter
     ( libMesh::ParsedFEMFunction<libMesh::Number> & func,
       const GetPot & input,
-      const std::string & func_param_name)
+      const std::string & func_param_name,
+      const std::string & param_default)
   {
     if( !input.have_variable(func_param_name) )
       {
@@ -85,8 +86,7 @@ namespace GRINS
         libmesh_error();
       }
 
-    static const std::string die("DIE!");
-    func.reparse(input(func_param_name, die));
+    func.reparse(input(func_param_name, param_default));
 
     libmesh_assert_msg(!_my_parsed_fem_functions.count(func_param_name),
       "ERROR: " << _my_name << " double-registered parameter " <<

--- a/test/input_files/parsed_qoi.in.in
+++ b/test/input_files/parsed_qoi.in.in
@@ -83,15 +83,15 @@ pin_location = '2.5 0' # Must be on boundary!
 enabled_qois = 'parsed_interior parsed_boundary weighted_flux'
 
 # All sensitivities should be zero
-adjoint_sensitivity_parameters = 'Physics/IncompressibleNavierStokes/mu Physics/Stokes/rho'
-forward_sensitivity_parameters = 'Physics/IncompressibleNavierStokes/mu Physics/Stokes/rho'
+adjoint_sensitivity_parameters = 'Physics/IncompressibleNavierStokes/mu Physics/Stokes/rho QoI/ParsedBoundary/qoi_functional/a QoI/ParsedInterior/qoi_functional/a'
+forward_sensitivity_parameters = 'Physics/IncompressibleNavierStokes/mu Physics/Stokes/rho QoI/ParsedBoundary/qoi_functional/a QoI/ParsedInterior/qoi_functional/a'
 
 [./ParsedBoundary]
 bc_ids = '3'
-qoi_functional = 'u'
+qoi_functional = 'a:=1;a+u'
 
 [../ParsedInterior]
-qoi_functional = 'u'
+qoi_functional = 'a:=1;a*u'
 
 [../WeightedFlux]
 variables = 'u'


### PR DESCRIPTION
This requires https://github.com/libMesh/libmesh/pull/667

We can now calculate sensitivities WRT inline variables in any parsed functions other than those imposed through boundary conditions.

@nicholasmalaya and @vikramvgarg might find this useful

This incorporates #314; we'll merge those two commits and pull that PR separately first and then rebase this off that; I just wanted to put the code out there for perusal now that it's passing tests with correct results.