### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.C linguist-language=C++
+*.h linguist-language=C++
+src/common/lcov/* linguist-vendored
+src/common/lic_utils/* linguist-vendored
+test/test_data/* linguist-vendored


### PR DESCRIPTION
Used by GitHub/linguist for source statistics. Mainly to tell it
we're doing C++ and ignore the license header stuff and the test data.