### PR TITLE
Use ParsedFEM- not Parsed-Func in VelocityPenalty

### DIFF
--- a/src/physics/include/grins/velocity_penalty_base.h
+++ b/src/physics/include/grins/velocity_penalty_base.h
@@ -31,7 +31,7 @@
 #include "grins/inc_navier_stokes_base.h"
 
 // libMesh
-#include "libmesh/parsed_function.h"
+#include "libmesh/fem_function_base.h"
 #include "libmesh/getpot.h"
 #include "libmesh/tensor_value.h"
 
@@ -53,21 +53,30 @@ namespace GRINS
     //! Read options from GetPot input file.
     virtual void read_input_options( const GetPot& input );
 
+    // Hack to read ParsedFEMFunction options after System init
+    void set_time_evolving_vars (libMesh::FEMSystem* system);
+
     bool compute_force ( const libMesh::Point& point,
-                         const libMesh::Real time,
+                         const AssemblyContext& context,
                          const libMesh::NumberVectorValue& U,
                          libMesh::NumberVectorValue& F,
                          libMesh::NumberTensorValue *dFdU = NULL);
    
   protected:
 
+    std::string base_physics_name;
+
     bool _quadratic_scaling;
 
-    libMesh::ParsedFunction<libMesh::Number> normal_vector_function;
+    libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
+      normal_vector_function;
 
-    libMesh::ParsedFunction<libMesh::Number> base_velocity_function;
+    libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
+      base_velocity_function;
 
   private:
+
+    const GetPot & _input;
 
     VelocityPenaltyBase();
   };

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -189,7 +189,7 @@ namespace GRINS
         libMesh::NumberTensorValue dFdU;
         libMesh::NumberTensorValue* dFdU_ptr =
           compute_jacobian ? &dFdU : NULL;
-        if (!this->compute_force(u_qpoint[qp], context.time, U, F, dFdU_ptr))
+        if (!this->compute_force(u_qpoint[qp], context, U, F, dFdU_ptr))
           continue;
 
         const libMesh::Real jac = JxW[qp];
@@ -248,37 +248,37 @@ namespace GRINS
 
     if( quantity_index == this->_velocity_penalty_x_index )
       {
-        this->normal_vector_function(point, context.time, output_vec);
+        (*this->normal_vector_function)(context, point, context.time, output_vec);
 
         value = output_vec(0);
       }
     else if( quantity_index == this->_velocity_penalty_y_index )
       {
-        this->normal_vector_function(point, context.time, output_vec);
+        (*this->normal_vector_function)(context, point, context.time, output_vec);
 
         value = output_vec(1);
       }
     else if( quantity_index == this->_velocity_penalty_z_index )
       {
-        this->normal_vector_function(point, context.time, output_vec);
+        (*this->normal_vector_function)(context, point, context.time, output_vec);
 
         value = output_vec(2);
       }
     else if( quantity_index == this->_velocity_penalty_base_x_index )
       {
-        this->base_velocity_function(point, context.time, output_vec);
+        (*this->base_velocity_function)(context, point, context.time, output_vec);
 
         value = output_vec(0);
       }
     else if( quantity_index == this->_velocity_penalty_base_y_index )
       {
-        this->base_velocity_function(point, context.time, output_vec);
+        (*this->base_velocity_function)(context, point, context.time, output_vec);
 
         value = output_vec(1);
       }
     else if( quantity_index == this->_velocity_penalty_base_z_index )
       {
-        this->base_velocity_function(point, context.time, output_vec);
+        (*this->base_velocity_function)(context, point, context.time, output_vec);
 
         value = output_vec(2);
       }

--- a/src/physics/src/velocity_penalty_adjoint_stab.C
+++ b/src/physics/src/velocity_penalty_adjoint_stab.C
@@ -171,7 +171,7 @@ namespace GRINS
         libMesh::NumberTensorValue dFdU;
         libMesh::NumberTensorValue* dFdU_ptr =
           compute_jacobian ? &dFdU : NULL;
-        if (!this->compute_force(u_qpoint[qp], context.time, U, F, dFdU_ptr))
+        if (!this->compute_force(u_qpoint[qp], context, U, F, dFdU_ptr))
           continue;
 
         for (unsigned int i=0; i != n_u_dofs; i++)
@@ -324,7 +324,7 @@ namespace GRINS
         libMesh::NumberTensorValue dFdU;
         libMesh::NumberTensorValue* dFdU_ptr =
           compute_jacobian ? &dFdU : NULL;
-        if (!this->compute_force(u_qpoint[qp], context.time, U, F, dFdU_ptr))
+        if (!this->compute_force(u_qpoint[qp], context, U, F, dFdU_ptr))
           continue;
 
         // First, an i-loop over the velocity degrees of freedom.


### PR DESCRIPTION
This may be necessary for some of @nicholasmalaya 's experiments.

This passes our VelocityPenalty regression tests but probably shouldn't be merged until Nick has time to play with it.