### PR TITLE
Make Boost Optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,7 +136,7 @@ dnl----------------
 dnl Check for boost
 dnl----------------
 BOOST_REQUIRE([1.39.0])
-
+BOOST_FIND_HEADER([boost/shared_ptr.hpp])
 
 dnl-------------------------------------
 dnl Check for GNU Linear Programming kit

--- a/configure.ac
+++ b/configure.ac
@@ -132,11 +132,49 @@ dnl----------------
 dnl### AX_PATH_GSL(1.10,AM_CONDITIONAL([UQBT_GSL], [test 'TRUE']),AC_MSG_ERROR([Could not find required GSL version.]))
 dnl AC_CACHE_SAVE
 
-dnl----------------
-dnl Check for boost
-dnl----------------
-BOOST_REQUIRE([1.39.0])
-BOOST_FIND_HEADER([boost/shared_ptr.hpp])
+
+dnl------------------------------------------
+dnl Check if libMesh detected std::shared_ptr
+dnl------------------------------------------
+AC_MSG_CHECKING([for C++11 std::shared_ptr support from libMesh])
+grins_save_CPPFLAGS=$CPPFLAGS
+CPPFLAGS="$LIBMESH_CPPFLAGS $CPPFLAGS"
+libmesh_have_cxx11_shared_ptr=no
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+                                      @%:@include <libmesh/libmesh_config.h>
+                                   ]],
+                                   [[
+                                      #if LIBMESH_HAVE_CXX11_SHARED_PTR
+                                      #else
+                                      #error "libMesh shared_ptr support not found!"
+                                      #endif
+                                   ]])
+                  ],
+                                   [
+                libmesh_have_cxx11_shared_ptr=yes
+                AC_MSG_RESULT(yes)
+            ],[
+                libmesh_have_cxx11_shared_ptr=no
+                AC_MSG_RESULT(no)
+])
+CPPFLAGS=$grins_save_CPPFLAGS
+
+dnl----------------------------------------------------------
+dnl Check for boost, only if libMesh didn't detect shared_ptr
+dnl----------------------------------------------------------
+if test "x$libmesh_have_cxx11_shared_ptr" != xyes; then
+   AC_MSG_WARN([libMesh did not detect std::shared_ptr, now searching for Boost for shared_ptr support!])
+   BOOST_REQUIRE([1.39.0])
+   BOOST_FIND_HEADER([boost/shared_ptr.hpp])
+
+   dnl If we made it this far, we found boost
+   dnl But the boost.m4 doesn't AC_SUBST(HAVE_BOOST)
+   dnl so we do it here so we can report in config_summary.m4
+   AC_SUBST(HAVE_BOOST,[1])
+else
+   dnl We didn't need Boost so we're not using it
+   AC_SUBST(HAVE_BOOST,[0])
+fi
 
 dnl-------------------------------------
 dnl Check for GNU Linear Programming kit

--- a/examples/cavity_benchmark/cavity.C
+++ b/examples/cavity_benchmark/cavity.C
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
     {
       // Asssign initial temperature value
       std::string system_name = libMesh_inputfile( "screen-options/system_name", "GRINS" );
-      std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
       const libMesh::System& system = es->get_system(system_name);
       
       libMesh::Parameters &params = es->parameters;

--- a/examples/inflating_sheet/inflating_sheet.C
+++ b/examples/inflating_sheet/inflating_sheet.C
@@ -73,9 +73,9 @@ int main(int argc, char* argv[])
       
       GRINS::SimulationBuilder sim_builder;
 
-std::tr1::shared_ptr<GRINS::InflatingSheetSolverFactory> sheet_factory( new GRINS::InflatingSheetSolverFactory );
+      GRINS::SharedPtr<GRINS::SolverFactory> sheet_factory( new GRINS::InflatingSheetSolverFactory );
 
-sim_builder.attach_solver_factory( sheet_factory );
+      sim_builder.attach_solver_factory( sheet_factory );
 
       GRINS::Simulation grins( libMesh_inputfile,
                                sim_builder,

--- a/examples/inflating_sheet/inflating_sheet_solver_factory.C
+++ b/examples/inflating_sheet/inflating_sheet_solver_factory.C
@@ -33,11 +33,11 @@
 
 namespace GRINS
 {
-  std::tr1::shared_ptr<Solver> InflatingSheetSolverFactory::build(const GetPot& input)
+  GRINS::SharedPtr<Solver> InflatingSheetSolverFactory::build(const GetPot& input)
   {
     std::string solver_type = input("SolverOptions/solver_type", "DIE!");
-    
-    std::tr1::shared_ptr<Solver> solver;  // Effectively NULL
+
+    GRINS::SharedPtr<Solver> solver;  // Effectively NULL
 
     if( solver_type == std::string("pressure_continuation") )
       {

--- a/examples/inflating_sheet/inflating_sheet_solver_factory.h
+++ b/examples/inflating_sheet/inflating_sheet_solver_factory.h
@@ -38,7 +38,7 @@ namespace GRINS
     InflatingSheetSolverFactory(){};
     virtual ~InflatingSheetSolverFactory(){};
 
-    virtual std::tr1::shared_ptr<GRINS::Solver> build(const GetPot& input);
+    virtual GRINS::SharedPtr<GRINS::Solver> build(const GetPot& input);
   };
 
 } // end namespace GRINS

--- a/examples/inflating_sheet/pressure_continuation_solver.C
+++ b/examples/inflating_sheet/pressure_continuation_solver.C
@@ -104,7 +104,7 @@ namespace GRINS
                                                        libMesh::Real pressure )
   {
     // Get Physics class and cast
-    std::tr1::shared_ptr<GRINS::Physics> raw_physics = system.get_physics(elastic_membrane_constant_pressure);
+    GRINS::SharedPtr<GRINS::Physics> raw_physics = system.get_physics(elastic_membrane_constant_pressure);
     ElasticMembraneConstantPressure& physics = libMesh::cast_ref<ElasticMembraneConstantPressure&>( *(raw_physics.get()) );
 
     physics.reset_pressure(pressure);

--- a/examples/laminar_flame/bunsen.C
+++ b/examples/laminar_flame/bunsen.C
@@ -119,10 +119,10 @@ int main(int argc, char* argv[])
  
   GRINS::SimulationBuilder sim_builder;
 
-  std::tr1::shared_ptr<BunsenBCFactory> bc_factory( new BunsenBCFactory );
+  GRINS::SharedPtr<GRINS::BoundaryConditionsFactory> bc_factory( new BunsenBCFactory );
   sim_builder.attach_bc_factory( bc_factory );
 
-  std::tr1::shared_ptr<GRINS::PhysicsFactory> physics_factory( new BunsenPhysicsFactory );
+  GRINS::SharedPtr<GRINS::PhysicsFactory> physics_factory( new BunsenPhysicsFactory );
   sim_builder.attach_physics_factory( physics_factory );
 
   GRINS::Simulation grins( libMesh_inputfile,
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
     {
       // Asssign initial temperature value
       std::string system_name = libMesh_inputfile( "screen-options/system_name", "GRINS" );
-      std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
       const libMesh::System& system = es->get_system(system_name);
       
       libMesh::Parameters &params = es->parameters;
@@ -201,12 +201,12 @@ int main(int argc, char* argv[])
       
       GRINS::Simulation restart_sim( restart_input,
 				     sim_builder );
-      std::tr1::shared_ptr<libMesh::EquationSystems> restart_es = restart_sim.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> restart_es = restart_sim.get_equation_system();
       libMesh::System& restart_system = restart_es->get_system(system_name);
       GRINS::MultiphysicsSystem& restart_ms_system = libMesh::libmesh_cast_ref<GRINS::MultiphysicsSystem&>( restart_system );
       */
 
-      std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
       libMesh::System& system = es->get_system(system_name);
       GRINS::MultiphysicsSystem& ms_system =
         libMesh::libmesh_cast_ref<GRINS::MultiphysicsSystem&>( system );
@@ -337,7 +337,7 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > BunsenBCFactory::build_
     const libMesh::Real factor = 1.0;
     const libMesh::Real r0 = 0.002;
 
-    std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+    GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> >
       vel_func( new GRINS::ConstantWithExponentialLayer( u0, factor, r0, delta ) );
     
     cont.set_func( vel_func );
@@ -348,8 +348,8 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > BunsenBCFactory::build_
     cont2.add_var_name( "u" );
     cont2.add_bc_id( 1 );
     cont2.add_bc_id( 3 );
-    
-    std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+
+    GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> >
       vel_func( new libMesh::ZeroFunction<libMesh::Number> );
 
     cont2.set_func( vel_func );
@@ -363,7 +363,7 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > BunsenBCFactory::build_
     const libMesh::Real factor = -1.0;
     const libMesh::Real r0 = 0.0025;
 
-    std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+    GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> >
       vel_func( new GRINS::ConstantWithExponentialLayer( u0, factor, r0, delta ) );
     
     cont3.set_func( vel_func );
@@ -386,8 +386,8 @@ void BunsenPhysicsFactory::add_physics( const GetPot& input,
 {
   if( physics_to_add == "BunsenSource" )
     {
-      physics_list[physics_to_add] = 
-	std::tr1::shared_ptr<GRINS::Physics>( new Bunsen::BunsenSource(physics_to_add,input) );
+      physics_list[physics_to_add] =
+	GRINS::SharedPtr<GRINS::Physics>( new Bunsen::BunsenSource(physics_to_add,input) );
     }
   else
     {

--- a/examples/laminar_flame/ignite_initial_guess.h
+++ b/examples/laminar_flame/ignite_initial_guess.h
@@ -82,7 +82,7 @@ namespace Bunsen
   protected:
 
     GRINS::MultiphysicsSystem& _restart_system;
-    std::tr1::shared_ptr<libMesh::FEMContext> _restart_context;
+    GRINS::SharedPtr<libMesh::FEMContext> _restart_context;
 
     //! Map from init system variable number to restart system variable number
     std::map<GRINS::VariableIndex,GRINS::VariableIndex> _var_map;

--- a/examples/mass_injection/injection.C
+++ b/examples/mass_injection/injection.C
@@ -88,7 +88,7 @@ int main(int argc, char* argv[])
  
   GRINS::SimulationBuilder sim_builder;
 
-  std::tr1::shared_ptr<InjectionBCFactory> bc_factory( new InjectionBCFactory );
+  GRINS::SharedPtr<GRINS::BoundaryConditionsFactory> bc_factory( new InjectionBCFactory );
 
   sim_builder.attach_bc_factory( bc_factory );
 
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
     {
       // Asssign initial temperature value
       std::string system_name = libMesh_inputfile( "screen-options/system_name", "GRINS" );
-      std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
       const libMesh::System& system = es->get_system(system_name);
       
       libMesh::Parameters &params = es->parameters;
@@ -178,9 +178,9 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > InjectionBCFactory::bui
   const libMesh::Real factor = 6.0*mdot/(l*l)/rho;
 
   std::cout << "factor = " << factor << std::endl;
-  
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > vel_func( new GRINS::ParabolicProfile( -factor, 0.0, 0.0, 0.0, 0.0, factor*l*l/4.0 ) );
-    
+
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> > vel_func( new GRINS::ParabolicProfile( -factor, 0.0, 0.0, 0.0, 0.0, factor*l*l/4.0 ) );
+
   cont.set_func( vel_func );
 
 
@@ -188,7 +188,7 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > InjectionBCFactory::bui
   cont2.add_var_name( "u" );
   cont2.add_bc_id( 1 );
 
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> >
     vel_func2( new libMesh::ZeroFunction<libMesh::Number> );
 
   cont2.set_func( vel_func2 );

--- a/examples/rayleigh_taylor/rayleigh.C
+++ b/examples/rayleigh_taylor/rayleigh.C
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
     {
       // Asssign initial temperature value
       std::string system_name = libMesh_inputfile( "screen-options/system_name", "GRINS" );
-      std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
       const libMesh::System& system = es->get_system(system_name);
       
       libMesh::Parameters &params = es->parameters;

--- a/examples/suspended_cable/suspended_cable.C
+++ b/examples/suspended_cable/suspended_cable.C
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
 
 	GRINS::SimulationBuilder sim_builder;
 
-//std::tr1::shared_ptr<GRINS::SuspendedCableSolverFactory> cable_factory( new GRINS::SuspendedCableSolverFactory );
+        //GRINS::SharedPtr<GRINS::SuspendedCableSolverFactory> cable_factory( new GRINS::SuspendedCableSolverFactory );
 
 //sim_builder.attach_solver_factory( cable_factory );
 
@@ -87,7 +87,7 @@ int main(int argc, char* argv[])
 						     libmesh_init.comm() );
 
 	std::string system_name = libMesh_inputfile( "screen-options/system_name", "GRINS" );
-	std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+	GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 	const libMesh::System& system = es->get_system(system_name);
 
 	libMesh::Parameters &params = es->parameters;

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -41,11 +41,16 @@ echo libMesh LIBS.................. : $LIBMESH_LIBS
 #echo HDF5.......................... : $HDF5_PREFIX
 #echo GSL........................... : $GSL_PREFIX
 #echo GLPK.......................... : $GLPK_PREFIX
-echo Boost......................... : $BOOST_ROOT
 
 # masa optional check:
 echo
 echo Optional Features:
+if test "x$HAVE_BOOST" = "x1"; then
+  echo '   'Boost......................... : yes
+  echo '     'BOOST_CPPFLAGS.............. : $BOOST_CPPFLAGS
+else
+  echo '   'Boost......................... : no
+fi
 if test "$HAVE_ANTIOCH" = "0"; then
   echo '   'Link with Antioch............. : no
 else

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -51,15 +51,21 @@ if test "x$HAVE_BOOST" = "x1"; then
 else
   echo '   'Boost......................... : no
 fi
-if test "$HAVE_ANTIOCH" = "0"; then
-  echo '   'Link with Antioch............. : no
+if test "x$HAVE_ANTIOCH" = "x1"; then
+  echo '   'Antioch....................... : yes
+  echo '     'ANTIOCH_CPPFLAGS............ : $ANTIOCH_CPPFLAGS
+  echo '     'ANTIOCH_LDFLAGS............. : $ANTIOCH_LDFLAGS
+  echo '     'ANTIOCH_LIBS................ : $ANTIOCH_LIBS
 else
-  echo '   'Link with Antioch............. : $ANTIOCH_PREFIX
+  echo '   'Antioch....................... : no
 fi
-if test "$HAVE_CANTERA" = "0"; then
-  echo '   'Link with Cantera............. : no
+if test "x$HAVE_CANTERA" = "x1"; then
+  echo '   'Cantera....................... : yes
+  echo '     'CANTERA_CPPFLAGS............ : $CANTERA_CPPFLAGS
+  echo '     'CANTERA_LDFLAGS............. : $CANTERA_LDFLAGS
+  echo '     'CANTERA_LIBS................ : $CANTERA_LIBS
 else
-  echo '   'Link with Cantera............. : $CANTERA_PREFIX
+  echo '   'Cantera....................... : no
 fi
 if test "$HAVE_GRVY" = "0"; then
   echo '   'Link with GRVY................ : no

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -416,6 +416,7 @@ include_HEADERS += solver/include/grins/displacement_continuation_solver.h
 # src/utilities headers
 include_HEADERS += $(top_builddir)/src/utilities/include/grins/grins_version.h
 include_HEADERS += utilities/include/grins/grins_enums.h
+include_HEADERS += utilities/include/grins/shared_ptr.h
 include_HEADERS += utilities/include/grins/physical_constants.h
 include_HEADERS += utilities/include/grins/input_utils.h
 include_HEADERS += utilities/include/grins/math_constants.h

--- a/src/bc_handling/include/grins/bc_handling_base.h
+++ b/src/bc_handling/include/grins/bc_handling_base.h
@@ -99,10 +99,10 @@ namespace GRINS
 
     const libMesh::Point& get_neumann_bc_value( GRINS::BoundaryID bc_id ) const;
 
-    std::tr1::shared_ptr< GRINS::NeumannFuncObj > get_neumann_bound_func( GRINS::BoundaryID bc_id,
+    SharedPtr< GRINS::NeumannFuncObj > get_neumann_bound_func( GRINS::BoundaryID bc_id,
 									  GRINS::VariableIndex var_id ) const;
 
-    std::tr1::shared_ptr< GRINS::NeumannFuncObj > get_neumann_bound_func( GRINS::BoundaryID bc_id,
+    SharedPtr< GRINS::NeumannFuncObj > get_neumann_bound_func( GRINS::BoundaryID bc_id,
 									  GRINS::VariableIndex var_id );
 
     virtual void init_dirichlet_bcs( libMesh::FEMSystem* system ) const;
@@ -188,7 +188,7 @@ namespace GRINS
   }
 
   inline
-  std::tr1::shared_ptr< GRINS::NeumannFuncObj >
+  SharedPtr< GRINS::NeumannFuncObj >
   BCHandlingBase::get_neumann_bound_func( GRINS::BoundaryID bc_id,
 					  GRINS::VariableIndex var_id ) const
   {
@@ -196,7 +196,7 @@ namespace GRINS
   }
 
   inline
-  std::tr1::shared_ptr< GRINS::NeumannFuncObj >
+  SharedPtr< GRINS::NeumannFuncObj >
   BCHandlingBase::get_neumann_bound_func( GRINS::BoundaryID bc_id,
 					  GRINS::VariableIndex var_id )
   {

--- a/src/bc_handling/include/grins/reacting_low_mach_navier_stokes_bc_handling.h
+++ b/src/bc_handling/include/grins/reacting_low_mach_navier_stokes_bc_handling.h
@@ -26,7 +26,7 @@
 #define GRINS_REACTING_LOW_MACH_NAVIER_STOKES_BC_HANDLING_H
 
 // shared_ptr
-#include "boost/tr1/memory.hpp"
+#include "grins/shared_ptr.h"
 
 // GRINS
 #include "grins/low_mach_navier_stokes_bc_handling.h"
@@ -95,7 +95,7 @@ namespace GRINS
     std::vector<std::string> _species_var_names;
     std::vector<GRINS::VariableIndex> _species_vars;
 
-    std::multimap<BoundaryID, std::tr1::shared_ptr<CatalyticWallBase<Chemistry> > > _catalytic_walls;
+    std::multimap<BoundaryID, SharedPtr<CatalyticWallBase<Chemistry> > > _catalytic_walls;
 
     const Chemistry& _chemistry;
 

--- a/src/bc_handling/include/grins/reacting_low_mach_navier_stokes_bc_handling.h
+++ b/src/bc_handling/include/grins/reacting_low_mach_navier_stokes_bc_handling.h
@@ -83,7 +83,7 @@ namespace GRINS
                              const std::string& reactant,
                              const std::string& bc_id_string,
                              const BoundaryID bc_id,
-                             boost::scoped_ptr<CatalycityBase>& gamma_r );
+                             libMesh::UniquePtr<CatalycityBase>& gamma_r );
 
      // We need a another container to stash dirichlet values for the speccies
     std::map< GRINS::BoundaryID, std::vector<libMesh::Real> > _species_bc_values;

--- a/src/bc_handling/src/bc_handling_base.C
+++ b/src/bc_handling/src/bc_handling_base.C
@@ -28,6 +28,7 @@
 
 // GRINS
 #include "grins/string_utils.h"
+#include "grins/shared_ptr.h"
 
 // libMesh
 #include "libmesh/composite_function.h"
@@ -141,7 +142,7 @@ namespace GRINS
 	std::set<BoundaryID> bc_ids = (*it).get_bc_ids();
       
 	// Get Dirichlet bc functor
-        std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+        SharedPtr<libMesh::FunctionBase<libMesh::Number> >
           func = (*it).get_func();
 
         // Remap indices as necessary
@@ -418,7 +419,7 @@ namespace GRINS
           libMesh::Number bc_val_num = StringUtilities::string_to_T<libMesh::Number>(bc_value);
 
           dirichlet_bc.set_func
-            (std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+            (SharedPtr<libMesh::FunctionBase<libMesh::Number> >
               (new libMesh::ConstFunction<libMesh::Number>(bc_val_num)));
 
           this->attach_dirichlet_bound_func(dirichlet_bc);
@@ -434,7 +435,7 @@ namespace GRINS
           dirichlet_bc.add_bc_id(bc_id);
 
           dirichlet_bc.set_func
-            (std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+            (SharedPtr<libMesh::FunctionBase<libMesh::Number> >
               (new libMesh::ParsedFunction<libMesh::Number>(bc_value)));
 
           this->attach_dirichlet_bound_func(dirichlet_bc);

--- a/src/bc_handling/src/inc_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/inc_navier_stokes_bc_handling.C
@@ -172,7 +172,7 @@ namespace GRINS
 	  cont.add_var_name( var );
 	  cont.add_bc_id( bc_id );
 
-	  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > func( new ParabolicProfile(a,b,c,d,e,f) );
+	  SharedPtr<libMesh::FunctionBase<libMesh::Number> > func( new ParabolicProfile(a,b,c,d,e,f) );
 	  cont.set_func( func );
 	  this->attach_dirichlet_bound_func( cont );
 	
@@ -189,7 +189,7 @@ namespace GRINS
 	  cont_fix.add_var_name( fix_var );
 	  cont_fix.add_bc_id( bc_id );
 
-          std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+          SharedPtr<libMesh::FunctionBase<libMesh::Number> >
             func_fix( new libMesh::ZeroFunction<libMesh::Number>() );
 	  cont_fix.set_func( func_fix );
 	  this->attach_dirichlet_bound_func( cont_fix );

--- a/src/bc_handling/src/low_mach_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/low_mach_navier_stokes_bc_handling.C
@@ -202,7 +202,7 @@ namespace GRINS
 	  cont.add_var_name( var );
 	  cont.add_bc_id( bc_id );
 
-          std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+          SharedPtr<libMesh::FunctionBase<libMesh::Number> >
             func( new GRINS::ParabolicProfile(a,b,c,d,e,f) );
 	  cont.set_func( func );
 	  this->attach_dirichlet_bound_func( cont );
@@ -214,7 +214,7 @@ namespace GRINS
 	  cont_fix.add_var_name( fix_var );
 	  cont_fix.add_bc_id( bc_id );
 
-          std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+          SharedPtr<libMesh::FunctionBase<libMesh::Number> >
             func_fix( new libMesh::ZeroFunction<libMesh::Number>() );
 	  cont_fix.set_func( func_fix );
 	  this->attach_dirichlet_bound_func( cont_fix );
@@ -233,7 +233,7 @@ namespace GRINS
 	  cont_fix.add_var_name( fix_var );
 	  cont_fix.add_bc_id( bc_id );
 
-          std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+          SharedPtr<libMesh::FunctionBase<libMesh::Number> >
             func_fix( new libMesh::ZeroFunction<libMesh::Number>() );
 	  cont_fix.set_func( func_fix );
 	  this->attach_dirichlet_bound_func( cont_fix );

--- a/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
@@ -40,9 +40,6 @@
 #include "libmesh/const_function.h"
 #include "libmesh/dirichlet_boundaries.h"
 
-// Boost
-#include "boost/scoped_ptr.hpp"
-
 namespace GRINS
 {
   template<typename Chemistry>
@@ -256,7 +253,7 @@ namespace GRINS
                   /* ------------- Parse and construct the corresponding catalyticities ------------- */
 
                   // These are temporary and will be cloned, so let them be destroyed when we're done
-                  boost::scoped_ptr<CatalycityBase> gamma_r(NULL);
+                  libMesh::UniquePtr<CatalycityBase> gamma_r(NULL);
 
                   this->build_catalycities( input, reactant, bc_id_string, bc_id, gamma_r );
 
@@ -368,7 +365,7 @@ namespace GRINS
                 const unsigned int p_species  = _chemistry.species_index( product );
 
                 // This is temporary and will be cloned, so let it be destroyed when we're done
-                boost::scoped_ptr<CatalycityBase> gamma_r(NULL);
+                libMesh::UniquePtr<CatalycityBase> gamma_r(NULL);
 
                 this->build_catalycities( input, gas_reactant, bc_id_string, bc_id, gamma_r );
 
@@ -579,7 +576,7 @@ namespace GRINS
                                                                              const std::string& reactant,
                                                                              const std::string& bc_id_string,
                                                                              const BoundaryID bc_id,
-                                                                             boost::scoped_ptr<CatalycityBase>& gamma_r )
+                                                                             libMesh::UniquePtr<CatalycityBase>& gamma_r )
   {
     std::string catalycity_type = input("Physics/"+_physics_name+"/gamma_"+reactant+"_"+bc_id_string+"_type", "none");
 

--- a/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
@@ -263,7 +263,7 @@ namespace GRINS
                   /* ------------- Now cache the CatalyticWall functions to init later ------------- */
                   libmesh_assert( gamma_r );
 
-                  std::tr1::shared_ptr<CatalyticWallBase<Chemistry> > wall_ptr( new GasRecombinationCatalyticWall<Chemistry>( _chemistry, *gamma_r, r_species, p_species ) );
+                  SharedPtr<CatalyticWallBase<Chemistry> > wall_ptr( new GasRecombinationCatalyticWall<Chemistry>( _chemistry, *gamma_r, r_species, p_species ) );
 
                   _catalytic_walls.insert( std::make_pair(bc_id, wall_ptr ) );
 
@@ -374,7 +374,7 @@ namespace GRINS
 
                 libmesh_assert( gamma_r );
 
-                std::tr1::shared_ptr<CatalyticWallBase<Chemistry> > wall_ptr( new GasSolidCatalyticWall<Chemistry>( _chemistry, *gamma_r, rg_species, rs_species, p_species ) );
+                SharedPtr<CatalyticWallBase<Chemistry> > wall_ptr( new GasSolidCatalyticWall<Chemistry>( _chemistry, *gamma_r, rg_species, rs_species, p_species ) );
 
                 _catalytic_walls.insert( std::make_pair(bc_id, wall_ptr ) );
 
@@ -415,7 +415,7 @@ namespace GRINS
         if( bc_type == GAS_RECOMBINATION_CATALYTIC_WALL ||
             bc_type == GAS_SOLID_CATALYTIC_WALL )
           {
-            typedef typename std::multimap<BoundaryID, std::tr1::shared_ptr<CatalyticWallBase<Chemistry> > >::iterator it_type;
+            typedef typename std::multimap<BoundaryID, SharedPtr<CatalyticWallBase<Chemistry> > >::iterator it_type;
 
             std::pair< it_type, it_type > it_range = _catalytic_walls.equal_range( bc_id );
 
@@ -552,7 +552,7 @@ namespace GRINS
       case( GAS_RECOMBINATION_CATALYTIC_WALL ):
       case( GAS_SOLID_CATALYTIC_WALL ):
         {
-          typedef typename std::multimap<BoundaryID, std::tr1::shared_ptr<CatalyticWallBase<Chemistry> > >::const_iterator it_type;
+          typedef typename std::multimap<BoundaryID, SharedPtr<CatalyticWallBase<Chemistry> > >::const_iterator it_type;
 
           std::pair< it_type, it_type > it_range = _catalytic_walls.equal_range( bc_id );
 

--- a/src/boundary_conditions/include/grins/boundary_conditions.h
+++ b/src/boundary_conditions/include/grins/boundary_conditions.h
@@ -93,7 +93,7 @@ namespace GRINS
 			const bool request_jacobian,
 			const VariableIndex var,
 			const libMesh::Real sign,
-			std::tr1::shared_ptr<NeumannFuncObj> neumann_func  ) const;
+			SharedPtr<NeumannFuncObj> neumann_func  ) const;
 
     //! Applies Neumann boundary conditions using a user-supplied function.
     /*! This function must also be aware of the Jacobian with respect to other variables. */
@@ -103,7 +103,7 @@ namespace GRINS
 				     const bool request_jacobian,
 				     const VariableIndex var,
 				     const libMesh::Real sign,
-				     const std::tr1::shared_ptr<NeumannFuncObj> neumann_func  ) const;
+				     const SharedPtr<NeumannFuncObj> neumann_func  ) const;
 
     //! Applies Neumann boundary conditions using a user-supplied function.
     /*!  This method is for the case where Neumann boundary condition is
@@ -115,7 +115,7 @@ namespace GRINS
 			       const bool request_jacobian,
 			       const VariableIndex var,
 			       const libMesh::Real sign,
-			       std::tr1::shared_ptr<NeumannFuncObj> neumann_func  ) const;
+			       SharedPtr<NeumannFuncObj> neumann_func  ) const;
 
     //! Applies Neumann boundary conditions using a user-supplied function.
     /*!  This method is for the case where Neumann boundary condition is
@@ -127,7 +127,7 @@ namespace GRINS
                                             const bool request_jacobian,
                                             const VariableIndex var,
                                             const libMesh::Real sign,
-                                            std::tr1::shared_ptr<NeumannFuncObj> neumann_func  ) const;
+                                            SharedPtr<NeumannFuncObj> neumann_func  ) const;
 
     /*! The idea here is to pin a variable to a particular value if there is
       a null space - e.g. pressure for IncompressibleNavierStokes. */

--- a/src/boundary_conditions/include/grins/catalytic_wall_base.h
+++ b/src/boundary_conditions/include/grins/catalytic_wall_base.h
@@ -25,14 +25,13 @@
 #ifndef GRINS_CATALYTIC_WALL_BASE_H
 #define GRINS_CATALYTIC_WALL_BASE_H
 
-// Boost
-#include "boost/scoped_ptr.hpp"
-
 // GRINS
 #include "grins/catalycity_base.h"
 
 // libMesh
 #include "libmesh/libmesh_common.h"
+#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+
 namespace libMesh
 {
   class FEMSystem;
@@ -78,7 +77,7 @@ namespace GRINS
 
     const Chemistry& _chemistry;
 
-    boost::scoped_ptr<CatalycityBase> _gamma_s;
+    libMesh::UniquePtr<CatalycityBase> _gamma_s;
 
     //! \f$ \sqrt{ \frac{R_s}{2\pi} } \f$
     const libMesh::Real _C;

--- a/src/boundary_conditions/include/grins/dbc_container.h
+++ b/src/boundary_conditions/include/grins/dbc_container.h
@@ -29,8 +29,6 @@
 #include <vector>
 #include <set>
 
-#include "boost/tr1/memory.hpp"
-
 // libMesh
 #include "libmesh/fem_function_base.h"
 #include "libmesh/function_base.h"
@@ -61,14 +59,14 @@ namespace GRINS
 
     //! Add the Dirichlet bc functor
     /*! There is only one Dirichlet bc functor for each container object */
-    void set_func( std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > func );
+    void set_func( SharedPtr<libMesh::FunctionBase<libMesh::Number> > func );
 
     void set_fem_func_string( const std::string& s );
 
     std::vector<GRINS::VariableName> get_var_names() const;
     std::set<GRINS::BoundaryID> get_bc_ids() const;
 
-    std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+    SharedPtr<libMesh::FunctionBase<libMesh::Number> >
     get_func() const;
 
     const std::string&
@@ -78,7 +76,7 @@ namespace GRINS
 
     std::vector<GRINS::VariableName> _var_names;
     std::set<GRINS::BoundaryID> _bc_ids;
-    std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > _func;
+    SharedPtr<libMesh::FunctionBase<libMesh::Number> > _func;
     std::string _parsed_fem_func_string;
     
   };

--- a/src/boundary_conditions/include/grins/nbc_container.h
+++ b/src/boundary_conditions/include/grins/nbc_container.h
@@ -49,16 +49,16 @@ namespace GRINS
 
     //! Add boundary id and corresponding functor object to be applied on that boundary
     void add_var_func_pair( VariableIndex var, 
-			    std::tr1::shared_ptr<NeumannFuncObj> func );
+			    SharedPtr<NeumannFuncObj> func );
 
     BoundaryID get_bc_id() const;
 
-    std::tr1::shared_ptr<NeumannFuncObj> get_func( VariableIndex var ) const;
+    SharedPtr<NeumannFuncObj> get_func( VariableIndex var ) const;
 
   protected:
     
     BoundaryID _bc_id;
-    std::map<VariableIndex,std::tr1::shared_ptr<NeumannFuncObj> > _funcs;
+    std::map<VariableIndex,SharedPtr<NeumannFuncObj> > _funcs;
 
   };
 

--- a/src/boundary_conditions/src/boundary_conditions.C
+++ b/src/boundary_conditions/src/boundary_conditions.C
@@ -203,7 +203,7 @@ namespace GRINS
                                           const bool request_jacobian,
                                           const VariableIndex var,
                                           const libMesh::Real sign,
-                                          const std::tr1::shared_ptr<NeumannFuncObj> neumann_func ) const
+                                          const SharedPtr<NeumannFuncObj> neumann_func ) const
   {
     libMesh::FEGenericBase<libMesh::Real>* side_fe = NULL; 
     context.get_side_fe( var, side_fe );
@@ -293,7 +293,7 @@ namespace GRINS
                                                  const bool request_jacobian,
                                                  const VariableIndex var,
                                                  const libMesh::Real sign,
-                                                 const std::tr1::shared_ptr<NeumannFuncObj> neumann_func ) const
+                                                 const SharedPtr<NeumannFuncObj> neumann_func ) const
   {
     libMesh::FEGenericBase<libMesh::Real>* side_fe = NULL; 
     context.get_side_fe( var, side_fe );
@@ -380,7 +380,7 @@ namespace GRINS
                                                               const bool request_jacobian,
                                                               const VariableIndex var,
                                                               const libMesh::Real sign,
-                                                              const std::tr1::shared_ptr<NeumannFuncObj> neumann_func ) const
+                                                              const SharedPtr<NeumannFuncObj> neumann_func ) const
   {
     libMesh::FEGenericBase<libMesh::Real>* side_fe = NULL; 
     context.get_side_fe( var, side_fe );
@@ -474,7 +474,7 @@ namespace GRINS
                                                        const bool request_jacobian,
                                                        const VariableIndex var,
                                                        const libMesh::Real sign,
-                                                       std::tr1::shared_ptr<NeumannFuncObj> neumann_func ) const
+                                                       SharedPtr<NeumannFuncObj> neumann_func ) const
   {
     libMesh::FEGenericBase<libMesh::Real>* side_fe = NULL; 
     context.get_side_fe( var, side_fe );
@@ -637,17 +637,17 @@ template void GRINS::BoundaryConditions::apply_neumann_normal_axisymmetric<libMe
 
 
 
-template void GRINS::BoundaryConditions::apply_neumann<libMesh::Real>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, std::tr1::shared_ptr<GRINS::NeumannFuncObj>) const;
-template void GRINS::BoundaryConditions::apply_neumann<libMesh::RealGradient>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, std::tr1::shared_ptr<GRINS::NeumannFuncObj>) const;
+template void GRINS::BoundaryConditions::apply_neumann<libMesh::Real>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, SharedPtr<GRINS::NeumannFuncObj>) const;
+template void GRINS::BoundaryConditions::apply_neumann<libMesh::RealGradient>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, SharedPtr<GRINS::NeumannFuncObj>) const;
 
-template void GRINS::BoundaryConditions::apply_neumann_axisymmetric<libMesh::Real>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, std::tr1::shared_ptr<GRINS::NeumannFuncObj>) const;
-template void GRINS::BoundaryConditions::apply_neumann_axisymmetric<libMesh::RealGradient>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, std::tr1::shared_ptr<GRINS::NeumannFuncObj>) const;
+template void GRINS::BoundaryConditions::apply_neumann_axisymmetric<libMesh::Real>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, SharedPtr<GRINS::NeumannFuncObj>) const;
+template void GRINS::BoundaryConditions::apply_neumann_axisymmetric<libMesh::RealGradient>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, SharedPtr<GRINS::NeumannFuncObj>) const;
 
-template void GRINS::BoundaryConditions::apply_neumann_normal<libMesh::Real>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, std::tr1::shared_ptr<GRINS::NeumannFuncObj>) const;
-template void GRINS::BoundaryConditions::apply_neumann_normal<libMesh::RealGradient>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, std::tr1::shared_ptr<GRINS::NeumannFuncObj>) const;
+template void GRINS::BoundaryConditions::apply_neumann_normal<libMesh::Real>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, SharedPtr<GRINS::NeumannFuncObj>) const;
+template void GRINS::BoundaryConditions::apply_neumann_normal<libMesh::RealGradient>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, SharedPtr<GRINS::NeumannFuncObj>) const;
 
-template void GRINS::BoundaryConditions::apply_neumann_normal_axisymmetric<libMesh::Real>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, std::tr1::shared_ptr<GRINS::NeumannFuncObj>) const;
-template void GRINS::BoundaryConditions::apply_neumann_normal_axisymmetric<libMesh::RealGradient>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, std::tr1::shared_ptr<GRINS::NeumannFuncObj>) const;
+template void GRINS::BoundaryConditions::apply_neumann_normal_axisymmetric<libMesh::Real>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, SharedPtr<GRINS::NeumannFuncObj>) const;
+template void GRINS::BoundaryConditions::apply_neumann_normal_axisymmetric<libMesh::RealGradient>(AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const libMesh::Real, SharedPtr<GRINS::NeumannFuncObj>) const;
 
 template void GRINS::BoundaryConditions::pin_value<libMesh::Real>( AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const double, const libMesh::Point&, const double);
 template void GRINS::BoundaryConditions::pin_value<libMesh::RealGradient>( AssemblyContext&, const GRINS::CachedValues&, const bool, const GRINS::VariableIndex, const double, const libMesh::Point&, const double);

--- a/src/boundary_conditions/src/dbc_container.C
+++ b/src/boundary_conditions/src/dbc_container.C
@@ -32,7 +32,7 @@ namespace GRINS
   DBCContainer::DBCContainer()
     : _var_names( std::vector<VariableName>() ),
       _bc_ids( std::set<BoundaryID>() ),
-      _func( std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >() ),
+      _func( NULL ),
       _parsed_fem_func_string()
   {
     return;
@@ -55,7 +55,7 @@ namespace GRINS
     return;
   }
 
-  void DBCContainer::set_func( std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > func )
+  void DBCContainer::set_func( SharedPtr<libMesh::FunctionBase<libMesh::Number> > func )
   {
     _func = func;
     return;
@@ -83,7 +83,7 @@ namespace GRINS
     return _parsed_fem_func_string;
   }
 
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > DBCContainer::get_func() const
+  SharedPtr<libMesh::FunctionBase<libMesh::Number> > DBCContainer::get_func() const
   {
     return _func;
   }

--- a/src/boundary_conditions/src/nbc_container.C
+++ b/src/boundary_conditions/src/nbc_container.C
@@ -49,7 +49,7 @@ namespace GRINS
   }
 
   void NBCContainer::add_var_func_pair( VariableIndex var, 
-					std::tr1::shared_ptr<NeumannFuncObj> func )
+					SharedPtr<NeumannFuncObj> func )
   {
     if( _funcs.find(var) != _funcs.end() )
       {
@@ -61,7 +61,7 @@ namespace GRINS
     return;
   }
 
-  std::tr1::shared_ptr<NeumannFuncObj> NBCContainer::get_func( VariableIndex var ) const
+  SharedPtr<NeumannFuncObj> NBCContainer::get_func( VariableIndex var ) const
   {
     libmesh_assert( _funcs.find(var) != _funcs.end() );
     return _funcs.find(var)->second;

--- a/src/error_estimation/include/grins/error_estimation_factory.h
+++ b/src/error_estimation/include/grins/error_estimation_factory.h
@@ -27,6 +27,7 @@
 
 // GRINS
 #include "grins/qoi_base.h"
+#include "grins/shared_ptr.h"
 
 // libMesh
 #include "libmesh/error_estimator.h"
@@ -44,8 +45,8 @@ namespace GRINS
 
     virtual ~ErrorEstimatorFactory();
 
-    virtual std::tr1::shared_ptr<libMesh::ErrorEstimator> build( const GetPot& input, 
-                                                                 const libMesh::QoISet& qoi_set );
+    virtual SharedPtr<libMesh::ErrorEstimator> build( const GetPot& input,
+                                                      const libMesh::QoISet& qoi_set );
 
   protected:
 

--- a/src/error_estimation/src/error_estimation_factory.C
+++ b/src/error_estimation/src/error_estimation_factory.C
@@ -46,14 +46,14 @@ namespace GRINS
     return;
   }
 
-  std::tr1::shared_ptr<libMesh::ErrorEstimator> ErrorEstimatorFactory::build( const GetPot& input,
-                                                                              const libMesh::QoISet& qoi_set )
+  SharedPtr<libMesh::ErrorEstimator> ErrorEstimatorFactory::build( const GetPot& input,
+                                                                   const libMesh::QoISet& qoi_set )
   {
     std::string estimator_type = input("MeshAdaptivity/estimator_type", "patch_recovery");
 
     ErrorEstimatorEnum estimator_enum = this->string_to_enum( estimator_type );
 
-    std::tr1::shared_ptr<libMesh::ErrorEstimator> error_estimator;
+    SharedPtr<libMesh::ErrorEstimator> error_estimator;
 
     switch( estimator_enum )
       {

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -159,9 +159,9 @@ namespace GRINS
     //! Query to check if a particular physics has been enabled
     bool has_physics( const std::string physics_name ) const;
 
-    std::tr1::shared_ptr<GRINS::Physics> get_physics( const std::string physics_name );
+    SharedPtr<GRINS::Physics> get_physics( const std::string physics_name );
 
-    std::tr1::shared_ptr<GRINS::Physics> get_physics( const std::string physics_name ) const;
+    SharedPtr<GRINS::Physics> get_physics( const std::string physics_name ) const;
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,
@@ -205,7 +205,7 @@ namespace GRINS
   };
 
   inline
-  std::tr1::shared_ptr<GRINS::Physics> MultiphysicsSystem::get_physics( const std::string physics_name ) const
+  SharedPtr<GRINS::Physics> MultiphysicsSystem::get_physics( const std::string physics_name ) const
   {
     libmesh_assert(_physics_list.find( physics_name ) != _physics_list.end());
 

--- a/src/physics/include/grins/physics_factory.h
+++ b/src/physics/include/grins/physics_factory.h
@@ -48,13 +48,13 @@ namespace GRINS
     
     PhysicsFactory();
 
-    //! Destructor does not need to delete std::tr1::shared_ptr's.
+    //! Destructor does not need to delete SharedPtr's.
     virtual ~PhysicsFactory();
     
     //! Builds PhysicsList. This is the primary function of this class.
     GRINS::PhysicsList build(const GetPot& input);
 
-    typedef std::tr1::shared_ptr<Physics> PhysicsPtr;
+    typedef SharedPtr<Physics> PhysicsPtr;
     typedef std::pair< std::string, PhysicsPtr > PhysicsPair;
 
   protected:

--- a/src/physics/include/grins/var_typedefs.h
+++ b/src/physics/include/grins/var_typedefs.h
@@ -29,10 +29,12 @@
 #include <string>
 #include <map>
 #include <limits>
-#include "boost/tr1/memory.hpp"
 
 // libMesh
 #include "libmesh/id_types.h"
+
+// GRINS
+#include "grins/shared_ptr.h"
 
 namespace GRINS
 {
@@ -54,10 +56,10 @@ namespace GRINS
   typedef libMesh::boundary_id_type BoundaryID;
 
   //! Container for GRINS::Physics object pointers
-  typedef std::map< std::string,std::tr1::shared_ptr<GRINS::Physics> > PhysicsList;
+  typedef std::map< std::string,SharedPtr<GRINS::Physics> > PhysicsList;
 
   //! Iterator for PhysicsList
-  typedef std::map< std::string,std::tr1::shared_ptr<GRINS::Physics> >::const_iterator PhysicsListIter;
+  typedef std::map< std::string,SharedPtr<GRINS::Physics> >::const_iterator PhysicsListIter;
 
 }
 #endif //GRINS_VAR_TYPEDEFS_H

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -281,7 +281,7 @@ namespace GRINS
 	 physics_iter != _physics_list.end();
 	 physics_iter++ )
       {
-        // boost::shared_ptr gets confused by operator->*
+        // shared_ptr gets confused by operator->*
 	((*(physics_iter->second)).*cachefunc)( c, cache );
       }
 

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -388,7 +388,7 @@ namespace GRINS
        &GRINS::Physics::compute_nonlocal_mass_residual_cache);
   }
 
-  std::tr1::shared_ptr<Physics> MultiphysicsSystem::get_physics( const std::string physics_name )
+  SharedPtr<Physics> MultiphysicsSystem::get_physics( const std::string physics_name )
   {
     if( _physics_list.find( physics_name ) == _physics_list.end() )
       {

--- a/src/properties/include/grins/antioch_chemistry.h
+++ b/src/properties/include/grins/antioch_chemistry.h
@@ -35,14 +35,12 @@
 
 // libMesh
 #include "libmesh/libmesh_common.h"
+#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
 
 // Antioch
 #include "antioch/vector_utils_decl.h"
 #include "antioch/vector_utils.h"
 #include "antioch/chemical_mixture.h"
-
-// Boost
-#include "boost/scoped_ptr.hpp"
 
 // libMesh forward declarations
 class GetPot;
@@ -109,7 +107,7 @@ namespace GRINS
 
   protected:
 
-    boost::scoped_ptr<Antioch::ChemicalMixture<libMesh::Real> > _antioch_gas;
+    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > _antioch_gas;
 
   private:
 

--- a/src/properties/include/grins/antioch_constant_transport_mixture.h
+++ b/src/properties/include/grins/antioch_constant_transport_mixture.h
@@ -74,9 +74,9 @@ namespace GRINS
 
     libMesh::Real _mu;
 
-    boost::scoped_ptr<Conductivity> _conductivity;
+    libMesh::UniquePtr<Conductivity> _conductivity;
 
-    boost::scoped_ptr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > _diffusivity;
+    libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > _diffusivity;
 
     /* Below we will specialize the specialized_build_* functions to the appropriate type.
        This way, we can control how the cached transport objects get constructed
@@ -90,7 +90,7 @@ namespace GRINS
     AntiochConstantTransportMixture();
 
     void specialized_build_conductivity( const GetPot& input,
-                                         boost::scoped_ptr<ConstantConductivity>& conductivity,
+                                         libMesh::UniquePtr<ConstantConductivity>& conductivity,
                                          conductivity_type<ConstantConductivity> )
     {
       conductivity.reset( new ConstantConductivity(input) );
@@ -98,7 +98,7 @@ namespace GRINS
     }
 
     void specialized_build_conductivity( const GetPot& input,
-                                         boost::scoped_ptr<ConstantPrandtlConductivity>& conductivity,
+                                         libMesh::UniquePtr<ConstantPrandtlConductivity>& conductivity,
                                          conductivity_type<ConstantPrandtlConductivity> )
     {
       conductivity.reset( new ConstantPrandtlConductivity(input) );

--- a/src/properties/include/grins/antioch_evaluator.h
+++ b/src/properties/include/grins/antioch_evaluator.h
@@ -41,9 +41,6 @@
 #include "antioch/cea_evaluator.h"
 #include "antioch/stat_mech_thermo.h"
 
-// Boost
-#include <boost/scoped_ptr.hpp>
-
 namespace GRINS
 {
   //! Wrapper class for evaluating chemistry and thermo properties using Antioch
@@ -106,13 +103,13 @@ namespace GRINS
   protected:
 
     const AntiochMixture& _chem;
-    
+
     // This is a template type
-    boost::scoped_ptr<Thermo> _thermo;
+    libMesh::UniquePtr<Thermo> _thermo;
 
-    boost::scoped_ptr<AntiochKinetics> _kinetics;
+    libMesh::UniquePtr<AntiochKinetics> _kinetics;
 
-    boost::scoped_ptr<Antioch::TempCache<libMesh::Real> > _temp_cache;
+    libMesh::UniquePtr<Antioch::TempCache<libMesh::Real> > _temp_cache;
 
     //! Helper method for managing _temp_cache
     /*! T *MUST* be pass-by-reference because of the structure
@@ -131,7 +128,7 @@ namespace GRINS
     AntiochEvaluator();
 
     void specialized_build_thermo( const AntiochMixture& mixture,
-                                   boost::scoped_ptr<Antioch::StatMechThermodynamics<libMesh::Real> >& thermo,
+                                   libMesh::UniquePtr<Antioch::StatMechThermodynamics<libMesh::Real> >& thermo,
                                    thermo_type<Antioch::StatMechThermodynamics<libMesh::Real> > )
     {
       thermo.reset( new Antioch::StatMechThermodynamics<libMesh::Real>( mixture.chemical_mixture() ) );
@@ -139,7 +136,7 @@ namespace GRINS
     }
     
     void specialized_build_thermo( const AntiochMixture& mixture,
-                                   boost::scoped_ptr<Antioch::CEAEvaluator<libMesh::Real> >& thermo,
+                                   libMesh::UniquePtr<Antioch::CEAEvaluator<libMesh::Real> >& thermo,
                                    thermo_type<Antioch::CEAEvaluator<libMesh::Real> > )
     {
       thermo.reset( new Antioch::CEAEvaluator<libMesh::Real>( mixture.cea_mixture() ) );

--- a/src/properties/include/grins/antioch_mixture.h
+++ b/src/properties/include/grins/antioch_mixture.h
@@ -44,9 +44,6 @@
 #include "antioch/cea_mixture.h"
 #include "antioch/reaction_set.h"
 
-// Boost
-#include "boost/scoped_ptr.hpp"
-
 // libMesh forward declarations
 class GetPot;
 
@@ -76,9 +73,9 @@ namespace GRINS
 
   protected:
 
-    boost::scoped_ptr<Antioch::ReactionSet<libMesh::Real> > _reaction_set;
+    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > _reaction_set;
 
-    boost::scoped_ptr<Antioch::CEAThermoMixture<libMesh::Real> > _cea_mixture;
+    libMesh::UniquePtr<Antioch::CEAThermoMixture<libMesh::Real> > _cea_mixture;
 
     std::vector<libMesh::Real> _h_stat_mech_ref_correction;
 

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
@@ -88,7 +88,7 @@ namespace GRINS
 
   protected:
 
-    boost::scoped_ptr<Antioch::MixtureAveragedTransportEvaluator<Diffusivity,Viscosity,Conductivity,libMesh::Real> > _wilke_evaluator;
+    libMesh::UniquePtr<Antioch::MixtureAveragedTransportEvaluator<Diffusivity,Viscosity,Conductivity,libMesh::Real> > _wilke_evaluator;
 
     const Antioch::MixtureDiffusion<Diffusivity,libMesh::Real>& _diffusivity;
 

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
@@ -99,17 +99,17 @@ namespace GRINS
 
   protected:
 
-    boost::scoped_ptr<Antioch::TransportMixture<libMesh::Real> > _trans_mixture;
+    libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> > _trans_mixture;
 
-    boost::scoped_ptr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > _wilke_mixture;
+    libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > _wilke_mixture;
 
-    boost::scoped_ptr<Thermo> _thermo;
+    libMesh::UniquePtr<Thermo> _thermo;
 
-    boost::scoped_ptr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> > _viscosity;
+    libMesh::UniquePtr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> > _viscosity;
 
-    boost::scoped_ptr<Antioch::MixtureConductivity<Conductivity,libMesh::Real> > _conductivity;
+    libMesh::UniquePtr<Antioch::MixtureConductivity<Conductivity,libMesh::Real> > _conductivity;
 
-    boost::scoped_ptr<Antioch::MixtureDiffusion<Diffusivity,libMesh::Real> > _diffusivity;
+    libMesh::UniquePtr<Antioch::MixtureDiffusion<Diffusivity,libMesh::Real> > _diffusivity;
 
     /* Below we will specialize the specialized_build_* functions to the appropriate type.
        This way, we can control how the cached transport objects get constructed
@@ -132,7 +132,7 @@ namespace GRINS
     AntiochMixtureAveragedTransportMixture();
 
     void specialized_build_thermo( const GetPot& /*input*/,
-                                   boost::scoped_ptr<Antioch::StatMechThermodynamics<libMesh::Real> >& thermo,
+                                   libMesh::UniquePtr<Antioch::StatMechThermodynamics<libMesh::Real> >& thermo,
                                    thermo_type<Antioch::StatMechThermodynamics<libMesh::Real> > )
     {
       thermo.reset( new Antioch::StatMechThermodynamics<libMesh::Real>( *(this->_antioch_gas.get()) ) );
@@ -140,7 +140,7 @@ namespace GRINS
     }
 
     void specialized_build_thermo( const GetPot& /*input*/,
-                                   boost::scoped_ptr<Antioch::CEAEvaluator<libMesh::Real> >& thermo,
+                                   libMesh::UniquePtr<Antioch::CEAEvaluator<libMesh::Real> >& thermo,
                                    thermo_type<Antioch::CEAEvaluator<libMesh::Real> > )
     {
       thermo.reset( new Antioch::CEAEvaluator<libMesh::Real>( this->cea_mixture() ) );
@@ -148,7 +148,7 @@ namespace GRINS
     }
 
     void specialized_build_viscosity( const GetPot& input,
-                                      boost::scoped_ptr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> >& viscosity,
+                                      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> >& viscosity,
                                       viscosity_type<Antioch::SutherlandViscosity<libMesh::Real> > )
     {
       viscosity.reset( new Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -161,7 +161,7 @@ namespace GRINS
     }
 
     void specialized_build_viscosity( const GetPot& input,
-                                      boost::scoped_ptr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> >& viscosity,
+                                      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> >& viscosity,
                                       viscosity_type<Antioch::BlottnerViscosity<libMesh::Real> > )
     {
       viscosity.reset( new Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -175,7 +175,7 @@ namespace GRINS
 
 #ifdef ANTIOCH_HAVE_GSL
     void specialized_build_viscosity( const GetPot& /*input*/,
-                                      boost::scoped_ptr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >& viscosity,
+                                      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >& viscosity,
                                       viscosity_type<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner> > )
     {
       viscosity.reset( new Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -185,7 +185,7 @@ namespace GRINS
 #endif // ANTIOCH_HAVE_GSL
 
     void specialized_build_conductivity( const GetPot& /*input*/,
-                                         boost::scoped_ptr<Antioch::MixtureConductivity<Antioch::EuckenThermalConductivity<Thermo>,libMesh::Real> >& conductivity,
+                                         libMesh::UniquePtr<Antioch::MixtureConductivity<Antioch::EuckenThermalConductivity<Thermo>,libMesh::Real> >& conductivity,
                                          conductivity_type<Antioch::EuckenThermalConductivity<Thermo> > )
     {
       conductivity.reset( new Antioch::MixtureConductivity<Antioch::EuckenThermalConductivity<Thermo>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -195,7 +195,7 @@ namespace GRINS
 
 #ifdef ANTIOCH_HAVE_GSL
     void specialized_build_conductivity( const GetPot& /*input*/,
-                                         boost::scoped_ptr<Antioch::MixtureConductivity<Antioch::KineticsTheoryThermalConductivity<Thermo,libMesh::Real>,libMesh::Real> >& conductivity,
+                                         libMesh::UniquePtr<Antioch::MixtureConductivity<Antioch::KineticsTheoryThermalConductivity<Thermo,libMesh::Real>,libMesh::Real> >& conductivity,
                                          conductivity_type<Antioch::KineticsTheoryThermalConductivity<Thermo,libMesh::Real> > )
     {
       conductivity.reset( new Antioch::MixtureConductivity<Antioch::KineticsTheoryThermalConductivity<Thermo,libMesh::Real>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -205,7 +205,7 @@ namespace GRINS
 #endif // ANTIOCH_HAVE_GSL
 
     void specialized_build_diffusivity( const GetPot& input,
-                                        boost::scoped_ptr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> >& diffusivity,
+                                        libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> >& diffusivity,
                                         diffusivity_type<Antioch::ConstantLewisDiffusivity<libMesh::Real> > )
     {
       if( !input.have_variable( "Physics/Antioch/Le" ) )
@@ -226,7 +226,7 @@ namespace GRINS
 
 #ifdef ANTIOCH_HAVE_GSL
     void specialized_build_diffusivity( const GetPot& /*input*/,
-                                        boost::scoped_ptr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >& diffusivity,
+                                        libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >& diffusivity,
                                         diffusivity_type<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > )
     {
       diffusivity.reset( new Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real>(*(_trans_mixture.get())) );

--- a/src/properties/include/grins/cantera_mixture.h
+++ b/src/properties/include/grins/cantera_mixture.h
@@ -39,8 +39,8 @@
 #include "cantera/transport.h"
 #include "libmesh/restore_warnings.h"
 
-// Boost
-#include <boost/scoped_ptr.hpp>
+// libMesh
+#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
 
 // libMesh forward declarations
 class GetPot;
@@ -97,9 +97,9 @@ namespace GRINS
 
   protected:
 
-    boost::scoped_ptr<Cantera::IdealGasMix> _cantera_gas;
+    libMesh::UniquePtr<Cantera::IdealGasMix> _cantera_gas;
 
-    boost::scoped_ptr<Cantera::Transport> _cantera_transport;
+    libMesh::UniquePtr<Cantera::Transport> _cantera_transport;
 
   private:
 

--- a/src/qoi/include/grins/qoi_factory.h
+++ b/src/qoi/include/grins/qoi_factory.h
@@ -32,7 +32,7 @@
 #include "grins/composite_qoi.h"
 
 // shared_ptr
-#include "boost/tr1/memory.hpp"
+#include "grins/shared_ptr.h"
 
 namespace GRINS
 {
@@ -44,18 +44,18 @@ namespace GRINS
     
     virtual ~QoIFactory();
 
-    virtual std::tr1::shared_ptr<CompositeQoI> build(const GetPot& input);
+    virtual SharedPtr<CompositeQoI> build(const GetPot& input);
 
   protected:
 
     virtual void add_qoi( const GetPot& input,
                           const std::string& qoi_name,
-                          std::tr1::shared_ptr<CompositeQoI>& qois );
+                          SharedPtr<CompositeQoI>& qois );
 
     virtual void check_qoi_physics_consistency( const GetPot& input,
 						const std::string& qoi_name );
 
-    virtual void echo_qoi_list( std::tr1::shared_ptr<CompositeQoI>& qois );
+    virtual void echo_qoi_list( SharedPtr<CompositeQoI>& qois );
 
     void consistency_helper( const std::set<std::string>& requested_physics,
 			     const std::set<std::string>& required_physics, 

--- a/src/qoi/src/qoi_factory.C
+++ b/src/qoi/src/qoi_factory.C
@@ -47,7 +47,7 @@ namespace GRINS
     return;
   }
 
-  std::tr1::shared_ptr<CompositeQoI> QoIFactory::build(const GetPot& input)
+  SharedPtr<CompositeQoI> QoIFactory::build(const GetPot& input)
   {
     std::string qoi_list = input("QoI/enabled_qois", "none" );
 
@@ -58,7 +58,7 @@ namespace GRINS
         StringUtilities::split_string( qoi_list, std::string(" "), qoi_names );
       }
 
-    std::tr1::shared_ptr<CompositeQoI> qois( new CompositeQoI );
+    SharedPtr<CompositeQoI> qois( new CompositeQoI );
     
     if( !qoi_names.empty() )
       {
@@ -79,7 +79,7 @@ namespace GRINS
     return qois;
   }
 
-  void QoIFactory::add_qoi( const GetPot& /*input*/, const std::string& qoi_name, std::tr1::shared_ptr<CompositeQoI>& qois )
+  void QoIFactory::add_qoi( const GetPot& /*input*/, const std::string& qoi_name, SharedPtr<CompositeQoI>& qois )
   {
     QoIBase* qoi = NULL;
 
@@ -150,7 +150,7 @@ namespace GRINS
     return;
   }
 
-  void QoIFactory::echo_qoi_list( std::tr1::shared_ptr<CompositeQoI>& qois )
+  void QoIFactory::echo_qoi_list( SharedPtr<CompositeQoI>& qois )
   {
     /*! \todo Generalize to multiple QoI case when CompositeQoI is implemented in libMesh */
     std::cout << "==========================================================" << std::endl

--- a/src/solver/include/grins/displacement_continuation_solver.h
+++ b/src/solver/include/grins/displacement_continuation_solver.h
@@ -38,7 +38,7 @@ namespace GRINS
     virtual ~DisplacementContinuationSolver();
 
     virtual void initialize( const GetPot& input, 
-			     std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+			     SharedPtr<libMesh::EquationSystems> equation_system,
 			     GRINS::MultiphysicsSystem* system );
 
     virtual void solve( SolverContext& context );

--- a/src/solver/include/grins/grins_solver.h
+++ b/src/solver/include/grins/grins_solver.h
@@ -62,7 +62,7 @@ namespace GRINS
     virtual ~Solver();
 
     virtual void initialize( const GetPot& input,
-			     std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+			     SharedPtr<libMesh::EquationSystems> equation_system,
 			     GRINS::MultiphysicsSystem* system );
 
     virtual void solve( SolverContext& context )=0;

--- a/src/solver/include/grins/grins_solver.h
+++ b/src/solver/include/grins/grins_solver.h
@@ -26,9 +26,6 @@
 #ifndef GRINS_SOLVER_H
 #define GRINS_SOLVER_H
 
-// C++
-#include "boost/tr1/memory.hpp"
-
 // GRINS
 #include "grins/nbc_container.h"
 

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -28,9 +28,6 @@
 // C++
 #include <string>
 
-// Boost
-#include <boost/scoped_ptr.hpp>
-
 // GRINS
 #include "grins/grins_solver.h"
 
@@ -83,7 +80,7 @@ namespace GRINS
 
     RefinementFlaggingType _refinement_type;
 
-    boost::scoped_ptr<libMesh::MeshRefinement> _mesh_refinement;
+    libMesh::UniquePtr<libMesh::MeshRefinement> _mesh_refinement;
 
     void build_mesh_refinement( libMesh::MeshBase& mesh );
 

--- a/src/solver/include/grins/mesh_builder.h
+++ b/src/solver/include/grins/mesh_builder.h
@@ -26,9 +26,6 @@
 #ifndef GRINS_MESH_BUILDER_H
 #define GRINS_MESH_BUILDER_H
 
-// C++
-#include "boost/tr1/memory.hpp"
-
 // libMesh
 #include "libmesh/mesh.h"
 #include "libmesh/getpot.h"
@@ -36,6 +33,7 @@
 
 // GRINS
 #include "grins/common.h"
+#include "grins/shared_ptr.h"
 
 namespace GRINS
 {
@@ -53,7 +51,7 @@ namespace GRINS
     void read_input_options( const GetPot& input );
 
     //! Builds the libMesh::Mesh according to input options.
-    std::tr1::shared_ptr<libMesh::UnstructuredMesh> build
+    SharedPtr<libMesh::UnstructuredMesh> build
       ( const GetPot& input,
         const libMesh::Parallel::Communicator &comm
         LIBMESH_CAN_DEFAULT_TO_COMMWORLD );

--- a/src/solver/include/grins/parameter_manager.h
+++ b/src/solver/include/grins/parameter_manager.h
@@ -32,9 +32,6 @@
 #include "libmesh/getpot.h"
 #include "libmesh/parameter_vector.h"
 
-// C++
-#include "boost/tr1/memory.hpp"
-
 namespace GRINS
 {
   // Forward declarations

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -31,6 +31,7 @@
 
 // GRINS
 #include "grins_config.h"
+#include "grins/shared_ptr.h"
 #include "grins/grins_solver.h"
 #include "grins/qoi_base.h"
 #include "grins/visualization.h"
@@ -160,7 +161,7 @@ namespace GRINS
     unsigned int _timesteps_per_vis;
     unsigned int _timesteps_per_perflog;
 
-    std::tr1::shared_ptr<libMesh::ErrorEstimator> _error_estimator;
+    SharedPtr<libMesh::ErrorEstimator> _error_estimator;
 
     ParameterManager _adjoint_parameters;
 

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -27,7 +27,7 @@
 #define GRINS_SIMULATION_H
 
 // C++
-#include "boost/tr1/memory.hpp"
+#include "grins/shared_ptr.h"
 
 // GRINS
 #include "grins_config.h"
@@ -81,7 +81,7 @@ namespace GRINS
 
     void print_sim_info();
 
-    std::tr1::shared_ptr<libMesh::EquationSystems> get_equation_system();	      
+    SharedPtr<libMesh::EquationSystems> get_equation_system();
     MultiphysicsSystem* get_multiphysics_system();
 
     const MultiphysicsSystem* get_multiphysics_system() const;
@@ -127,11 +127,11 @@ namespace GRINS
     //! Helper function
     void init_adjoint_solve( const GetPot& input, bool output_adjoint );
 
-    std::tr1::shared_ptr<libMesh::UnstructuredMesh> _mesh;
+    SharedPtr<libMesh::UnstructuredMesh> _mesh;
 
-    std::tr1::shared_ptr<libMesh::EquationSystems> _equation_system;
+    SharedPtr<libMesh::EquationSystems> _equation_system;
 
-    std::tr1::shared_ptr<GRINS::Solver> _solver;
+    SharedPtr<GRINS::Solver> _solver;
 
     //! GRINS::Multiphysics system name
     std::string _system_name;
@@ -139,9 +139,9 @@ namespace GRINS
     // This needs to be a standard pointer, as _equation_system will own and destroy the object.
     GRINS::MultiphysicsSystem* _multiphysics_system;
 
-    std::tr1::shared_ptr<GRINS::Visualization> _vis;
+    SharedPtr<GRINS::Visualization> _vis;
 
-    std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> > _postprocessing;
+    SharedPtr<PostProcessedQuantities<libMesh::Real> > _postprocessing;
 
     // Screen display options
     bool _print_mesh_info;

--- a/src/solver/include/grins/simulation_builder.h
+++ b/src/solver/include/grins/simulation_builder.h
@@ -35,6 +35,7 @@
 #include "grins/qoi_factory.h"
 #include "grins/postprocessing_factory.h"
 #include "grins/error_estimation_factory.h"
+#include "grins/shared_ptr.h"
 
 namespace GRINS
 {
@@ -67,8 +68,8 @@ namespace GRINS
 
     std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> > build_postprocessing( const GetPot& input );
 
-    std::tr1::shared_ptr<libMesh::ErrorEstimator> build_error_estimator( const GetPot& input,
-                                                                         const libMesh::QoISet& qoi_set );
+    SharedPtr<libMesh::ErrorEstimator> build_error_estimator( const GetPot& input,
+                                                              const libMesh::QoISet& qoi_set );
 
     void attach_physics_factory( std::tr1::shared_ptr<PhysicsFactory> physics_factory );
 

--- a/src/solver/include/grins/simulation_builder.h
+++ b/src/solver/include/grins/simulation_builder.h
@@ -46,16 +46,16 @@ namespace GRINS
     SimulationBuilder();
     virtual ~SimulationBuilder();
 
-    std::tr1::shared_ptr<libMesh::UnstructuredMesh> build_mesh
+    SharedPtr<libMesh::UnstructuredMesh> build_mesh
       ( const GetPot& input,
         const libMesh::Parallel::Communicator &comm
         LIBMESH_CAN_DEFAULT_TO_COMMWORLD );
 
     GRINS::PhysicsList build_physics( const GetPot& input );
 
-    std::tr1::shared_ptr<GRINS::Solver> build_solver( const GetPot& input );
+    SharedPtr<GRINS::Solver> build_solver( const GetPot& input );
 
-    std::tr1::shared_ptr<GRINS::Visualization> build_vis
+    SharedPtr<GRINS::Visualization> build_vis
       ( const GetPot& input,
         const libMesh::Parallel::Communicator &comm
         LIBMESH_CAN_DEFAULT_TO_COMMWORLD );
@@ -64,41 +64,41 @@ namespace GRINS
 
     std::map< GRINS::PhysicsName, GRINS::NBCContainer > build_neumann_bcs( libMesh::EquationSystems& equation_system );
 
-    std::tr1::shared_ptr<CompositeQoI> build_qoi( const GetPot& input );
+    SharedPtr<CompositeQoI> build_qoi( const GetPot& input );
 
-    std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> > build_postprocessing( const GetPot& input );
+    SharedPtr<PostProcessedQuantities<libMesh::Real> > build_postprocessing( const GetPot& input );
 
     SharedPtr<libMesh::ErrorEstimator> build_error_estimator( const GetPot& input,
                                                               const libMesh::QoISet& qoi_set );
 
-    void attach_physics_factory( std::tr1::shared_ptr<PhysicsFactory> physics_factory );
+    void attach_physics_factory( SharedPtr<PhysicsFactory> physics_factory );
 
-    void attach_solver_factory( std::tr1::shared_ptr<SolverFactory> solver_factory );
+    void attach_solver_factory( SharedPtr<SolverFactory> solver_factory );
 
-    void attach_mesh_builder( std::tr1::shared_ptr<MeshBuilder> mesh_builder );
+    void attach_mesh_builder( SharedPtr<MeshBuilder> mesh_builder );
     
-    void attach_vis_factory( std::tr1::shared_ptr<VisualizationFactory> vis_factory );
+    void attach_vis_factory( SharedPtr<VisualizationFactory> vis_factory );
 
-    void attach_bc_factory( std::tr1::shared_ptr<BoundaryConditionsFactory> bc_factory );
+    void attach_bc_factory( SharedPtr<BoundaryConditionsFactory> bc_factory );
 
-    void attach_qoi_factory( std::tr1::shared_ptr<QoIFactory> qoi_factory );
+    void attach_qoi_factory( SharedPtr<QoIFactory> qoi_factory );
 
-    void attach_postprocessing_factory( std::tr1::shared_ptr<PostprocessingFactory> postprocessing_factory );
+    void attach_postprocessing_factory( SharedPtr<PostprocessingFactory> postprocessing_factory );
 
-    void attach_error_estimator_factory( std::tr1::shared_ptr<ErrorEstimatorFactory> error_estimator_factory );
+    void attach_error_estimator_factory( SharedPtr<ErrorEstimatorFactory> error_estimator_factory );
 
     const MeshBuilder& mesh_builder() const;
 
   protected:
     
-    std::tr1::shared_ptr<PhysicsFactory> _physics_factory;
-    std::tr1::shared_ptr<MeshBuilder> _mesh_builder;
-    std::tr1::shared_ptr<SolverFactory> _solver_factory;
-    std::tr1::shared_ptr<VisualizationFactory> _vis_factory;
-    std::tr1::shared_ptr<BoundaryConditionsFactory> _bc_factory;
-    std::tr1::shared_ptr<QoIFactory> _qoi_factory;
-    std::tr1::shared_ptr<PostprocessingFactory> _postprocessing_factory;
-    std::tr1::shared_ptr<ErrorEstimatorFactory> _error_estimator_factory;
+    SharedPtr<PhysicsFactory> _physics_factory;
+    SharedPtr<MeshBuilder> _mesh_builder;
+    SharedPtr<SolverFactory> _solver_factory;
+    SharedPtr<VisualizationFactory> _vis_factory;
+    SharedPtr<BoundaryConditionsFactory> _bc_factory;
+    SharedPtr<QoIFactory> _qoi_factory;
+    SharedPtr<PostprocessingFactory> _postprocessing_factory;
+    SharedPtr<ErrorEstimatorFactory> _error_estimator_factory;
       
   }; //class SimulationBuilder
 } // namespace GRINS

--- a/src/solver/include/grins/solver_context.h
+++ b/src/solver/include/grins/solver_context.h
@@ -26,7 +26,7 @@
 #ifndef GRINS_SOLVER_CONTEXT_H
 #define GRINS_SOLVER_CONTEXT_H
 
-#include "boost/tr1/memory.hpp"
+#include "grins/shared_ptr.h"
 
 // GRINS
 #include "grins/shared_ptr.h"
@@ -55,8 +55,8 @@ namespace GRINS
     ~SolverContext(){};
 
     GRINS::MultiphysicsSystem* system;
-    std::tr1::shared_ptr<libMesh::EquationSystems> equation_system;
-    std::tr1::shared_ptr<GRINS::Visualization> vis;
+    SharedPtr<libMesh::EquationSystems> equation_system;
+    SharedPtr<GRINS::Visualization> vis;
     unsigned int timesteps_per_vis;
     unsigned int timesteps_per_perflog;
     bool output_vis;
@@ -69,7 +69,7 @@ namespace GRINS
     bool print_qoi;
     bool do_adjoint_solve;
 
-    std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> > postprocessing;
+    SharedPtr<PostProcessedQuantities<libMesh::Real> > postprocessing;
 
     SharedPtr<libMesh::ErrorEstimator> error_estimator;
 

--- a/src/solver/include/grins/solver_context.h
+++ b/src/solver/include/grins/solver_context.h
@@ -29,6 +29,7 @@
 #include "boost/tr1/memory.hpp"
 
 // GRINS
+#include "grins/shared_ptr.h"
 #include "grins/visualization.h"
 #include "grins/postprocessed_quantities.h"
 
@@ -70,7 +71,7 @@ namespace GRINS
 
     std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> > postprocessing;
 
-    std::tr1::shared_ptr<libMesh::ErrorEstimator> error_estimator;
+    SharedPtr<libMesh::ErrorEstimator> error_estimator;
 
   };
 

--- a/src/solver/include/grins/solver_factory.h
+++ b/src/solver/include/grins/solver_factory.h
@@ -47,7 +47,7 @@ namespace GRINS
     //! Builds GRINS::Solver object.
     /*! Users should override this method to construct 
         their own solvers. */
-    virtual std::tr1::shared_ptr<GRINS::Solver> build(const GetPot& input);
+    virtual SharedPtr<GRINS::Solver> build(const GetPot& input);
 
   };
 } // namespace GRINS

--- a/src/solver/src/displacement_continuation_solver.C
+++ b/src/solver/src/displacement_continuation_solver.C
@@ -85,7 +85,7 @@ namespace GRINS
   }
 
   void DisplacementContinuationSolver::initialize( const GetPot& input, 
-                                                   std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+                                                   SharedPtr<libMesh::EquationSystems> equation_system,
                                                    GRINS::MultiphysicsSystem* system )
   {
     // First init everything on the base class side, which will reinit equation_system

--- a/src/solver/src/grins_solver.C
+++ b/src/solver/src/grins_solver.C
@@ -67,7 +67,7 @@ namespace GRINS
   }
 
   void Solver::initialize( const GetPot& /*input*/,
-			   std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+			   SharedPtr<libMesh::EquationSystems> equation_system,
 			   MultiphysicsSystem* system )
   {
 

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -53,7 +53,7 @@ namespace GRINS
     return;
   }
 
-  std::tr1::shared_ptr<libMesh::UnstructuredMesh> MeshBuilder::build
+  SharedPtr<libMesh::UnstructuredMesh> MeshBuilder::build
     (const GetPot& input,
      const libMesh::Parallel::Communicator &comm)
   {
@@ -178,7 +178,7 @@ namespace GRINS
         this->do_mesh_refinement_from_input( input, comm, *mesh );
       }
 
-    return std::tr1::shared_ptr<libMesh::UnstructuredMesh>(mesh);
+    return SharedPtr<libMesh::UnstructuredMesh>(mesh);
   }
 
   void MeshBuilder::generate_mesh( const std::string& mesh_build_type, const GetPot& input,

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -181,7 +181,7 @@ namespace GRINS
   void Simulation::init_qois( const GetPot& input, SimulationBuilder& sim_builder )
   {
     // If the user actually asks for a QoI, then we add it.
-    std::tr1::shared_ptr<CompositeQoI> qois = sim_builder.build_qoi( input );
+    SharedPtr<CompositeQoI> qois = sim_builder.build_qoi( input );
     if( qois->n_qois() > 0 )
       {
         // This *must* be done after equation_system->init in order to get variable indices
@@ -419,7 +419,7 @@ namespace GRINS
     return;
   }
 
-  std::tr1::shared_ptr<libMesh::EquationSystems> Simulation::get_equation_system()
+  SharedPtr<libMesh::EquationSystems> Simulation::get_equation_system()
   {
     return _equation_system;
   }
@@ -481,7 +481,7 @@ namespace GRINS
              bc != neumann_bcs.end();
              bc++ )
           {
-            std::tr1::shared_ptr<Physics> physics = system->get_physics( bc->first );
+            SharedPtr<Physics> physics = system->get_physics( bc->first );
             physics->attach_neumann_bound_func( bc->second );
           }
       }
@@ -496,7 +496,7 @@ namespace GRINS
          it != dbc_map.end();
          it++ )
       {
-        std::tr1::shared_ptr<Physics> physics = system->get_physics( it->first );
+        SharedPtr<Physics> physics = system->get_physics( it->first );
 
         physics->attach_dirichlet_bound_func( it->second );
       }

--- a/src/solver/src/simulation_builder.C
+++ b/src/solver/src/simulation_builder.C
@@ -50,52 +50,52 @@ namespace GRINS
     return;
   }
   
-  void SimulationBuilder::attach_physics_factory( std::tr1::shared_ptr<PhysicsFactory> physics_factory )
+  void SimulationBuilder::attach_physics_factory( SharedPtr<PhysicsFactory> physics_factory )
   {
     this->_physics_factory = physics_factory;
     return;
   }
   
-  void SimulationBuilder::attach_solver_factory( std::tr1::shared_ptr<SolverFactory> solver_factory )
+  void SimulationBuilder::attach_solver_factory( SharedPtr<SolverFactory> solver_factory )
   {
     this->_solver_factory = solver_factory;
     return;
   }
 
-  void SimulationBuilder::attach_mesh_builder( std::tr1::shared_ptr<MeshBuilder> mesh_builder )
+  void SimulationBuilder::attach_mesh_builder( SharedPtr<MeshBuilder> mesh_builder )
   {
     this->_mesh_builder = mesh_builder;
     return;
   }
     
-  void SimulationBuilder::attach_vis_factory( std::tr1::shared_ptr<VisualizationFactory> vis_factory )
+  void SimulationBuilder::attach_vis_factory( SharedPtr<VisualizationFactory> vis_factory )
   {
     this->_vis_factory = vis_factory;
     return;
   }
 
-  void SimulationBuilder::attach_bc_factory( std::tr1::shared_ptr<BoundaryConditionsFactory> bc_factory )
+  void SimulationBuilder::attach_bc_factory( SharedPtr<BoundaryConditionsFactory> bc_factory )
   {
     this->_bc_factory = bc_factory;
     return;
   }
 
-  void SimulationBuilder::attach_qoi_factory( std::tr1::shared_ptr<QoIFactory> qoi_factory )
+  void SimulationBuilder::attach_qoi_factory( SharedPtr<QoIFactory> qoi_factory )
   {
     this->_qoi_factory = qoi_factory;
   }
 
-  void SimulationBuilder::attach_postprocessing_factory( std::tr1::shared_ptr<PostprocessingFactory> postprocessing_factory )
+  void SimulationBuilder::attach_postprocessing_factory( SharedPtr<PostprocessingFactory> postprocessing_factory )
   {
     this->_postprocessing_factory = postprocessing_factory; 
   }
 
-  void SimulationBuilder::attach_error_estimator_factory( std::tr1::shared_ptr<ErrorEstimatorFactory> error_estimator_factory )
+  void SimulationBuilder::attach_error_estimator_factory( SharedPtr<ErrorEstimatorFactory> error_estimator_factory )
   {
     this->_error_estimator_factory = error_estimator_factory;
   }
 
-  std::tr1::shared_ptr<libMesh::UnstructuredMesh> SimulationBuilder::build_mesh
+  SharedPtr<libMesh::UnstructuredMesh> SimulationBuilder::build_mesh
     ( const GetPot& input,
       const libMesh::Parallel::Communicator &comm)
   {
@@ -107,12 +107,12 @@ namespace GRINS
     return (this->_physics_factory)->build(input);
   }
   
-  std::tr1::shared_ptr<GRINS::Solver> SimulationBuilder::build_solver( const GetPot& input )
+  SharedPtr<GRINS::Solver> SimulationBuilder::build_solver( const GetPot& input )
   {
     return (this->_solver_factory)->build(input);
   }
 
-  std::tr1::shared_ptr<GRINS::Visualization> SimulationBuilder::build_vis
+  SharedPtr<GRINS::Visualization> SimulationBuilder::build_vis
     ( const GetPot& input,
       const libMesh::Parallel::Communicator &comm)
   {
@@ -129,12 +129,12 @@ namespace GRINS
     return (this->_bc_factory)->build_neumann(equation_system);
   }
   
-  std::tr1::shared_ptr<CompositeQoI> SimulationBuilder::build_qoi( const GetPot& input )
+  SharedPtr<CompositeQoI> SimulationBuilder::build_qoi( const GetPot& input )
   {
     return (this->_qoi_factory)->build(input);
   }
 
-  std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> >
+  SharedPtr<PostProcessedQuantities<libMesh::Real> >
   SimulationBuilder::build_postprocessing( const GetPot& input )
   {
     return (this->_postprocessing_factory)->build(input);

--- a/src/solver/src/simulation_builder.C
+++ b/src/solver/src/simulation_builder.C
@@ -140,7 +140,7 @@ namespace GRINS
     return (this->_postprocessing_factory)->build(input);
   }
 
-  std::tr1::shared_ptr<libMesh::ErrorEstimator> SimulationBuilder::build_error_estimator( const GetPot& input,
+  SharedPtr<libMesh::ErrorEstimator> SimulationBuilder::build_error_estimator( const GetPot& input,
                                                                                           const libMesh::QoISet& qoi_set)
    {
      return (this->_error_estimator_factory)->build(input,qoi_set);

--- a/src/solver/src/solver_context.C
+++ b/src/solver/src/solver_context.C
@@ -33,8 +33,8 @@ namespace GRINS
 {
   SolverContext::SolverContext()
     : system(NULL),
-      equation_system( std::tr1::shared_ptr<libMesh::EquationSystems>() ),
-      vis( std::tr1::shared_ptr<GRINS::Visualization>() ),
+      equation_system( SharedPtr<libMesh::EquationSystems>() ),
+      vis( SharedPtr<GRINS::Visualization>() ),
       timesteps_per_vis( 1 ),
       timesteps_per_perflog( 1 ),
       output_vis( false ),
@@ -45,7 +45,7 @@ namespace GRINS
       print_perflog( false ),
       print_scalars( false ),
       do_adjoint_solve(false),
-      postprocessing( std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> >() )
+      postprocessing( SharedPtr<PostProcessedQuantities<libMesh::Real> >() )
   {
     return;
   }

--- a/src/solver/src/solver_factory.C
+++ b/src/solver/src/solver_factory.C
@@ -46,13 +46,13 @@ namespace GRINS
     return;
   }
 
-  std::tr1::shared_ptr<Solver> SolverFactory::build(const GetPot& input)
+  SharedPtr<Solver> SolverFactory::build(const GetPot& input)
   {
     bool mesh_adaptive = input("MeshAdaptivity/mesh_adaptive", false );
 
     bool transient = input("unsteady-solver/transient", false );
 
-    std::tr1::shared_ptr<Solver> solver;  // Effectively NULL
+    SharedPtr<Solver> solver;  // Effectively NULL
 
     std::string solver_type = input("SolverOptions/solver_type", "DIE!");
 

--- a/src/utilities/include/grins/shared_ptr.h
+++ b/src/utilities/include/grins/shared_ptr.h
@@ -40,11 +40,19 @@ namespace GRINS
 #ifdef LIBMESH_HAVE_CXX11_SHARED_PTR
   template<typename T>
   class SharedPtr : public std::shared_ptr<T>
-  {};
+  {
+  public:
+    SharedPtr() : std::shared_ptr<T>() {};
+    SharedPtr( T* ptr ) : std::shared_ptr<T>(ptr) {};
+  };
 #elif GRINS_HAVE_BOOST_SHARED_PTR_HPP
   template<typename T>
   class SharedPtr : public boost::shared_ptr<T>
-  {};
+  {
+  public:
+    SharedPtr() : boost::shared_ptr<T>() {};
+    SharedPtr( T* ptr ) : boost::shared_ptr<T>(ptr) {};
+  };
 #else
 #     error "No valid definition for shared_ptr found!"
 #endif

--- a/src/utilities/include/grins/shared_ptr.h
+++ b/src/utilities/include/grins/shared_ptr.h
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_SHARED_PTR_H
+#define GRINS_SHARED_PTR_H
+
+#include "grins_config.h"
+#include "libmesh/libmesh_config.h"
+
+// Here, we just piggy back on libMesh's test for shared_ptr
+#ifdef LIBMESH_HAVE_CXX11_SHARED_PTR
+#include <memory>
+#elif GRINS_HAVE_BOOST_SHARED_PTR_HPP
+#include <boost/shared_ptr.hpp>
+#endif
+
+namespace GRINS
+{
+#ifdef LIBMESH_HAVE_CXX11_SHARED_PTR
+  template<typename T>
+  class SharedPtr : public std::shared_ptr<T>
+  {};
+#elif GRINS_HAVE_BOOST_SHARED_PTR_HPP
+  template<typename T>
+  class SharedPtr : public boost::shared_ptr<T>
+  {};
+#else
+#     error "No valid definition for shared_ptr found!"
+#endif
+}
+
+#endif // GRINS_SHARED_PTR_H

--- a/src/visualization/include/grins/postprocessed_quantities.h
+++ b/src/visualization/include/grins/postprocessed_quantities.h
@@ -89,7 +89,7 @@ namespace GRINS
     std::map<VariableIndex, unsigned int> _quantity_index_var_map;
     
     MultiphysicsSystem* _multiphysics_sys;
-    std::tr1::shared_ptr<AssemblyContext> _multiphysics_context;
+    SharedPtr<AssemblyContext> _multiphysics_context;
 
   private:
 

--- a/src/visualization/include/grins/postprocessing_factory.h
+++ b/src/visualization/include/grins/postprocessing_factory.h
@@ -26,8 +26,6 @@
 #ifndef GRINS_POSTPROCESSING_FACTORY_H
 #define GRINS_POSTPROCESSING_FACTORY_H
 
-#include "boost/tr1/memory.hpp"
-
 // libMesh
 #include "libmesh/getpot.h"
 

--- a/src/visualization/include/grins/postprocessing_factory.h
+++ b/src/visualization/include/grins/postprocessing_factory.h
@@ -47,7 +47,7 @@ namespace GRINS
     PostprocessingFactory();
     virtual ~PostprocessingFactory();
 
-    virtual std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> >
+    virtual SharedPtr<PostProcessedQuantities<libMesh::Real> >
     build(const GetPot& input);
 
   };

--- a/src/visualization/include/grins/steady_visualization.h
+++ b/src/visualization/include/grins/steady_visualization.h
@@ -39,25 +39,25 @@ namespace GRINS
                         LIBMESH_CAN_DEFAULT_TO_COMMWORLD);
     ~SteadyVisualization();
 
-    virtual void output_residual( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    virtual void output_residual( SharedPtr<libMesh::EquationSystems> equation_system,
 				  GRINS::MultiphysicsSystem* system,
 				  const unsigned int time_step,
 				  const libMesh::Real time );
 
     virtual void output_residual_sensitivities
-      (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+      (SharedPtr<libMesh::EquationSystems> equation_system,
        GRINS::MultiphysicsSystem* system,
        const libMesh::ParameterVector & params,
        const unsigned int time_step,
        const libMesh::Real time );
     
-    virtual void output_adjoint( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    virtual void output_adjoint( SharedPtr<libMesh::EquationSystems> equation_system,
                                  GRINS::MultiphysicsSystem* system,
                                  const unsigned int time_step,
                                  const libMesh::Real time );
 
     virtual void output_solution_sensitivities
-      (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+      (SharedPtr<libMesh::EquationSystems> equation_system,
        GRINS::MultiphysicsSystem* system,
        const libMesh::ParameterVector & params,
        const unsigned int time_step,

--- a/src/visualization/include/grins/unsteady_visualization.h
+++ b/src/visualization/include/grins/unsteady_visualization.h
@@ -40,25 +40,25 @@ namespace GRINS
                           LIBMESH_CAN_DEFAULT_TO_COMMWORLD);
     ~UnsteadyVisualization();
 
-    virtual void output_residual( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    virtual void output_residual( SharedPtr<libMesh::EquationSystems> equation_system,
 				  GRINS::MultiphysicsSystem* system,
 				  const unsigned int time_step,
 				  const libMesh::Real time);
 
     virtual void output_residual_sensitivities
-      (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+      (SharedPtr<libMesh::EquationSystems> equation_system,
        GRINS::MultiphysicsSystem* system,
        const libMesh::ParameterVector & params,
        const unsigned int time_step,
        const libMesh::Real time);
     
-    virtual void output_adjoint( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    virtual void output_adjoint( SharedPtr<libMesh::EquationSystems> equation_system,
                                  GRINS::MultiphysicsSystem* system,
                                  const unsigned int time_step,
                                  const libMesh::Real time );
 
     virtual void output_solution_sensitivities
-      (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+      (SharedPtr<libMesh::EquationSystems> equation_system,
        GRINS::MultiphysicsSystem* system,
        const libMesh::ParameterVector & params,
        const unsigned int time_step,

--- a/src/visualization/include/grins/visualization.h
+++ b/src/visualization/include/grins/visualization.h
@@ -29,10 +29,12 @@
 // C++
 #include <string>
 #include <vector>
-#include "boost/tr1/memory.hpp"
 
 // libMesh
 #include "libmesh/equation_systems.h"
+
+// GRINS
+#include "grins/shared_ptr.h"
 
 // libMesh forward declarations
 class GetPot;
@@ -55,50 +57,50 @@ namespace GRINS
                    LIBMESH_CAN_DEFAULT_TO_COMMWORLD );
     virtual ~Visualization();
 
-    void output( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system );
-    void output( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    void output( SharedPtr<libMesh::EquationSystems> equation_system );
+    void output( SharedPtr<libMesh::EquationSystems> equation_system,
 		 const unsigned int time_step, const libMesh::Real time );
 
-    void output_residual( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    void output_residual( SharedPtr<libMesh::EquationSystems> equation_system,
 			  GRINS::MultiphysicsSystem* system );
 
-    virtual void output_residual( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    virtual void output_residual( SharedPtr<libMesh::EquationSystems> equation_system,
 				  GRINS::MultiphysicsSystem* system,
 				  const unsigned int time_step, const libMesh::Real time ) =0;
 
     void output_residual_sensitivities
-      (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+      (SharedPtr<libMesh::EquationSystems> equation_system,
        GRINS::MultiphysicsSystem* system,
        const libMesh::ParameterVector & params);
 
     virtual void output_residual_sensitivities
-      (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+      (SharedPtr<libMesh::EquationSystems> equation_system,
        GRINS::MultiphysicsSystem* system,
        const libMesh::ParameterVector & params,
        const unsigned int time_step, const libMesh::Real time ) =0;
-    
-    void output_adjoint( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+
+    void output_adjoint( SharedPtr<libMesh::EquationSystems> equation_system,
                          GRINS::MultiphysicsSystem* system );
 
-    virtual void output_adjoint( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    virtual void output_adjoint( SharedPtr<libMesh::EquationSystems> equation_system,
                                  GRINS::MultiphysicsSystem* system,
                                  const unsigned int time_step,
                                  const libMesh::Real time ) =0;
 
     void output_solution_sensitivities
-      (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+      (SharedPtr<libMesh::EquationSystems> equation_system,
        GRINS::MultiphysicsSystem* system,
        const libMesh::ParameterVector & params);
 
     virtual void output_solution_sensitivities
-      (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+      (SharedPtr<libMesh::EquationSystems> equation_system,
        GRINS::MultiphysicsSystem* system,
        const libMesh::ParameterVector & params,
        const unsigned int time_step, const libMesh::Real time ) =0;
 
-    void dump_visualization( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    void dump_visualization( SharedPtr<libMesh::EquationSystems> equation_system,
 			     const std::string& filename_prefix, const libMesh::Real time );
-    
+
   protected:
 
     // Visualization options

--- a/src/visualization/include/grins/visualization_factory.h
+++ b/src/visualization/include/grins/visualization_factory.h
@@ -26,9 +26,6 @@
 #ifndef GRINS_VISUALIZATION_FACTORY_H
 #define GRINS_VISUALIZATION_FACTORY_H
 
-// C++
-#include "boost/tr1/memory.hpp"
-
 // GRINS
 #include "grins/visualization.h"
 

--- a/src/visualization/include/grins/visualization_factory.h
+++ b/src/visualization/include/grins/visualization_factory.h
@@ -41,7 +41,7 @@ namespace GRINS
     VisualizationFactory();
     virtual ~VisualizationFactory();
 
-    virtual std::tr1::shared_ptr<GRINS::Visualization> build
+    virtual SharedPtr<GRINS::Visualization> build
       ( const GetPot& input,
         const libMesh::Parallel::Communicator &comm
         LIBMESH_CAN_DEFAULT_TO_COMMWORLD );

--- a/src/visualization/src/postprocessing_factory.C
+++ b/src/visualization/src/postprocessing_factory.C
@@ -37,10 +37,10 @@ namespace GRINS
     return;
   }
 
-  std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> >
+  SharedPtr<PostProcessedQuantities<libMesh::Real> >
   PostprocessingFactory::build(const GetPot& input)
   {
-    return std::tr1::shared_ptr<PostProcessedQuantities<libMesh::Real> >
+    return SharedPtr<PostProcessedQuantities<libMesh::Real> >
       ( new PostProcessedQuantities<libMesh::Real>(input) );
   }
 

--- a/src/visualization/src/steady_visualization.C
+++ b/src/visualization/src/steady_visualization.C
@@ -50,7 +50,7 @@ namespace GRINS
     return;
   }
 
-  void SteadyVisualization::output_residual( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+  void SteadyVisualization::output_residual( SharedPtr<libMesh::EquationSystems> equation_system,
 					     MultiphysicsSystem* system,
 					     const unsigned int,
 					     const libMesh::Real )
@@ -75,7 +75,7 @@ namespace GRINS
   }
 
   void SteadyVisualization::output_residual_sensitivities
-    (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    (SharedPtr<libMesh::EquationSystems> equation_system,
      MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int,
@@ -101,7 +101,7 @@ namespace GRINS
       }
   }
 
-  void SteadyVisualization::output_adjoint( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+  void SteadyVisualization::output_adjoint( SharedPtr<libMesh::EquationSystems> equation_system,
                                             MultiphysicsSystem* system,
                                             const unsigned int /*time_step*/,
                                             const libMesh::Real /*time*/ )
@@ -130,7 +130,7 @@ namespace GRINS
   }
 
   void SteadyVisualization::output_solution_sensitivities
-    (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    (SharedPtr<libMesh::EquationSystems> equation_system,
      MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int,

--- a/src/visualization/src/unsteady_visualization.C
+++ b/src/visualization/src/unsteady_visualization.C
@@ -52,7 +52,7 @@ namespace GRINS
   }
 
   void UnsteadyVisualization::output_residual
-    ( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    ( SharedPtr<libMesh::EquationSystems> equation_system,
       MultiphysicsSystem* system,
       const unsigned int time_step,
       const libMesh::Real time )
@@ -96,7 +96,7 @@ namespace GRINS
   }
 
   void UnsteadyVisualization::output_residual_sensitivities
-    (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    (SharedPtr<libMesh::EquationSystems> equation_system,
      MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int time_step,
@@ -127,7 +127,7 @@ namespace GRINS
   }
 
   void UnsteadyVisualization::output_adjoint
-    ( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    ( SharedPtr<libMesh::EquationSystems> equation_system,
       MultiphysicsSystem* system,
       const unsigned int time_step,
       const libMesh::Real time )
@@ -160,7 +160,7 @@ namespace GRINS
   }
 
   void UnsteadyVisualization::output_solution_sensitivities
-    (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    (SharedPtr<libMesh::EquationSystems> equation_system,
      MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int time_step,

--- a/src/visualization/src/visualization.C
+++ b/src/visualization/src/visualization.C
@@ -95,7 +95,7 @@ namespace GRINS
     return;
   }
 
-  void Visualization::output( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system )
+  void Visualization::output( SharedPtr<libMesh::EquationSystems> equation_system )
   {
     this->dump_visualization( equation_system, _vis_output_file_prefix, 0.0 );
 
@@ -103,7 +103,7 @@ namespace GRINS
   }
 
   void Visualization::output
-    ( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    ( SharedPtr<libMesh::EquationSystems> equation_system,
       const unsigned int time_step,
       const libMesh::Real time )
   {
@@ -119,7 +119,7 @@ namespace GRINS
     return;
   }
 
-  void Visualization::output_residual( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+  void Visualization::output_residual( SharedPtr<libMesh::EquationSystems> equation_system,
 				       MultiphysicsSystem* system )
   {
     this->output_residual( equation_system, system, 0, 0.0 );
@@ -127,7 +127,7 @@ namespace GRINS
   }
 
   void Visualization::output_residual_sensitivities
-    (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    (SharedPtr<libMesh::EquationSystems> equation_system,
      MultiphysicsSystem* system,
      const libMesh::ParameterVector & params)
   {
@@ -135,14 +135,14 @@ namespace GRINS
       ( equation_system, system, params, 0, 0.0 );
   }
 
-  void Visualization::output_adjoint( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+  void Visualization::output_adjoint( SharedPtr<libMesh::EquationSystems> equation_system,
                                       MultiphysicsSystem* system )
   {
     this->output_adjoint( equation_system, system, 0, 0.0 );
   }
 
   void Visualization::output_solution_sensitivities
-    (std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    (SharedPtr<libMesh::EquationSystems> equation_system,
      MultiphysicsSystem* system,
      const libMesh::ParameterVector & params)
   {
@@ -151,7 +151,7 @@ namespace GRINS
   }
 
   void Visualization::dump_visualization
-    ( std::tr1::shared_ptr<libMesh::EquationSystems> equation_system,
+    ( SharedPtr<libMesh::EquationSystems> equation_system,
       const std::string& filename_prefix,
       const libMesh::Real time )
   {

--- a/src/visualization/src/visualization_factory.C
+++ b/src/visualization/src/visualization_factory.C
@@ -46,7 +46,7 @@ namespace GRINS
     return;
   }
 
-  std::tr1::shared_ptr<Visualization> VisualizationFactory::build
+  SharedPtr<Visualization> VisualizationFactory::build
     ( const GetPot& input,
       const libMesh::Parallel::Communicator &comm )
   {
@@ -59,7 +59,7 @@ namespace GRINS
     else
       vis = new SteadyVisualization( input, comm );
 
-    return std::tr1::shared_ptr<Visualization>( vis );
+    return SharedPtr<Visualization>( vis );
   }
 
 } // namespace GRINS

--- a/test/3d_low_mach_jacobians.C
+++ b/test/3d_low_mach_jacobians.C
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
     {
       // Asssign initial temperature value
       std::string system_name = libMesh_inputfile( "screen-options/system_name", "GRINS" );
-      std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
       const libMesh::System& system = es->get_system(system_name);
       
       libMesh::Parameters &params = es->parameters;

--- a/test/antioch_evaluator_regression.C
+++ b/test/antioch_evaluator_regression.C
@@ -38,14 +38,12 @@
 #include "grins/cached_values.h"
 
 // libMesh
+#include "libmesh/libmesh_common.h"
 #include "libmesh/getpot.h"
 
 // Antioch
 #include "antioch/cea_evaluator.h"
 #include "antioch/stat_mech_thermo.h"
-
-// Boost
-#include "boost/math/special_functions/fpclassify.hpp" //isnan
 
 int test_generic( const libMesh::Real value, const libMesh::Real value_reg, const std::string& name )
 {
@@ -63,7 +61,7 @@ int test_generic( const libMesh::Real value, const libMesh::Real value_reg, cons
                 << name+"_reg = " << value_reg << std::endl
                 << "rel_error = " << rel_error << std::endl;
     }
-  
+
   return return_flag;
 }
 
@@ -183,7 +181,7 @@ int test_evaluator( const GRINS::AntiochMixture& antioch_mixture )
 
   return_flag_temp = test_cv<Thermo>( cv );
   if( return_flag_temp != 0 ) return_flag = 1;
-  
+
   return_flag_temp = test_h_s<Thermo>( h_s );
   if( return_flag_temp != 0 ) return_flag = 1;
 
@@ -191,11 +189,11 @@ int test_evaluator( const GRINS::AntiochMixture& antioch_mixture )
 
   for( unsigned int i = 0; i < n_species; i++ )
     {
-      std::cout << std::scientific << std::setprecision(16) 
+      std::cout << std::scientific << std::setprecision(16)
                 << "omega_dot(" << i << ") = " << omega_dot[i] << std::endl;
     }
 
-  
+
   double tol = std::numeric_limits<double>::epsilon()*40;
 
   // Check that omega_dot sums to 1
@@ -215,7 +213,7 @@ int test_evaluator( const GRINS::AntiochMixture& antioch_mixture )
   bool omega_is_nan = false;
   for( unsigned int s = 0; s < n_species; s++ )
     {
-      if( boost::math::isnan(omega_dot[s]) )
+      if( libMesh::libmesh_isnan(omega_dot[s]) )
         {
           omega_is_nan = true;
           return_flag = 1;
@@ -263,7 +261,7 @@ int main( int argc, char* argv[] )
     }
 
   GetPot input( argv[1] );
-  
+
   GRINS::AntiochMixture antioch_mixture(input);
 
   int return_flag = 0;

--- a/test/axisym_reacting_low_mach_regression.C
+++ b/test/axisym_reacting_low_mach_regression.C
@@ -144,7 +144,7 @@ int run( int argc, char* argv[], const GetPot& input, GetPot& command_line )
     {
       // Asssign initial temperature value
       std::string system_name = input( "screen-options/system_name", "GRINS" );
-      std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
       const libMesh::System& system = es->get_system(system_name);
 
       libMesh::Parameters &params = es->parameters;
@@ -161,7 +161,7 @@ int run( int argc, char* argv[], const GetPot& input, GetPot& command_line )
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
    // Create Exact solution object and attach exact solution quantities
   libMesh::ExactSolution exact_sol(*es);

--- a/test/elastic_sheet_regression.C
+++ b/test/elastic_sheet_regression.C
@@ -92,7 +92,7 @@ int run( int argc, char* argv[], const GetPot& input )
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems>
+  GRINS::SharedPtr<libMesh::EquationSystems>
     es = grins.get_equation_system();
 
   //es->write("foobar.xdr");

--- a/test/generic_solution_regression.C
+++ b/test/generic_solution_regression.C
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
    // Create Exact solution object and attach exact solution quantities
   libMesh::ExactSolution exact_sol(*es);

--- a/test/grins_flow_regression.C
+++ b/test/grins_flow_regression.C
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   //es->write("foobar.xdr");
 

--- a/test/low_mach_cavity_benchmark_regression.C
+++ b/test/low_mach_cavity_benchmark_regression.C
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
     {
       // Asssign initial temperature value
       std::string system_name = libMesh_inputfile( "screen-options/system_name", "GRINS" );
-      std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
       const libMesh::System& system = es->get_system(system_name);
       
       libMesh::Parameters &params = es->parameters;

--- a/test/reacting_low_mach_regression.C
+++ b/test/reacting_low_mach_regression.C
@@ -117,7 +117,7 @@ int run( int argc, char* argv[], const GetPot& input )
     {
       // Asssign initial temperature value
       std::string system_name = input( "screen-options/system_name", "GRINS" );
-      std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+      GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
       const libMesh::System& system = es->get_system(system_name);
       
       libMesh::Parameters &params = es->parameters;
@@ -147,7 +147,7 @@ int run( int argc, char* argv[], const GetPot& input )
 #endif
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems>
+  GRINS::SharedPtr<libMesh::EquationSystems>
     es = grins.get_equation_system();
 
   //es->write("foobar.xdr");

--- a/test/suspended_cable_regression.C
+++ b/test/suspended_cable_regression.C
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
 	std::string system_name = libMesh_inputfile( "screen-options/system_name", "GRINS" );
 
 	// Get equation systems
-	std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+	GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 	const libMesh::System& system = es->get_system(system_name);
 
 	libMesh::Parameters &params = es->parameters;

--- a/test/test_axi_ns_con_cyl_flow.C
+++ b/test/test_axi_ns_con_cyl_flow.C
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
 
   GRINS::SimulationBuilder sim_builder;
 
-  std::tr1::shared_ptr<AxiConCylBCFactory> bc_factory( new AxiConCylBCFactory );
+  GRINS::SharedPtr<GRINS::BoundaryConditionsFactory> bc_factory( new AxiConCylBCFactory );
 
   sim_builder.attach_bc_factory(bc_factory);
 
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   // Create Exact solution object and attach exact solution quantities
   libMesh::ExactSolution exact_sol(*es);
@@ -173,9 +173,9 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > AxiConCylBCFactory::bui
   cont.add_var_name( "z_vel" );
   cont.add_bc_id( 0 );
   cont.add_bc_id( 2 );
-  
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > vel_func( new GRINS::ConcentricCylinderProfile );
-    
+
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> > vel_func( new GRINS::ConcentricCylinderProfile );
+
   cont.set_func( vel_func );
 
 
@@ -184,7 +184,7 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > AxiConCylBCFactory::bui
   cont2.add_bc_id( 0 );
   cont2.add_bc_id( 2 );
 
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> >
     vel_func2( new libMesh::ZeroFunction<libMesh::Number> );
 
   cont2.set_func( vel_func2 );

--- a/test/test_axi_ns_poiseuille_flow.C
+++ b/test/test_axi_ns_poiseuille_flow.C
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
  
   GRINS::SimulationBuilder sim_builder;
 
-  std::tr1::shared_ptr<AxiParabolicBCFactory> bc_factory( new AxiParabolicBCFactory );
+  GRINS::SharedPtr<GRINS::BoundaryConditionsFactory> bc_factory( new AxiParabolicBCFactory );
 
   sim_builder.attach_bc_factory(bc_factory);
 
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
 #endif
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   // Do solve here
   grins.run();
@@ -169,10 +169,10 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > AxiParabolicBCFactory::
   cont.add_var_name( "z_vel" );
   cont.add_bc_id( 0 );
   cont.add_bc_id( 2 );
-  
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> >
-    vel_func( new GRINS::ParabolicProfile( -100.0/4.0, 0.0, 0.0, 0.0, 0.0, 100.0/4.0 ) ); 
-    
+
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> >
+    vel_func( new GRINS::ParabolicProfile( -100.0/4.0, 0.0, 0.0, 0.0, 0.0, 100.0/4.0 ) );
+
   cont.set_func( vel_func );
     
   std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > mymap;

--- a/test/test_ns_couette_flow_2d_x.C
+++ b/test/test_ns_couette_flow_2d_x.C
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
   grvy_timer.Finalize();
 #endif
 
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   // Create Exact solution object and attach exact solution quantities
   libMesh::ExactSolution exact_sol(*es);

--- a/test/test_ns_couette_flow_2d_y.C
+++ b/test/test_ns_couette_flow_2d_y.C
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
   grvy_timer.Finalize();
 #endif
 
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   // Create Exact solution object and attach exact solution quantities
   libMesh::ExactSolution exact_sol(*es);

--- a/test/test_ns_poiseuille_flow.C
+++ b/test/test_ns_poiseuille_flow.C
@@ -98,7 +98,7 @@ int main(int argc, char* argv[])
  
   GRINS::SimulationBuilder sim_builder;
 
-  std::tr1::shared_ptr<ParabolicBCFactory> bc_factory( new ParabolicBCFactory );
+  GRINS::SharedPtr<GRINS::BoundaryConditionsFactory> bc_factory( new ParabolicBCFactory );
 
   sim_builder.attach_bc_factory(bc_factory);
 
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   // Create Exact solution object and attach exact solution quantities
   libMesh::ExactSolution exact_sol(*es);
@@ -166,8 +166,8 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > ParabolicBCFactory::bui
   cont.add_var_name( "u" );
   cont.add_bc_id( 1 );
   cont.add_bc_id( 3 );
-  
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > u_func( new GRINS::ParabolicProfile );
+
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> > u_func( new GRINS::ParabolicProfile );
 
   cont.set_func( u_func );
 

--- a/test/test_stokes_poiseuille_flow.C
+++ b/test/test_stokes_poiseuille_flow.C
@@ -97,7 +97,7 @@ int main(int argc, char* argv[])
  
   GRINS::SimulationBuilder sim_builder;
 
-  std::tr1::shared_ptr<ParabolicBCFactory> bc_factory( new ParabolicBCFactory );
+  GRINS::SharedPtr<GRINS::BoundaryConditionsFactory> bc_factory( new ParabolicBCFactory );
 
   sim_builder.attach_bc_factory(bc_factory);
 
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   // Create Exact solution object and attach exact solution quantities
   libMesh::ExactSolution exact_sol(*es);
@@ -167,8 +167,8 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > ParabolicBCFactory::bui
   cont.add_var_name( "u" );
   cont.add_bc_id( 1 );
   cont.add_bc_id( 3 );
-  
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > u_func( new GRINS::ParabolicProfile );
+
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> > u_func( new GRINS::ParabolicProfile );
 
   cont.set_func( u_func );
 

--- a/test/test_stokes_poiseuille_flow_parsed_viscosity.C
+++ b/test/test_stokes_poiseuille_flow_parsed_viscosity.C
@@ -97,7 +97,7 @@ int main(int argc, char* argv[])
  
   GRINS::SimulationBuilder sim_builder;
 
-  std::tr1::shared_ptr<ParabolicBCFactory> bc_factory( new ParabolicBCFactory );
+  GRINS::SharedPtr<GRINS::BoundaryConditionsFactory> bc_factory( new ParabolicBCFactory );
 
   sim_builder.attach_bc_factory(bc_factory);
 
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   // Create Exact solution object and attach exact solution quantities
   libMesh::ExactSolution exact_sol(*es);
@@ -165,8 +165,8 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > ParabolicBCFactory::bui
   cont.add_var_name( "u" );
   cont.add_bc_id( 1 );
   cont.add_bc_id( 3 );
-  
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > u_func( new GRINS::ParabolicProfile );
+
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> > u_func( new GRINS::ParabolicProfile );
 
   cont.set_func( u_func );
 

--- a/test/test_stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity.C
+++ b/test/test_stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity.C
@@ -97,7 +97,7 @@ int main(int argc, char* argv[])
  
   GRINS::SimulationBuilder sim_builder;
 
-  std::tr1::shared_ptr<ParabolicBCFactory> bc_factory( new ParabolicBCFactory );
+  GRINS::SharedPtr<GRINS::BoundaryConditionsFactory> bc_factory( new ParabolicBCFactory );
 
   sim_builder.attach_bc_factory(bc_factory);
 
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   // Create Exact solution object and attach exact solution quantities
   libMesh::ExactSolution exact_sol(*es);
@@ -167,8 +167,8 @@ std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > ParabolicBCFactory::bui
   cont.add_var_name( "u" );
   cont.add_bc_id( 1 );
   cont.add_bc_id( 3 );
-  
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > u_func( new GRINS::ParabolicProfile );
+
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> > u_func( new GRINS::ParabolicProfile );
 
   cont.set_func( u_func );
 

--- a/test/test_thermally_driven_flow.C
+++ b/test/test_thermally_driven_flow.C
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
  
   GRINS::SimulationBuilder sim_builder;
 
-  sim_builder.attach_bc_factory( std::tr1::shared_ptr<GRINS::BoundaryConditionsFactory>( new GRINS::ThermallyDrivenFlowTestBCFactory( libMesh_inputfile ) ) );
+  sim_builder.attach_bc_factory( GRINS::SharedPtr<GRINS::BoundaryConditionsFactory>( new GRINS::ThermallyDrivenFlowTestBCFactory( libMesh_inputfile ) ) );
 
   GRINS::Simulation grins( libMesh_inputfile,
 			   sim_builder,
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
   grins.run();
 
   // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   //es->write("foobar.xdr");
 
@@ -214,7 +214,7 @@ std::map< GRINS::PhysicsName, GRINS::NBCContainer > GRINS::ThermallyDrivenFlowTe
       const libMesh::System& system = es.get_system("GRINS");
       const GRINS::VariableIndex T_var = system.variable_number("T");
 
-      std::tr1::shared_ptr<GRINS::NeumannFuncObj> func( new ZeroFluxBC );
+      GRINS::SharedPtr<GRINS::NeumannFuncObj> func( new ZeroFluxBC );
 
       GRINS::NBCContainer nbc_container;
       nbc_container.set_bc_id(0);

--- a/test/test_turbulent_channel.C
+++ b/test/test_turbulent_channel.C
@@ -249,7 +249,7 @@ int main(int argc, char* argv[])
 
   GRINS::SimulationBuilder sim_builder;
 
-  std::tr1::shared_ptr<TurbulentBCFactory> bc_factory( new TurbulentBCFactory(turbulent_bc_values.get()) );
+  GRINS::SharedPtr<GRINS::BoundaryConditionsFactory> bc_factory( new TurbulentBCFactory(turbulent_bc_values.get()) );
 
   sim_builder.attach_bc_factory(bc_factory);
 
@@ -268,7 +268,7 @@ int main(int argc, char* argv[])
   grins.run();
 
 // Get equation systems to create ExactSolution object
-  std::tr1::shared_ptr<libMesh::EquationSystems> es = grins.get_equation_system();
+  GRINS::SharedPtr<libMesh::EquationSystems> es = grins.get_equation_system();
 
   // Create Exact solution object and attach exact solution quantities
   //libMesh::ExactSolution exact_sol(*es);
@@ -387,9 +387,9 @@ void test_error_norm( libMesh::ExactSolution& exact_sol,
 
 std::multimap< GRINS::PhysicsName, GRINS::DBCContainer > TurbulentBCFactory::build_dirichlet( )
 {
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > turbulent_inlet_u( new TurbulentBdyFunctionU(this->turbulent_bc_values) );
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> > turbulent_inlet_u( new TurbulentBdyFunctionU(this->turbulent_bc_values) );
 
-  std::tr1::shared_ptr<libMesh::FunctionBase<libMesh::Number> > turbulent_inlet_nu( new TurbulentBdyFunctionNu(this->turbulent_bc_values) );
+  GRINS::SharedPtr<libMesh::FunctionBase<libMesh::Number> > turbulent_inlet_nu( new TurbulentBdyFunctionNu(this->turbulent_bc_values) );
 
   GRINS::DBCContainer cont_u;
   cont_u.add_var_name( "u" );


### PR DESCRIPTION
I've wanted to do this for awhile, but the straw that broke the camel's back was needing to use GCC 5.2.0 on my laptop (thanks for breaking backward compatibility with the assembler Apple) and there were *many* warnings about the `auto_ptr` interface in the Boost smart pointer implementations, making real warnings undetectable.

This PR adds `GRINS::SharedPtr`. I took a cue from the discussion libqueso/queso#398 and went with inheritance instead of the template typedef trick. We piggy back on libMesh's check for `std::shared_ptr` and prefer that if it's there. If not, we fall back to Boost, and then error if `boost::shared_ptr` is not available. I also updated all uses of `boost::scoped_ptr` to use `libMesh::UniquePtr`. Note I haven't touched the `libMesh::AutoPtr` uses, we'll do that in a separate PR. Finally, updated the build system so we only try to detect (and use) Boost if libMesh didn't find `std::shared_ptr`. I also updated the config_summary  for the Boost changes. Also updated config_summary to make the info reported on Cantera and Antioch a little more precise/verbose while I was at it.

Happy Thanksgiving GRINS users and developers.