### PR TITLE
Adjoint refinement options input

### DIFF
--- a/src/error_estimation/src/error_estimation_factory.C
+++ b/src/error_estimation/src/error_estimation_factory.C
@@ -109,7 +109,7 @@ namespace GRINS
           adjoint_error_estimator->qoi_set() = qoi_set;
 
           adjoint_error_estimator->number_h_refinements = input( "MeshAdaptivity/arefee_h_refs", 1 );
-          adjoint_error_estimator->number_p_refinements = input( "MeshAdaptivity/arefee_h_refs", 0 );
+          adjoint_error_estimator->number_p_refinements = input( "MeshAdaptivity/arefee_p_refs", 0 );
         }
         break;
 

--- a/src/error_estimation/src/error_estimation_factory.C
+++ b/src/error_estimation/src/error_estimation_factory.C
@@ -108,8 +108,8 @@ namespace GRINS
 
           adjoint_error_estimator->qoi_set() = qoi_set;
 
-          adjoint_error_estimator->number_h_refinements = input( "MeshAdaptivity/arefee_h_refs", 1 );
-          adjoint_error_estimator->number_p_refinements = input( "MeshAdaptivity/arefee_p_refs", 0 );
+          adjoint_error_estimator->number_h_refinements = input( "MeshAdaptivity/n_adjoint_h_refinements", 1 );
+          adjoint_error_estimator->number_p_refinements = input( "MeshAdaptivity/n_adjoint_p_refinements", 0 );
         }
         break;
 

--- a/src/error_estimation/src/error_estimation_factory.C
+++ b/src/error_estimation/src/error_estimation_factory.C
@@ -46,7 +46,7 @@ namespace GRINS
     return;
   }
 
-  std::tr1::shared_ptr<libMesh::ErrorEstimator> ErrorEstimatorFactory::build( const GetPot& input, 
+  std::tr1::shared_ptr<libMesh::ErrorEstimator> ErrorEstimatorFactory::build( const GetPot& input,
                                                                               const libMesh::QoISet& qoi_set )
   {
     std::string estimator_type = input("MeshAdaptivity/estimator_type", "patch_recovery");
@@ -54,31 +54,31 @@ namespace GRINS
     ErrorEstimatorEnum estimator_enum = this->string_to_enum( estimator_type );
 
     std::tr1::shared_ptr<libMesh::ErrorEstimator> error_estimator;
-    
+
     switch( estimator_enum )
       {
       case(ADJOINT_RESIDUAL):
         {
           error_estimator.reset( new libMesh::AdjointResidualErrorEstimator );
-    
+
           libMesh::AdjointResidualErrorEstimator*
             adjoint_error_estimator =
               libMesh::libmesh_cast_ptr<libMesh::AdjointResidualErrorEstimator*>
                 ( error_estimator.get() );
-          
+
           adjoint_error_estimator->qoi_set() = qoi_set;
 
           libMesh::PatchRecoveryErrorEstimator *p1 = new libMesh::PatchRecoveryErrorEstimator;
           adjoint_error_estimator->primal_error_estimator().reset( p1 );
-      
+
           libMesh::PatchRecoveryErrorEstimator *p2 = new libMesh::PatchRecoveryErrorEstimator;
-          adjoint_error_estimator->dual_error_estimator().reset( p2 );   
-      
+          adjoint_error_estimator->dual_error_estimator().reset( p2 );
+
           bool patch_reuse = input( "MeshAdaptivity/patch_reuse", false );
           adjoint_error_estimator->primal_error_estimator()->error_norm.set_type
             ( 0, libMesh::H1_SEMINORM );
           p1->set_patch_reuse( patch_reuse );
-      
+
           adjoint_error_estimator->dual_error_estimator()->error_norm.set_type
             ( 0, libMesh::H1_SEMINORM );
           p2->set_patch_reuse( patch_reuse );
@@ -108,8 +108,8 @@ namespace GRINS
 
           adjoint_error_estimator->qoi_set() = qoi_set;
 
-          adjoint_error_estimator->number_h_refinements = 1;
-          adjoint_error_estimator->number_p_refinements = 0;
+          adjoint_error_estimator->number_h_refinements = input( "MeshAdaptivity/arefee_h_refs", 1 );
+          adjoint_error_estimator->number_p_refinements = input( "MeshAdaptivity/arefee_h_refs", 0 );
         }
         break;
 
@@ -127,7 +127,7 @@ namespace GRINS
         }
 
       } // switch( estimator_enum )
-    
+
     return error_estimator;
   }
 

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -72,6 +72,7 @@ namespace GRINS
     libMesh::Real _refine_fraction;
     libMesh::Real _coarsen_fraction;
     libMesh::Real _coarsen_threshold;
+    bool compute_QoI_error_estimate;
     bool _plot_cell_errors;
     std::string _error_plot_prefix;
 

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -72,7 +72,7 @@ namespace GRINS
     libMesh::Real _refine_fraction;
     libMesh::Real _coarsen_fraction;
     libMesh::Real _coarsen_threshold;
-    bool _compute_QoI_error_estimate;
+    bool _compute_qoi_error_estimate;
     bool _plot_cell_errors;
     std::string _error_plot_prefix;
 

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -72,7 +72,7 @@ namespace GRINS
     libMesh::Real _refine_fraction;
     libMesh::Real _coarsen_fraction;
     libMesh::Real _coarsen_threshold;
-    bool compute_QoI_error_estimate;
+    bool _compute_QoI_error_estimate;
     bool _plot_cell_errors;
     std::string _error_plot_prefix;
 

--- a/src/solver/include/grins/steady_mesh_adaptive_solver.h
+++ b/src/solver/include/grins/steady_mesh_adaptive_solver.h
@@ -60,6 +60,8 @@ namespace GRINS
 
     virtual void init_time_solver( MultiphysicsSystem* system );
 
+    void check_qoi_error_option_consistency( SolverContext& context );
+
   };
 
 } // end namespace GRINS

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -45,6 +45,7 @@ namespace GRINS
       _refine_fraction( input("MeshAdaptivity/refine_percentage", 0.2) ),
       _coarsen_fraction( input("MeshAdaptivity/coarsen_percentage", 0.2) ),
       _coarsen_threshold( input("MeshAdaptivity/coarsen_threshold", 0) ),
+      compute_QoI_error_estimate( input("MeshAdaptivity/compute_QoI_error_estimate", false)),
       _plot_cell_errors( input("MeshAdaptivity/plot_cell_errors", false) ),
       _error_plot_prefix( input("MeshAdaptivity/error_plot_prefix", "cell_error") ),
       _node_level_mismatch_limit( input("MeshAdaptivity/node_level_mismatch_limit", 0) ),
@@ -58,7 +59,7 @@ namespace GRINS
 
     return;
   }
-  
+
   MeshAdaptiveSolverBase::~MeshAdaptiveSolverBase()
   {
     return;
@@ -71,27 +72,27 @@ namespace GRINS
     _mesh_refinement->absolute_global_tolerance() = _absolute_global_tolerance;
     _mesh_refinement->nelem_target() = _nelem_target;
     _mesh_refinement->refine_fraction() = _refine_fraction;
-    _mesh_refinement->coarsen_fraction() = _coarsen_fraction;  
+    _mesh_refinement->coarsen_fraction() = _coarsen_fraction;
     _mesh_refinement->coarsen_threshold() = _coarsen_threshold;
     _mesh_refinement->node_level_mismatch_limit() = _node_level_mismatch_limit;
     _mesh_refinement->edge_level_mismatch_limit() = _edge_level_mismatch_limit;
     _mesh_refinement->face_level_mismatch_limit() = _face_level_mismatch_limit;
     _mesh_refinement->set_enforce_mismatch_limit_prior_to_refinement(_enforce_mismatch_limit_prior_to_refinement);
 
-    return; 
+    return;
   }
 
   void MeshAdaptiveSolverBase::set_refinement_type( const GetPot& input,
                                                     MeshAdaptiveSolverBase::RefinementFlaggingType& refinement_type )
   {
-    std::string refinement_stategy = input("MeshAdaptivity/refinement_strategy", "elem_fraction" ); 
+    std::string refinement_stategy = input("MeshAdaptivity/refinement_strategy", "elem_fraction" );
 
     if( !input.have_variable("MeshAdaptivity/absolute_global_tolerance" ) )
       {
         std::cerr << "Error: Must specify absolute_global_tolerance for" << std::endl
                   << "       adaptive refinement algorithms."
                   << std::endl;
-        
+
         libmesh_error();
       }
 
@@ -113,7 +114,7 @@ namespace GRINS
             libmesh_error();
           }
       }
-    
+
     else if( refinement_stategy == std::string("error_fraction") )
       {
         refinement_type = ERROR_FRACTION;
@@ -173,7 +174,7 @@ namespace GRINS
 
     return converged;
   }
-  
+
   void MeshAdaptiveSolverBase::flag_elements_for_refinement( const libMesh::ErrorVector& error )
   {
     switch(_refinement_type)
@@ -189,13 +190,13 @@ namespace GRINS
           _mesh_refinement->flag_elements_by_nelem_target( error );
         }
         break;
-        
+
       case( ERROR_FRACTION ):
         {
           _mesh_refinement->flag_elements_by_error_fraction( error );
         }
         break;
-        
+
       case( ELEM_FRACTION ):
         {
           _mesh_refinement->flag_elements_by_elem_fraction( error );

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -45,7 +45,7 @@ namespace GRINS
       _refine_fraction( input("MeshAdaptivity/refine_percentage", 0.2) ),
       _coarsen_fraction( input("MeshAdaptivity/coarsen_percentage", 0.2) ),
       _coarsen_threshold( input("MeshAdaptivity/coarsen_threshold", 0) ),
-      compute_QoI_error_estimate( input("MeshAdaptivity/compute_QoI_error_estimate", false)),
+      _compute_QoI_error_estimate( input("MeshAdaptivity/compute_QoI_error_estimate", false)),
       _plot_cell_errors( input("MeshAdaptivity/plot_cell_errors", false) ),
       _error_plot_prefix( input("MeshAdaptivity/error_plot_prefix", "cell_error") ),
       _node_level_mismatch_limit( input("MeshAdaptivity/node_level_mismatch_limit", 0) ),

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -45,7 +45,7 @@ namespace GRINS
       _refine_fraction( input("MeshAdaptivity/refine_percentage", 0.2) ),
       _coarsen_fraction( input("MeshAdaptivity/coarsen_percentage", 0.2) ),
       _coarsen_threshold( input("MeshAdaptivity/coarsen_threshold", 0) ),
-      _compute_QoI_error_estimate( input("MeshAdaptivity/compute_QoI_error_estimate", false)),
+      _compute_qoi_error_estimate( input("MeshAdaptivity/compute_QoI_error_estimate", false)),
       _plot_cell_errors( input("MeshAdaptivity/plot_cell_errors", false) ),
       _error_plot_prefix( input("MeshAdaptivity/error_plot_prefix", "cell_error") ),
       _node_level_mismatch_limit( input("MeshAdaptivity/node_level_mismatch_limit", 0) ),

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -45,7 +45,7 @@ namespace GRINS
       _refine_fraction( input("MeshAdaptivity/refine_percentage", 0.2) ),
       _coarsen_fraction( input("MeshAdaptivity/coarsen_percentage", 0.2) ),
       _coarsen_threshold( input("MeshAdaptivity/coarsen_threshold", 0) ),
-      _compute_qoi_error_estimate( input("MeshAdaptivity/compute_QoI_error_estimate", false)),
+      _compute_qoi_error_estimate( input("MeshAdaptivity/compute_qoi_error_estimate", false)),
       _plot_cell_errors( input("MeshAdaptivity/plot_cell_errors", false) ),
       _error_plot_prefix( input("MeshAdaptivity/error_plot_prefix", "cell_error") ),
       _node_level_mismatch_limit( input("MeshAdaptivity/node_level_mismatch_limit", 0) ),

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -437,7 +437,7 @@ namespace GRINS
     // Most of this was pulled from FIN-S
     if (restart_file != "none")
       {
-        std::cout << " ====== Restarting from " << restart_file << std::endl;      
+        std::cout << " ====== Restarting from " << restart_file << std::endl;
 
         // Must have correct file type to restart
         if (restart_file.rfind(".xdr") < restart_file.size())
@@ -445,7 +445,7 @@ namespace GRINS
                                  //libMesh::EquationSystems::READ_HEADER |  // Allow for thermochemistry upgrades
                                  libMesh::EquationSystems::READ_DATA |
                                  libMesh::EquationSystems::READ_ADDITIONAL_DATA);
-      
+
         else if  (restart_file.rfind(".xda") < restart_file.size())
           _equation_system->read(restart_file,GRINSEnums::READ,
                                  //libMesh::EquationSystems::READ_HEADER |  // Allow for thermochemistry upgrades
@@ -457,10 +457,10 @@ namespace GRINS
             std::cerr << "Error: Restart filename must have .xdr or .xda extension!" << std::endl;
             libmesh_error();
           }
-      
+
         const std::string system_name = input("screen-options/system_name", "GRINS" );
 
-        MultiphysicsSystem& system = 
+        MultiphysicsSystem& system =
           _equation_system->get_system<MultiphysicsSystem>(system_name);
 
         // Update the old data
@@ -534,7 +534,7 @@ namespace GRINS
     bool do_adjoint_solve = false;
 
     // First check if the error estimator requires an adjoint solve
-    if( error_estimator.find("adjoint") != std::string::npos )
+    if( error_estimator.find("adjoint") != std::string::npos || error_estimator.find("ADJOINT") != std::string::npos )
       do_adjoint_solve = true;
 
     // Next check if parameter sensitivies require an adjoint solve

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -63,7 +63,7 @@ namespace GRINS
   {
     // If we are computing QoI error estimates, we have to be using
     // the Adjoint Refinement Error Estimator
-    if( this->_compute_QoI_error_estimate )
+    if( this->_compute_qoi_error_estimate )
       if(context.error_estimator->type() != libMesh::ADJOINT_REFINEMENT)
       {
 	std::string error_message = "You asked for QoI error estimates but did not use an Adjoint Refinement Error Estimator!\n";
@@ -130,7 +130,7 @@ namespace GRINS
           }
 
 	// Get the global error estimate if you can and are asked to
-	if( this->_compute_QoI_error_estimate )
+	if( this->_compute_qoi_error_estimate )
 	  for(unsigned int i = 0; i != context.system->qoi.size(); i++)
 	  {
 	    libMesh::AdjointRefinementEstimator* adjoint_ref_error_estimator = libMesh::libmesh_cast_ptr<libMesh::AdjointRefinementEstimator*>( context.error_estimator.get() );


### PR DESCRIPTION
Changes to allow user to request an Adjoint Refinement Error Estimate for a QoI. 

Passes make check and tested with parsed laplace regression. Core capability verified earlier in libMesh.