### PR TITLE
Fixes for libMesh/libmesh#701

### DIFF
--- a/src/physics/src/elastic_cable.C
+++ b/src/physics/src/elastic_cable.C
@@ -39,6 +39,7 @@
 #include "libmesh/boundary_info.h"
 #include "libmesh/fem_system.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/elem.h"
 
 namespace GRINS
 {

--- a/src/physics/src/elastic_membrane.C
+++ b/src/physics/src/elastic_membrane.C
@@ -40,6 +40,7 @@
 #include "libmesh/boundary_info.h"
 #include "libmesh/fem_system.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/elem.h"
 
 namespace GRINS
 {

--- a/src/qoi/src/vorticity.C
+++ b/src/qoi/src/vorticity.C
@@ -35,6 +35,7 @@
 #include "libmesh/fem_system.h"
 #include "libmesh/quadrature.h"
 #include "libmesh/fe_base.h"
+#include "libmesh/elem.h"
 
 namespace GRINS
 {

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -38,7 +38,7 @@
 #include "libmesh/parallel_mesh.h"
 #include "libmesh/parsed_function.h"
 #include "libmesh/serial_mesh.h"
-
+#include "libmesh/elem.h"
 
 namespace GRINS
 {

--- a/src/solver/src/parameter_user.C
+++ b/src/solver/src/parameter_user.C
@@ -35,6 +35,7 @@
 #include "libmesh/parsed_function.h"
 #include "libmesh/parsed_function_parameter.h"
 
+
 namespace GRINS
 {
 #if LIBMESH_DIM == 3

--- a/src/utilities/include/grins/distance_function.h
+++ b/src/utilities/include/grins/distance_function.h
@@ -36,13 +36,13 @@
 #include "libmesh/dense_matrix.h"
 #include "libmesh/fe_base.h"
 #include "libmesh/system.h"
+#include "libmesh/elem.h"
 
 // Forward Declarations
 namespace libMesh {
   class EquationSystems;
   class BoundaryMesh;
   class Node;
-  class Elem;
 }
 
 


### PR DESCRIPTION
cppclean was run on the libMesh tree and we needed to add a few
missing headers as a result.