### PR TITLE
Adjoint sensitivities include an adjoint solve

### DIFF
--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -535,9 +535,11 @@ namespace GRINS
 
     // First check if the error estimator requires an adjoint solve
     if( error_estimator.find("adjoint") != std::string::npos )
-      {
-        do_adjoint_solve = true;
-      }
+      do_adjoint_solve = true;
+
+    // Next check if parameter sensitivies require an adjoint solve
+    if ( _adjoint_parameters.parameter_vector.size() )
+      do_adjoint_solve = true;
 
     // Now check if the user requested to do an adjoint solve regardless
     /*! \todo This option name WILL change at some point. */


### PR DESCRIPTION
So we shouldn't need to specify do_adjoint_solve manually in the input file before outputting z.