### PR TITLE
Consolidate Variable Initialization/Usage

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,6 +139,7 @@ libgrins_la_SOURCES += physics/src/parsed_source_term.C
 libgrins_la_SOURCES += physics/src/thermo_pressure_variable.C
 libgrins_la_SOURCES += physics/src/thermo_pressure_fe_variable.C
 libgrins_la_SOURCES += physics/src/species_mass_fracs_variables.C
+libgrins_la_SOURCES += physics/src/species_mass_fracs_fe_variables.C
 
 # src/properties files
 libgrins_la_SOURCES += properties/src/parsed_property_base.C
@@ -362,6 +363,7 @@ include_HEADERS += physics/include/grins/parsed_source_term.h
 include_HEADERS += physics/include/grins/thermo_pressure_variable.h
 include_HEADERS += physics/include/grins/thermo_pressure_fe_variable.h
 include_HEADERS += physics/include/grins/species_mass_fracs_variables.h
+include_HEADERS += physics/include/grins/species_mass_fracs_fe_variables.h
 
 # src/properties headers
 include_HEADERS += properties/include/grins/property_types.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -138,6 +138,7 @@ libgrins_la_SOURCES += physics/src/constant_source_term.C
 libgrins_la_SOURCES += physics/src/parsed_source_term.C
 libgrins_la_SOURCES += physics/src/thermo_pressure_variable.C
 libgrins_la_SOURCES += physics/src/thermo_pressure_fe_variable.C
+libgrins_la_SOURCES += physics/src/species_mass_fracs_variables.C
 
 # src/properties files
 libgrins_la_SOURCES += properties/src/parsed_property_base.C
@@ -360,6 +361,7 @@ include_HEADERS += physics/include/grins/constant_source_term.h
 include_HEADERS += physics/include/grins/parsed_source_term.h
 include_HEADERS += physics/include/grins/thermo_pressure_variable.h
 include_HEADERS += physics/include/grins/thermo_pressure_fe_variable.h
+include_HEADERS += physics/include/grins/species_mass_fracs_variables.h
 
 # src/properties headers
 include_HEADERS += properties/include/grins/property_types.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -136,6 +136,7 @@ libgrins_la_SOURCES += physics/src/nonlinear_elasticity_instantiate.C
 libgrins_la_SOURCES += physics/src/source_term_base.C
 libgrins_la_SOURCES += physics/src/constant_source_term.C
 libgrins_la_SOURCES += physics/src/parsed_source_term.C
+libgrins_la_SOURCES += physics/src/thermo_pressure_variable.C
 
 # src/properties files
 libgrins_la_SOURCES += properties/src/parsed_property_base.C
@@ -356,6 +357,7 @@ include_HEADERS += physics/include/grins/elastic_cable_constant_gravity.h
 include_HEADERS += physics/include/grins/source_term_base.h
 include_HEADERS += physics/include/grins/constant_source_term.h
 include_HEADERS += physics/include/grins/parsed_source_term.h
+include_HEADERS += physics/include/grins/thermo_pressure_variable.h
 
 # src/properties headers
 include_HEADERS += properties/include/grins/property_types.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,7 @@ libgrins_la_SOURCES += physics/src/source_term_base.C
 libgrins_la_SOURCES += physics/src/constant_source_term.C
 libgrins_la_SOURCES += physics/src/parsed_source_term.C
 libgrins_la_SOURCES += physics/src/thermo_pressure_variable.C
+libgrins_la_SOURCES += physics/src/thermo_pressure_fe_variable.C
 
 # src/properties files
 libgrins_la_SOURCES += properties/src/parsed_property_base.C
@@ -358,6 +359,7 @@ include_HEADERS += physics/include/grins/source_term_base.h
 include_HEADERS += physics/include/grins/constant_source_term.h
 include_HEADERS += physics/include/grins/parsed_source_term.h
 include_HEADERS += physics/include/grins/thermo_pressure_variable.h
+include_HEADERS += physics/include/grins/thermo_pressure_fe_variable.h
 
 # src/properties headers
 include_HEADERS += properties/include/grins/property_types.h

--- a/src/bc_handling/include/grins/axisym_heat_transfer_bc_handling.h
+++ b/src/bc_handling/include/grins/axisym_heat_transfer_bc_handling.h
@@ -27,6 +27,7 @@
 
 //GRINS
 #include "bc_handling_base.h"
+#include "grins/primitive_temp_variables.h"
 
 namespace GRINS
 {
@@ -65,9 +66,7 @@ namespace GRINS
 
     AxisymmetricHeatTransferBCHandling();
 
-    std::string _T_var_name;
-
-    VariableIndex _T_var;
+    PrimitiveTempVariables _temp_vars;
 
     enum AHT_BC_TYPES{AXISYMMETRIC=0,
 		      ISOTHERMAL_WALL,

--- a/src/bc_handling/include/grins/low_mach_navier_stokes_bc_handling.h
+++ b/src/bc_handling/include/grins/low_mach_navier_stokes_bc_handling.h
@@ -28,6 +28,7 @@
 //GRINS
 #include "grins/bc_handling_base.h"
 #include "grins/parabolic_profile.h"
+#include "grins/primitive_flow_variables.h"
 
 namespace GRINS
 {
@@ -62,8 +63,10 @@ namespace GRINS
 
   protected:
 
-    std::string _u_var_name, _v_var_name, _w_var_name, _T_var_name;
-    
+    PrimitiveFlowVariables _flow_vars;
+
+    std::string _T_var_name;
+
     GRINS::VariableIndex _T_var;
 
     // We need a second container to stash dirichlet values for the energy equation

--- a/src/bc_handling/include/grins/low_mach_navier_stokes_bc_handling.h
+++ b/src/bc_handling/include/grins/low_mach_navier_stokes_bc_handling.h
@@ -29,6 +29,7 @@
 #include "grins/bc_handling_base.h"
 #include "grins/parabolic_profile.h"
 #include "grins/primitive_flow_variables.h"
+#include "grins/primitive_temp_variables.h"
 
 namespace GRINS
 {
@@ -65,9 +66,7 @@ namespace GRINS
 
     PrimitiveFlowVariables _flow_vars;
 
-    std::string _T_var_name;
-
-    GRINS::VariableIndex _T_var;
+    PrimitiveTempVariables _temp_vars;
 
     // We need a second container to stash dirichlet values for the energy equation
     std::map< GRINS::BoundaryID, libMesh::Real > _T_values;

--- a/src/bc_handling/include/grins/reacting_low_mach_navier_stokes_bc_handling.h
+++ b/src/bc_handling/include/grins/reacting_low_mach_navier_stokes_bc_handling.h
@@ -31,6 +31,7 @@
 // GRINS
 #include "grins/low_mach_navier_stokes_bc_handling.h"
 #include "grins/catalytic_wall_base.h"
+#include "grins/species_mass_fracs_variables.h"
 
 namespace GRINS
 {
@@ -91,9 +92,9 @@ namespace GRINS
     // We also need another map container
     std::vector<std::pair<BoundaryID,BCType> > _species_bc_map;
 
+    SpeciesMassFractionsVariables _species_vars;
+
     unsigned int _n_species;
-    std::vector<std::string> _species_var_names;
-    std::vector<GRINS::VariableIndex> _species_vars;
 
     std::multimap<BoundaryID, SharedPtr<CatalyticWallBase<Chemistry> > > _catalytic_walls;
 

--- a/src/bc_handling/src/low_mach_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/low_mach_navier_stokes_bc_handling.C
@@ -39,7 +39,7 @@ namespace GRINS
 							       const GetPot& input)
     : BCHandlingBase(physics_name),
       _flow_vars(input),
-      _T_var_name( input("Physics/VariableNames/Temperature", T_var_name_default ) )
+      _temp_vars(input)
   {
     std::string id_str = "Physics/"+_physics_name+"/vel_bc_ids";
     std::string bc_str = "Physics/"+_physics_name+"/vel_bc_types";
@@ -113,7 +113,7 @@ namespace GRINS
   {
     _flow_vars.init(const_cast<libMesh::FEMSystem*>(&system));
 
-    _T_var = system.variable_number( _T_var_name );
+    _temp_vars.init(const_cast<libMesh::FEMSystem*>(&system));
 
     return;
   }
@@ -304,7 +304,7 @@ namespace GRINS
   {
     int dim = system->get_mesh().mesh_dimension();
 
-    VariableIndex T_var = system->variable_number( _T_var_name );
+    VariableIndex T_var = _temp_vars.T_var();
     VariableIndex u_var = _flow_vars.u_var();
     VariableIndex v_var = _flow_vars.v_var();
     VariableIndex w_var = -1;

--- a/src/bc_handling/src/low_mach_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/low_mach_navier_stokes_bc_handling.C
@@ -38,9 +38,7 @@ namespace GRINS
   LowMachNavierStokesBCHandling::LowMachNavierStokesBCHandling(const std::string& physics_name,
 							       const GetPot& input)
     : BCHandlingBase(physics_name),
-      _u_var_name( input("Physics/VariableNames/u_velocity", u_var_name_default ) ),
-      _v_var_name( input("Physics/VariableNames/v_velocity", v_var_name_default ) ),
-      _w_var_name( input("Physics/VariableNames/w_velocity", w_var_name_default ) ),
+      _flow_vars(input),
       _T_var_name( input("Physics/VariableNames/Temperature", T_var_name_default ) )
   {
     std::string id_str = "Physics/"+_physics_name+"/vel_bc_ids";
@@ -113,6 +111,8 @@ namespace GRINS
 
   void LowMachNavierStokesBCHandling::init_bc_data( const libMesh::FEMSystem& system )
   {
+    _flow_vars.init(const_cast<libMesh::FEMSystem*>(&system));
+
     _T_var = system.variable_number( _T_var_name );
 
     return;
@@ -305,11 +305,11 @@ namespace GRINS
     int dim = system->get_mesh().mesh_dimension();
 
     VariableIndex T_var = system->variable_number( _T_var_name );
-    VariableIndex u_var = system->variable_number( _u_var_name );
-    VariableIndex v_var = system->variable_number( _v_var_name );
+    VariableIndex u_var = _flow_vars.u_var();
+    VariableIndex v_var = _flow_vars.v_var();
     VariableIndex w_var = -1;
     if( dim == 3 )
-      w_var = system->variable_number( _w_var_name );
+      w_var = _flow_vars.w_var();
 
     switch( bc_type )
       {

--- a/src/physics/include/grins/axisym_boussinesq_buoyancy.h
+++ b/src/physics/include/grins/axisym_boussinesq_buoyancy.h
@@ -30,6 +30,8 @@
 #include "grins_config.h"
 #include "grins/grins_enums.h"
 #include "grins/physics.h"
+#include "grins/primitive_flow_fe_variables.h"
+#include "grins/primitive_temp_fe_variables.h"
 
 // libMesh
 #include "libmesh/enum_order.h"
@@ -79,32 +81,9 @@ namespace GRINS
     //! Physical dimension of problem
     unsigned int _dim;
 
-    //! Element type, read from input
-    GRINSEnums::FEFamily _T_FE_family, _V_FE_family;
+    PrimitiveFlowFEVariables _flow_vars;
 
-    //! Temperature element order, read from input
-    GRINSEnums::Order _T_order, _V_order;
-
-    // Indices for each variable;
-    //! Index for r-velocity field
-    VariableIndex _u_r_var;
-
-    //! Index for z-velocity field
-    VariableIndex _u_z_var;
-
-    //! Index for temperature field
-    VariableIndex _T_var;
-
-    // Names of each variable in the system
-
-    //! Name of r-velocity
-    std::string _u_r_var_name;
-
-    //! Name of z-velocity
-    std::string _u_z_var_name;
-
-    //! Name of temperature
-    std::string _T_var_name;
+    PrimitiveTempFEVariables _temp_vars;
 
     //! \f$ \rho = \f$ density
     libMesh::Number _rho;

--- a/src/physics/include/grins/axisym_heat_transfer.h
+++ b/src/physics/include/grins/axisym_heat_transfer.h
@@ -30,6 +30,8 @@
 #include "grins_config.h"
 #include "grins/grins_enums.h"
 #include "grins/physics.h"
+#include "grins/primitive_flow_fe_variables.h"
+#include "grins/primitive_temp_fe_variables.h"
 
 // libMesh
 #include "libmesh/enum_order.h"
@@ -96,31 +98,9 @@ namespace GRINS
     /*! \todo Make this static member of base class? */
     unsigned int _dim;
 
-    // Indices for each variable;
-    //! Index for temperature field
-    VariableIndex _T_var;
+    PrimitiveFlowFEVariables _flow_vars;
 
-    //! Index for r-velocity field
-    VariableIndex _u_r_var;
-
-    //! Index for z-velocity field
-    VariableIndex _u_z_var; 
-
-    // Names of each variable in the system
-    //! Name for temperature variable
-    std::string _T_var_name;
-
-    //! Name of r-velocity
-    std::string _u_r_var_name;
-
-    //! Name of z-velocity
-    std::string _u_z_var_name;
-
-    //! Element type, read from input
-    GRINSEnums::FEFamily _T_FE_family, _V_FE_family;
-
-    //! Temperature element order, read from input
-    GRINSEnums::Order _T_order, _V_order;
+    PrimitiveTempFEVariables _temp_vars;
 
     //! Material parameters, read from input
     /*! \todo Need to generalize material parameters. Right now they

--- a/src/physics/include/grins/low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_base.h
@@ -31,6 +31,7 @@
 #include "grins/assembly_context.h"
 #include "grins/grins_enums.h"
 #include "grins/primitive_flow_fe_variables.h"
+#include "grins/primitive_temp_fe_variables.h"
 
 //libMesh
 #include "libmesh/enum_order.h"
@@ -97,18 +98,13 @@ namespace GRINS
 
     PrimitiveFlowFEVariables _flow_vars;
 
+    PrimitiveTempFEVariables _temp_vars;
+
     //! Indices for each (owned) variable;
-    VariableIndex _T_var; /* Index for pressure field */
     VariableIndex _p0_var; /* Index for thermodynamic pressure */
 
     //! Names of each (owned) variable in the system
-    std::string _T_var_name, _p0_var_name;
-
-    //! Element type, read from input
-    GRINSEnums::FEFamily _T_FE_family;
-
-    //! Element orders, read from input
-    GRINSEnums::Order _T_order;
+    std::string _p0_var_name;
 
     //! Viscosity object
     Viscosity _mu;
@@ -135,7 +131,7 @@ namespace GRINS
   inline
   libMesh::Real LowMachNavierStokesBase<V,SH,TC>::T( const libMesh::Point& p, const AssemblyContext& c ) const
   {
-    return c.point_value(_T_var,p);
+    return c.point_value(_temp_vars.T_var(),p);
   }
 
   template<class V, class SH, class TC>

--- a/src/physics/include/grins/low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_base.h
@@ -30,6 +30,7 @@
 #include "grins/physics.h"
 #include "grins/assembly_context.h"
 #include "grins/grins_enums.h"
+#include "grins/primitive_flow_fe_variables.h"
 
 //libMesh
 #include "libmesh/enum_order.h"
@@ -94,22 +95,20 @@ namespace GRINS
     //! Physical dimension of problem
     unsigned int _dim;
 
+    PrimitiveFlowFEVariables _flow_vars;
+
     //! Indices for each (owned) variable;
-    VariableIndex _u_var; /* Index for x-velocity field */
-    VariableIndex _v_var; /* Index for y-velocity field */
-    VariableIndex _w_var; /* Index for z-velocity field */
-    VariableIndex _p_var; /* Index for pressure field */
     VariableIndex _T_var; /* Index for pressure field */
     VariableIndex _p0_var; /* Index for thermodynamic pressure */
 
     //! Names of each (owned) variable in the system
-    std::string _u_var_name, _v_var_name, _w_var_name, _p_var_name, _T_var_name, _p0_var_name;
+    std::string _T_var_name, _p0_var_name;
 
     //! Element type, read from input
-    GRINSEnums::FEFamily _V_FE_family, _P_FE_family, _T_FE_family;
+    GRINSEnums::FEFamily _T_FE_family;
 
     //! Element orders, read from input
-    GRINSEnums::Order _V_order, _P_order, _T_order;
+    GRINSEnums::Order _T_order;
 
     //! Viscosity object
     Viscosity _mu;

--- a/src/physics/include/grins/low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_base.h
@@ -32,6 +32,7 @@
 #include "grins/grins_enums.h"
 #include "grins/primitive_flow_fe_variables.h"
 #include "grins/primitive_temp_fe_variables.h"
+#include "grins/thermo_pressure_fe_variable.h"
 
 //libMesh
 #include "libmesh/enum_order.h"
@@ -100,11 +101,7 @@ namespace GRINS
 
     PrimitiveTempFEVariables _temp_vars;
 
-    //! Indices for each (owned) variable;
-    VariableIndex _p0_var; /* Index for thermodynamic pressure */
-
-    //! Names of each (owned) variable in the system
-    std::string _p0_var_name;
+    ThermoPressureFEVariable _p0_var;
 
     //! Viscosity object
     Viscosity _mu;
@@ -140,23 +137,23 @@ namespace GRINS
   {
     return p0/(this->_R*T);
   }
-  
+
   template<class V, class SH, class TC>
   inline
   libMesh::Real LowMachNavierStokesBase<V,SH,TC>::d_rho_dT( libMesh::Real T, libMesh::Real p0 ) const
   {
     return -p0/(this->_R*(T*T));
   }
-  
+
   template<class V, class SH, class TC>
-  inline 
+  inline
   libMesh::Real LowMachNavierStokesBase<V,SH,TC>::get_p0_steady( const AssemblyContext& c,
 								 unsigned int qp ) const
   {
     libMesh::Real p0;
     if( this->_enable_thermo_press_calc )
       {
-	p0 = c.interior_value( _p0_var, qp );
+	p0 = c.interior_value( _p0_var.p0_var(), qp );
       }
     else
       {
@@ -166,14 +163,14 @@ namespace GRINS
   }
 
   template<class V, class SH, class TC>
-  inline 
+  inline
   libMesh::Real LowMachNavierStokesBase<V,SH,TC>::get_p0_steady_side( const AssemblyContext& c,
 								      unsigned int qp ) const
   {
     libMesh::Real p0;
     if( this->_enable_thermo_press_calc )
       {
-	p0 = c.side_value( _p0_var, qp );
+	p0 = c.side_value( _p0_var.p0_var(), qp );
       }
     else
       {
@@ -183,14 +180,14 @@ namespace GRINS
   }
 
   template<class V, class SH, class TC>
-  inline 
-  libMesh::Real LowMachNavierStokesBase<V,SH,TC>::get_p0_steady( const AssemblyContext& c, 
+  inline
+  libMesh::Real LowMachNavierStokesBase<V,SH,TC>::get_p0_steady( const AssemblyContext& c,
 								 const libMesh::Point& p ) const
   {
     libMesh::Real p0;
     if( this->_enable_thermo_press_calc )
       {
-	p0 = c.point_value( _p0_var, p );
+	p0 = c.point_value( _p0_var.p0_var(), p );
       }
     else
       {
@@ -200,13 +197,13 @@ namespace GRINS
   }
 
   template<class V, class SH, class TC>
-  inline 
+  inline
   libMesh::Real LowMachNavierStokesBase<V,SH,TC>::get_p0_transient( AssemblyContext& c, unsigned int qp ) const
   {
     libMesh::Real p0;
     if( this->_enable_thermo_press_calc )
       {
-	p0 = c.fixed_interior_value( _p0_var, qp );
+	p0 = c.fixed_interior_value( _p0_var.p0_var(), qp );
       }
     else
       {

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
@@ -34,6 +34,7 @@
 #include "grins/assembly_context.h"
 #include "grins/primitive_flow_fe_variables.h"
 #include "grins/primitive_temp_fe_variables.h"
+#include "grins/thermo_pressure_fe_variable.h"
 
 namespace GRINS
 {
@@ -91,13 +92,13 @@ namespace GRINS
 
     PrimitiveTempFEVariables _temp_vars;
 
+    ThermoPressureFEVariable _p0_var;
+
     //! Indices for each (owned) variable;
     std::vector<VariableIndex> _species_vars; /* Indicies for species densities */
-    VariableIndex _p0_var; /* Index for thermodynamic pressure */
 
     //! Names of each (owned) variable in the system
     std::vector<std::string> _species_var_names;
-    std::string _p0_var_name;
 
     //! Element type, read from input
     GRINSEnums::FEFamily _species_FE_family;
@@ -172,7 +173,7 @@ namespace GRINS
     libMesh::Real p0;
     if( this->_enable_thermo_press_calc )
       {
-        p0 = c.interior_value( _p0_var, qp );
+        p0 = c.interior_value( _p0_var.p0_var(), qp );
       }
     else
       {
@@ -189,7 +190,7 @@ namespace GRINS
     libMesh::Real p0;
     if( this->_enable_thermo_press_calc )
       {
-        p0 = c.side_value( _p0_var, qp );
+        p0 = c.side_value( _p0_var.p0_var(), qp );
       }
     else
       {
@@ -206,7 +207,7 @@ namespace GRINS
     libMesh::Real p0;
     if( this->_enable_thermo_press_calc )
       {
-        p0 = c.point_value( _p0_var, p );
+        p0 = c.point_value( _p0_var.p0_var(), p );
       }
     else
       {
@@ -223,7 +224,7 @@ namespace GRINS
     libMesh::Real p0;
     if( this->_enable_thermo_press_calc )
       {
-        p0 = c.fixed_interior_value( _p0_var, qp );
+        p0 = c.fixed_interior_value( _p0_var.p0_var(), qp );
       }
     else
       {

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
@@ -35,6 +35,7 @@
 #include "grins/primitive_flow_fe_variables.h"
 #include "grins/primitive_temp_fe_variables.h"
 #include "grins/thermo_pressure_fe_variable.h"
+#include "grins/species_mass_fracs_fe_variables.h"
 
 namespace GRINS
 {
@@ -85,26 +86,16 @@ namespace GRINS
     //! Physical dimension of problem
     unsigned int _dim;
 
-    //! Number of species
-    unsigned int _n_species;
-
     PrimitiveFlowFEVariables _flow_vars;
 
     PrimitiveTempFEVariables _temp_vars;
 
     ThermoPressureFEVariable _p0_var;
 
-    //! Indices for each (owned) variable;
-    std::vector<VariableIndex> _species_vars; /* Indicies for species densities */
+    SpeciesMassFractionsFEVariables _species_vars;
 
-    //! Names of each (owned) variable in the system
-    std::vector<std::string> _species_var_names;
-
-    //! Element type, read from input
-    GRINSEnums::FEFamily _species_FE_family;
-
-    //! Element orders, read from input
-    GRINSEnums::Order _species_order;
+    //! Number of species
+    unsigned int _n_species;
 
     //! Gravity vector
     libMesh::Point _g; 
@@ -144,7 +135,7 @@ namespace GRINS
 
     for( unsigned int var = 0; var < this->_n_species; var++ )
       {
-        mass_fracs[var] = c.point_value(_species_vars[var],p);
+        mass_fracs[var] = c.point_value(_species_vars.species_var(var),p);
       }
 
     return;

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
@@ -32,6 +32,8 @@
 #include "grins/physics.h"
 #include "grins/pressure_pinning.h"
 #include "grins/assembly_context.h"
+#include "grins/primitive_flow_fe_variables.h"
+#include "grins/primitive_temp_fe_variables.h"
 
 namespace GRINS
 {
@@ -85,24 +87,23 @@ namespace GRINS
     //! Number of species
     unsigned int _n_species;
 
+    PrimitiveFlowFEVariables _flow_vars;
+
+    PrimitiveTempFEVariables _temp_vars;
+
     //! Indices for each (owned) variable;
     std::vector<VariableIndex> _species_vars; /* Indicies for species densities */
-    VariableIndex _u_var; /* Index for x-velocity field */
-    VariableIndex _v_var; /* Index for y-velocity field */
-    VariableIndex _w_var; /* Index for z-velocity field */
-    VariableIndex _p_var; /* Index for pressure field */
-    VariableIndex _T_var; /* Index for pressure field */
     VariableIndex _p0_var; /* Index for thermodynamic pressure */
 
     //! Names of each (owned) variable in the system
     std::vector<std::string> _species_var_names;
-    std::string _u_var_name, _v_var_name, _w_var_name, _p_var_name, _T_var_name, _p0_var_name;
+    std::string _p0_var_name;
 
     //! Element type, read from input
-    GRINSEnums::FEFamily _species_FE_family, _V_FE_family, _P_FE_family, _T_FE_family;
+    GRINSEnums::FEFamily _species_FE_family;
 
     //! Element orders, read from input
-    GRINSEnums::Order _species_order, _V_order, _P_order, _T_order;
+    GRINSEnums::Order _species_order;
 
     //! Gravity vector
     libMesh::Point _g; 
@@ -130,7 +131,7 @@ namespace GRINS
   inline
   libMesh::Real ReactingLowMachNavierStokesBase<Mixture,Evaluator>::T( const libMesh::Point& p,
                                                                        const AssemblyContext& c ) const
-  { return c.point_value(_T_var,p); }
+  { return c.point_value(_temp_vars.T_var(),p); }
 
   template<typename Mixture, typename Evaluator>
   inline

--- a/src/physics/include/grins/species_mass_fracs_fe_variables.h
+++ b/src/physics/include/grins/species_mass_fracs_fe_variables.h
@@ -1,0 +1,65 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_SPECIES_MASS_FRACS_FE_VARIABLES_H
+#define GRINS_SPECIES_MASS_FRACS_FE_VARIABLES_H
+
+// GRINS
+#include "grins/grins_enums.h"
+#include "grins/species_mass_fracs_variables.h"
+
+// libMesh
+#include "libmesh/enum_order.h"
+#include "libmesh/enum_fe_family.h"
+
+namespace GRINS
+{
+
+  class SpeciesMassFractionsFEVariables : public SpeciesMassFractionsVariables
+  {
+  public:
+
+    SpeciesMassFractionsFEVariables( const GetPot& input, const std::string& physics_name );
+    ~SpeciesMassFractionsFEVariables(){};
+
+    virtual void init( libMesh::FEMSystem* system );
+
+  protected:
+
+    //! Element type, read from input
+    GRINSEnums::FEFamily _species_FE_family;
+
+    //! Element orders, read from input
+    GRINSEnums::Order _species_order;
+
+  private:
+
+    SpeciesMassFractionsFEVariables();
+
+  };
+
+} // end namespace GRINS
+
+#endif //GRINS_SPECIES_MASS_FRACS_FE_VARIABLES_H

--- a/src/physics/include/grins/species_mass_fracs_variables.h
+++ b/src/physics/include/grins/species_mass_fracs_variables.h
@@ -1,0 +1,87 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_SPECIES_MASS_FRACS_VARIABLES_H
+#define GRINS_SPECIES_MASS_FRACS_VARIABLES_H
+
+// C++
+#include <vector>
+
+// GRINS
+#include "grins/var_typedefs.h"
+
+// libMesh forward declarations
+class GetPot;
+namespace libMesh
+{
+  class FEMSystem;
+}
+
+namespace GRINS
+{
+  class SpeciesMassFractionsVariables
+  {
+  public:
+
+    SpeciesMassFractionsVariables( const GetPot& input, const std::string& material_name );
+    ~SpeciesMassFractionsVariables(){};
+
+    virtual void init( libMesh::FEMSystem* system );
+
+    unsigned int n_species() const;
+
+    VariableIndex species_var( unsigned int species ) const;
+
+  protected:
+
+    //! Indices for each (owned) variable;
+    std::vector<VariableIndex> _species_vars; /* Indicies for species densities */
+
+    //! Names of each (owned) variable in the system
+    std::vector<std::string> _species_var_names;
+
+  private:
+
+    SpeciesMassFractionsVariables();
+
+  };
+
+  inline
+  unsigned int SpeciesMassFractionsVariables::n_species() const
+  {
+    // We *must* use the size of _species_var_names here since that gets populated
+    // at construction time.
+    return _species_var_names.size();
+  }
+
+  inline
+  VariableIndex SpeciesMassFractionsVariables::species_var( unsigned int species ) const
+  {
+    return _species_vars[species];
+  }
+
+} // end namespace GRINS
+
+#endif // GRINS_SPECIES_MASS_FRACS_VARIABLES_H

--- a/src/physics/include/grins/thermo_pressure_fe_variable.h
+++ b/src/physics/include/grins/thermo_pressure_fe_variable.h
@@ -1,0 +1,64 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_THERMO_PRESSURE_FE_VARIABLE_H
+#define GRINS_THERMO_PRESSURE_FE_VARIABLE_H
+
+// GRINS
+#include "grins/grins_enums.h"
+#include "grins/thermo_pressure_variable.h"
+
+// libMesh
+#include "libmesh/enum_order.h"
+#include "libmesh/enum_fe_family.h"
+
+namespace GRINS
+{
+
+  class ThermoPressureFEVariable : public ThermoPressureVariable
+  {
+  public:
+
+    ThermoPressureFEVariable( const GetPot& input, const std::string& physics_name );
+    ~ThermoPressureFEVariable(){};
+
+    virtual void init( libMesh::FEMSystem* system );
+
+  protected:
+
+    //! Element type, read from input
+    GRINSEnums::FEFamily _P_FE_family;
+
+    //! Element orders, read from input
+    GRINSEnums::Order _P_order;
+
+  private:
+
+    ThermoPressureFEVariable();
+
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_THERMO_PRESSURE_FE_VARIABLE_H

--- a/src/physics/include/grins/thermo_pressure_variable.h
+++ b/src/physics/include/grins/thermo_pressure_variable.h
@@ -1,0 +1,74 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_THERMO_PRESSURE_VARIABLE_H
+#define GRINS_THERMO_PRESSURE_VARIABLE_H
+
+// GRINS
+#include "grins/var_typedefs.h"
+
+// libMesh forward declarations
+class GetPot;
+namespace libMesh
+{
+  class FEMSystem;
+}
+
+namespace GRINS
+{
+  class ThermoPressureVariable
+  {
+  public:
+
+    ThermoPressureVariable( const GetPot& input );
+    ~ThermoPressureVariable(){};
+
+    virtual void init( libMesh::FEMSystem* system );
+
+    VariableIndex p0_var() const;
+
+  protected:
+
+    //! Indices for each (owned) variable;
+    VariableIndex _p0_var;
+
+    //! Names of each (owned) variable in the system
+    std::string _p0_var_name;
+
+  private:
+
+    ThermoPressureVariable();
+
+  };
+
+  inline
+  VariableIndex ThermoPressureVariable::p0_var() const
+  {
+    return _p0_var;
+  }
+
+} // end namespace GRINS
+
+#endif // GRINS_THERMO_PRESSURE_VARIABLE_H

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -124,10 +124,10 @@ namespace GRINS
     context.get_side_fe(this->_flow_vars.u_var())->get_dphi();
     context.get_side_fe(this->_flow_vars.u_var())->get_xyz();
 
-    context.get_side_fe(this->_T_var)->get_JxW();
-    context.get_side_fe(this->_T_var)->get_phi();
-    context.get_side_fe(this->_T_var)->get_dphi();
-    context.get_side_fe(this->_T_var)->get_xyz();
+    context.get_side_fe(this->_temp_vars.T_var())->get_JxW();
+    context.get_side_fe(this->_temp_vars.T_var())->get_phi();
+    context.get_side_fe(this->_temp_vars.T_var())->get_dphi();
+    context.get_side_fe(this->_temp_vars.T_var())->get_xyz();
 
     return;
   }
@@ -237,24 +237,22 @@ namespace GRINS
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.get_element_fe(this->_T_var)->get_phi();
-      
+      context.get_element_fe(this->_temp_vars.T_var())->get_phi();
+
     // The temperature shape function gradients (in global coords.)
     // at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.get_element_fe(this->_T_var)->get_dphi();
-      
-      
+      context.get_element_fe(this->_temp_vars.T_var())->get_dphi();
 
 
 
     libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_flow_vars.p_var()); // R_{p}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
-    
+
      // The number of local degrees of freedom in each variable.
-    const unsigned int n_t_dofs = context.get_dof_indices(this->_T_var).size();    
-    
+    const unsigned int n_t_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
+
      // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
@@ -290,7 +288,7 @@ namespace GRINS
 
     libMesh::DenseSubMatrix<libMesh::Number> &KPu = context.get_elem_jacobian(this->_flow_vars.p_var(), this->_flow_vars.u_var());
     libMesh::DenseSubMatrix<libMesh::Number> &KPv = context.get_elem_jacobian(this->_flow_vars.p_var(), this->_flow_vars.v_var());
-    libMesh::DenseSubMatrix<libMesh::Number> &KPT = context.get_elem_jacobian(this->_flow_vars.p_var(), this->_T_var);
+    libMesh::DenseSubMatrix<libMesh::Number> &KPT = context.get_elem_jacobian(this->_flow_vars.p_var(), this->_temp_vars.T_var());
 
     libMesh::DenseSubMatrix<libMesh::Number>* KPw = NULL;
 
@@ -352,7 +350,7 @@ namespace GRINS
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
     const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
 
     // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
     libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
@@ -369,7 +367,7 @@ namespace GRINS
     const std::vector<std::vector<libMesh::Real> >& p_phi =
       context.get_element_fe(this->_flow_vars.p_var())->get_phi();
       const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.get_element_fe(this->_T_var)->get_phi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_phi();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
@@ -440,8 +438,8 @@ namespace GRINS
     libMesh::DenseSubMatrix<libMesh::Number> &Kvp = context.get_elem_jacobian(this->_flow_vars.v_var(), this->_flow_vars.p_var()); // R_{v},{p}
     libMesh::DenseSubMatrix<libMesh::Number>* Kwp = NULL;
 
-    libMesh::DenseSubMatrix<libMesh::Number> &KuT = context.get_elem_jacobian(this->_flow_vars.u_var(), this->_T_var); // R_{u},{p}
-    libMesh::DenseSubMatrix<libMesh::Number> &KvT = context.get_elem_jacobian(this->_flow_vars.v_var(), this->_T_var); // R_{v},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &KuT = context.get_elem_jacobian(this->_flow_vars.u_var(), this->_temp_vars.T_var()); // R_{u},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &KvT = context.get_elem_jacobian(this->_flow_vars.v_var(), this->_temp_vars.T_var()); // R_{v},{p}
     libMesh::DenseSubMatrix<libMesh::Number>* KwT = NULL;
 
     if( this->_dim == 3 )
@@ -452,9 +450,9 @@ namespace GRINS
 	Kwv = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_flow_vars.v_var()); // R_{w},{v};
 	Kww = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_flow_vars.w_var()); // R_{w},{w}
 	Kwp = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_flow_vars.p_var()); // R_{w},{p}
-	KwT = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_T_var); // R_{w},{T}
+	KwT = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_temp_vars.T_var()); // R_{w},{T}
       }
-            
+
 	// Now a loop over the pressure degrees of freedom.  This
 	// computes the contributions of the continuity equation.
 	for (unsigned int i=0; i != n_u_dofs; i++)
@@ -643,24 +641,24 @@ namespace GRINS
 								  CachedValues& cache )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_T_var)->get_JxW();
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.get_element_fe(this->_T_var)->get_phi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_phi();
     const std::vector<std::vector<libMesh::Real> >& u_phi =
       context.get_element_fe(this->_flow_vars.u_var())->get_phi();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.get_element_fe(this->_T_var)->get_dphi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_temp_vars.T_var()); // R_{T}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
@@ -677,15 +675,15 @@ namespace GRINS
 		if (this->_dim == 3)
 		  U(2) = cache.get_cached_values(Cache::Z_VELOCITY)[qp]; // w
 
-		libMesh::DenseSubMatrix<libMesh::Number> &KTu = context.get_elem_jacobian(this->_T_var, this->_flow_vars.u_var()); // R_{u},{u}
-		libMesh::DenseSubMatrix<libMesh::Number> &KTv = context.get_elem_jacobian(this->_T_var, this->_flow_vars.v_var()); // R_{u},{u}
+		libMesh::DenseSubMatrix<libMesh::Number> &KTu = context.get_elem_jacobian(this->_temp_vars.T_var(), this->_flow_vars.u_var()); // R_{u},{u}
+		libMesh::DenseSubMatrix<libMesh::Number> &KTv = context.get_elem_jacobian(this->_temp_vars.T_var(), this->_flow_vars.v_var()); // R_{u},{u}
 			libMesh::DenseSubMatrix<libMesh::Number>* KTw = NULL;
 
-		libMesh::DenseSubMatrix<libMesh::Number> &KTT = context.get_elem_jacobian(this->_T_var, this->_T_var); // R_{u},{u}
+		libMesh::DenseSubMatrix<libMesh::Number> &KTT = context.get_elem_jacobian(this->_temp_vars.T_var(), this->_temp_vars.T_var()); // R_{u},{u}
 
 		if( this->_dim == 3 )
 		  {
-		    KTw = &context.get_elem_jacobian(this->_T_var, this->_flow_vars.w_var()); // R_{u},{w}
+		    KTw = &context.get_elem_jacobian(this->_temp_vars.T_var(), this->_flow_vars.w_var()); // R_{u},{w}
 		  }
 
 		libMesh::Number k = this->_k(T);
@@ -777,9 +775,9 @@ namespace GRINS
 	// u_fixed will be given by the fixed_interior_value function
 	// while u' will be given by the interior_rate function.
 	libMesh::Real T_dot;
-        context.interior_rate(this->_T_var, qp, T_dot);
+        context.interior_rate(this->_temp_vars.T_var(), qp, T_dot);
 
-	libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
+	libMesh::Real T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
 
 	for (unsigned int i = 0; i != n_p_dofs; ++i)
 	  {
@@ -832,8 +830,8 @@ namespace GRINS
 	if( this->_dim == 3 )
 	  context.interior_rate(this->_flow_vars.w_var(), qp, w_dot);
 
-	libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
-      
+	libMesh::Real T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
+
 	libMesh::Number rho = this->rho(T, this->get_p0_transient(context, qp));
       
 	for (unsigned int i = 0; i != n_u_dofs; ++i)
@@ -876,18 +874,18 @@ namespace GRINS
 								     AssemblyContext& context )
   {
     // Element Jacobian * quadrature weights for interior integration
-    const std::vector<libMesh::Real> &JxW = 
-      context.get_element_fe(this->_T_var)->get_JxW();
+    const std::vector<libMesh::Real> &JxW =
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The shape functions at interior quadrature points.
-    const std::vector<std::vector<libMesh::Real> >& T_phi = 
-      context.get_element_fe(this->_T_var)->get_phi();
-  
+    const std::vector<std::vector<libMesh::Real> >& T_phi =
+      context.get_element_fe(this->_temp_vars.T_var())->get_phi();
+
     // The number of local degrees of freedom in each variable
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
 
     // The subvectors and submatrices we need to fill:
-    libMesh::DenseSubVector<libMesh::Real> &F_T = context.get_elem_residual(this->_T_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_T = context.get_elem_residual(this->_temp_vars.T_var());
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -899,9 +897,9 @@ namespace GRINS
 	// u_fixed will be given by the fixed_interior_value function
 	// while u will be given by the interior_rate function.
 	libMesh::Real T_dot;
-        context.interior_rate(this->_T_var, qp, T_dot);
+        context.interior_rate(this->_temp_vars.T_var(), qp, T_dot);
 
-	libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
+	libMesh::Real T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
 
 	libMesh::Real cp = this->_cp(T);
 
@@ -922,8 +920,8 @@ namespace GRINS
 									     AssemblyContext& context )
   {
     // Element Jacobian * quadrature weights for interior integration
-    const std::vector<libMesh::Real> &JxW = 
-      context.get_element_fe(this->_T_var)->get_JxW();
+    const std::vector<libMesh::Real> &JxW =
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The number of local degrees of freedom in each variable
     const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var).size();
@@ -936,7 +934,7 @@ namespace GRINS
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {
 	libMesh::Number T;
-	T = context.interior_value(this->_T_var, qp);
+	T = context.interior_value(this->_temp_vars.T_var(), qp);
 
 	libMesh::Gradient grad_u, grad_v, grad_w;
 	grad_u = context.interior_gradient(this->_flow_vars.u_var(), qp);
@@ -973,23 +971,23 @@ namespace GRINS
     const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var).size();
 
     // Element Jacobian * quadrature weight for side integration.
-    //const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(this->_T_var)->get_JxW();
+    //const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(this->_temp_vars.T_var())->get_JxW();
 
-    //const std::vector<Point> &normals = context.get_side_fe(this->_T_var)->get_normals();
+    //const std::vector<Point> &normals = context.get_side_fe(this->_temp_vars.T_var())->get_normals();
 
     //libMesh::DenseSubVector<libMesh::Number> &F_p0 = context.get_elem_residual(this->_p0_var); // residual
 
     // Physical location of the quadrature points
-    //const std::vector<libMesh::Point>& qpoint = context.get_side_fe(this->_T_var)->get_xyz();
+    //const std::vector<libMesh::Point>& qpoint = context.get_side_fe(this->_temp_vars.T_var())->get_xyz();
 
     unsigned int n_qpoints = context.get_side_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	/*
-	libMesh::Number T = context.side_value( this->_T_var, qp );
+	libMesh::Number T = context.side_value( this->_temp_vars.T_var(), qp );
 	libMesh::Gradient U = ( context.side_value( this->_flow_vars.u_var(), qp ),
 				context.side_value( this->_flow_vars.v_var(), qp ) );
-	libMesh::Gradient grad_T = context.side_gradient( this->_T_var, qp );
+	libMesh::Gradient grad_T = context.side_gradient( this->_temp_vars.T_var(), qp );
 
 
 	libMesh::Number p0 = context.side_value( this->_p0_var, qp );
@@ -1021,16 +1019,16 @@ namespace GRINS
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var).size();
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
     const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration
-    const std::vector<libMesh::Real> &JxW = 
-      context.get_element_fe(this->_T_var)->get_JxW();
+    const std::vector<libMesh::Real> &JxW =
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.get_element_fe(this->_T_var)->get_phi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_phi();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& p_phi =
@@ -1038,7 +1036,7 @@ namespace GRINS
 
     // The subvectors and submatrices we need to fill:
     libMesh::DenseSubVector<libMesh::Real> &F_p0 = context.get_elem_residual(this->_p0_var);
-    libMesh::DenseSubVector<libMesh::Real> &F_T = context.get_elem_residual(this->_T_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_T = context.get_elem_residual(this->_temp_vars.T_var());
     libMesh::DenseSubVector<libMesh::Real> &F_p = context.get_elem_residual(this->_flow_vars.p_var());
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
@@ -1046,7 +1044,7 @@ namespace GRINS
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {
 	libMesh::Number T;
-	T = context.fixed_interior_value(this->_T_var, qp);
+	T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
 
 	libMesh::Number cp = this->_cp(T);
 	libMesh::Number cv = cp + this->_R;
@@ -1113,8 +1111,8 @@ namespace GRINS
 	    w[qp] = context.interior_value(this->_flow_vars.w_var(), qp);
 	    grad_w[qp] = context.interior_gradient(this->_flow_vars.w_var(), qp);
 	  }
-	T[qp] = context.interior_value(this->_T_var, qp);
-	grad_T[qp] = context.interior_gradient(this->_T_var, qp);
+	T[qp] = context.interior_value(this->_temp_vars.T_var(), qp);
+	grad_T[qp] = context.interior_gradient(this->_temp_vars.T_var(), qp);
 
 	p[qp] = context.interior_value(this->_flow_vars.p_var(), qp);
 	p0[qp] = this->get_p0_steady(context, qp);

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -119,10 +119,10 @@ namespace GRINS
     LowMachNavierStokesBase<Mu,SH,TC>::init_context(context);
 
     // We also need the side shape functions, etc.
-    context.get_side_fe(this->_u_var)->get_JxW();
-    context.get_side_fe(this->_u_var)->get_phi();
-    context.get_side_fe(this->_u_var)->get_dphi();
-    context.get_side_fe(this->_u_var)->get_xyz();
+    context.get_side_fe(this->_flow_vars.u_var())->get_JxW();
+    context.get_side_fe(this->_flow_vars.u_var())->get_phi();
+    context.get_side_fe(this->_flow_vars.u_var())->get_dphi();
+    context.get_side_fe(this->_flow_vars.u_var())->get_xyz();
 
     context.get_side_fe(this->_T_var)->get_JxW();
     context.get_side_fe(this->_T_var)->get_phi();
@@ -185,7 +185,7 @@ namespace GRINS
     // Pin p = p_value at p_point
     if( this->_pin_pressure )
       {
-	this->_p_pinning.pin_value( context, compute_jacobian, this->_p_var);
+	this->_p_pinning.pin_value( context, compute_jacobian, this->_flow_vars.p_var());
       }
 
     return;
@@ -214,27 +214,27 @@ namespace GRINS
 								CachedValues& cache )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& p_phi =
-      context.get_element_fe(this->_p_var)->get_phi();
-      
-      
-      
+      context.get_element_fe(this->_flow_vars.p_var())->get_phi();
+
+
+
     // The velocity shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.get_element_fe(this->_u_var)->get_phi();
-      
+      context.get_element_fe(this->_flow_vars.u_var())->get_phi();
+
     // The velocity shape function gradients (in global coords.)
     // at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.get_element_fe(this->_u_var)->get_dphi();
-      
+      context.get_element_fe(this->_flow_vars.u_var())->get_dphi();
+
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
       context.get_element_fe(this->_T_var)->get_phi();
@@ -246,7 +246,9 @@ namespace GRINS
       
       
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
+
+
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_flow_vars.p_var()); // R_{p}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     
@@ -254,13 +256,13 @@ namespace GRINS
     const unsigned int n_t_dofs = context.get_dof_indices(this->_T_var).size();    
     
      // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
-    // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
+    // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
-    
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.w_var()).size());
+
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Number u, v, T;
@@ -284,17 +286,17 @@ namespace GRINS
 	    libMesh::Gradient grad_w = cache.get_cached_gradient_values(Cache::Z_VELOCITY_GRAD)[qp];
 	    divU += grad_w(2);
           }
-          
-          
-    libMesh::DenseSubMatrix<libMesh::Number> &KPu = context.get_elem_jacobian(this->_p_var, this->_u_var); 
-    libMesh::DenseSubMatrix<libMesh::Number> &KPv = context.get_elem_jacobian(this->_p_var, this->_v_var);
-    libMesh::DenseSubMatrix<libMesh::Number> &KPT = context.get_elem_jacobian(this->_p_var, this->_T_var);
-    
+
+
+    libMesh::DenseSubMatrix<libMesh::Number> &KPu = context.get_elem_jacobian(this->_flow_vars.p_var(), this->_flow_vars.u_var());
+    libMesh::DenseSubMatrix<libMesh::Number> &KPv = context.get_elem_jacobian(this->_flow_vars.p_var(), this->_flow_vars.v_var());
+    libMesh::DenseSubMatrix<libMesh::Number> &KPT = context.get_elem_jacobian(this->_flow_vars.p_var(), this->_T_var);
+
     libMesh::DenseSubMatrix<libMesh::Number>* KPw = NULL;
 
     if( this->_dim == 3 )
       {
-        KPw = &context.get_elem_jacobian(this->_p_var, this->_w_var);
+        KPw = &context.get_elem_jacobian(this->_flow_vars.p_var(), this->_flow_vars.w_var());
       }
 
 	// Now a loop over the pressure degrees of freedom.  This
@@ -348,34 +350,39 @@ namespace GRINS
 								    CachedValues& cache )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
     const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
-        
-    // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
+
+    // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.w_var()).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.get_element_fe(this->_u_var)->get_phi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_phi();
     const std::vector<std::vector<libMesh::Real> >& p_phi =
-      context.get_element_fe(this->_p_var)->get_phi();
+      context.get_element_fe(this->_flow_vars.p_var())->get_phi();
       const std::vector<std::vector<libMesh::Real> >& T_phi =
       context.get_element_fe(this->_T_var)->get_phi();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.get_element_fe(this->_u_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_flow_vars.u_var()); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_flow_vars.v_var()); // R_{v}
+    libMesh::DenseSubVector<libMesh::Real>* Fw = NULL;
+
+    if( this->_dim == 3 )
+      {
+        Fw  = &context.get_elem_residual(this->_flow_vars.w_var()); // R_{w}
+      }
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
@@ -416,36 +423,36 @@ namespace GRINS
 	libMesh::Number rho = this->rho( T, p0 );
 	libMesh::Number d_rho = this->d_rho_dT( T, p0 );
 	libMesh::Number d_mu = this->_mu.deriv(T);
-	
-	libMesh::DenseSubMatrix<libMesh::Number> &Kuu = context.get_elem_jacobian(this->_u_var, this->_u_var); // R_{u},{u}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kuv = context.get_elem_jacobian(this->_u_var, this->_v_var); // R_{u},{v}
+
+	libMesh::DenseSubMatrix<libMesh::Number> &Kuu = context.get_elem_jacobian(this->_flow_vars.u_var(), this->_flow_vars.u_var()); // R_{u},{u}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kuv = context.get_elem_jacobian(this->_flow_vars.u_var(), this->_flow_vars.v_var()); // R_{u},{v}
     libMesh::DenseSubMatrix<libMesh::Number>* Kuw = NULL;
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kvu = context.get_elem_jacobian(this->_v_var, this->_u_var); // R_{v},{u}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kvv = context.get_elem_jacobian(this->_v_var, this->_v_var); // R_{v},{v}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kvu = context.get_elem_jacobian(this->_flow_vars.v_var(), this->_flow_vars.u_var()); // R_{v},{u}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kvv = context.get_elem_jacobian(this->_flow_vars.v_var(), this->_flow_vars.v_var()); // R_{v},{v}
     libMesh::DenseSubMatrix<libMesh::Number>* Kvw = NULL;
 
     libMesh::DenseSubMatrix<libMesh::Number>* Kwu = NULL;
     libMesh::DenseSubMatrix<libMesh::Number>* Kwv = NULL;
     libMesh::DenseSubMatrix<libMesh::Number>* Kww = NULL;
 
-    libMesh::DenseSubMatrix<libMesh::Number> &Kup = context.get_elem_jacobian(this->_u_var, this->_p_var); // R_{u},{p}
-    libMesh::DenseSubMatrix<libMesh::Number> &Kvp = context.get_elem_jacobian(this->_v_var, this->_p_var); // R_{v},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kup = context.get_elem_jacobian(this->_flow_vars.u_var(), this->_flow_vars.p_var()); // R_{u},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &Kvp = context.get_elem_jacobian(this->_flow_vars.v_var(), this->_flow_vars.p_var()); // R_{v},{p}
     libMesh::DenseSubMatrix<libMesh::Number>* Kwp = NULL;
 
-    libMesh::DenseSubMatrix<libMesh::Number> &KuT = context.get_elem_jacobian(this->_u_var, this->_T_var); // R_{u},{p}
-    libMesh::DenseSubMatrix<libMesh::Number> &KvT = context.get_elem_jacobian(this->_v_var, this->_T_var); // R_{v},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &KuT = context.get_elem_jacobian(this->_flow_vars.u_var(), this->_T_var); // R_{u},{p}
+    libMesh::DenseSubMatrix<libMesh::Number> &KvT = context.get_elem_jacobian(this->_flow_vars.v_var(), this->_T_var); // R_{v},{p}
     libMesh::DenseSubMatrix<libMesh::Number>* KwT = NULL;
 
     if( this->_dim == 3 )
       {
-	Kuw = &context.get_elem_jacobian(this->_u_var, this->_w_var); // R_{u},{w}
-	Kvw = &context.get_elem_jacobian(this->_v_var, this->_w_var); // R_{v},{w}
-	Kwu = &context.get_elem_jacobian(this->_w_var, this->_u_var); // R_{w},{u};
-	Kwv = &context.get_elem_jacobian(this->_w_var, this->_v_var); // R_{w},{v};
-	Kww = &context.get_elem_jacobian(this->_w_var, this->_w_var); // R_{w},{w}
-	Kwp = &context.get_elem_jacobian(this->_w_var, this->_p_var); // R_{w},{p}
-	KwT = &context.get_elem_jacobian(this->_w_var, this->_T_var); // R_{w},{T}
+	Kuw = &context.get_elem_jacobian(this->_flow_vars.u_var(), this->_flow_vars.w_var()); // R_{u},{w}
+	Kvw = &context.get_elem_jacobian(this->_flow_vars.v_var(), this->_flow_vars.w_var()); // R_{v},{w}
+	Kwu = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_flow_vars.u_var()); // R_{w},{u};
+	Kwv = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_flow_vars.v_var()); // R_{w},{v};
+	Kww = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_flow_vars.w_var()); // R_{w},{w}
+	Kwp = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_flow_vars.p_var()); // R_{w},{p}
+	KwT = &context.get_elem_jacobian(this->_flow_vars.w_var(), this->_T_var); // R_{w},{T}
       }
             
 	// Now a loop over the pressure degrees of freedom.  This
@@ -467,7 +474,7 @@ namespace GRINS
 		       )*JxW[qp];
 	    if (this->_dim == 3)
 	      {
-		Fw(i) += ( -rho*U*grad_w*u_phi[i][qp]                 // convection term
+		(*Fw)(i) += ( -rho*U*grad_w*u_phi[i][qp]                 // convection term
 			   + p*u_gradphi[i][qp](2)                           // pressure term
 			   - this->_mu(T)*(u_gradphi[i][qp]*grad_w + u_gradphi[i][qp]*grad_wT
 					   - 2.0/3.0*divU*u_gradphi[i][qp](2) )    // diffusion term
@@ -637,8 +644,8 @@ namespace GRINS
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
-    
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
+
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
       context.get_element_fe(this->_T_var)->get_JxW();
@@ -647,8 +654,8 @@ namespace GRINS
     const std::vector<std::vector<libMesh::Real> >& T_phi =
       context.get_element_fe(this->_T_var)->get_phi();
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.get_element_fe(this->_u_var)->get_phi();
-      
+      context.get_element_fe(this->_flow_vars.u_var())->get_phi();
+
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
       context.get_element_fe(this->_T_var)->get_dphi();
@@ -669,16 +676,16 @@ namespace GRINS
 		libMesh::NumberVectorValue U(u,v);
 		if (this->_dim == 3)
 		  U(2) = cache.get_cached_values(Cache::Z_VELOCITY)[qp]; // w
-		  
-		libMesh::DenseSubMatrix<libMesh::Number> &KTu = context.get_elem_jacobian(this->_T_var, this->_u_var); // R_{u},{u}
-		libMesh::DenseSubMatrix<libMesh::Number> &KTv = context.get_elem_jacobian(this->_T_var, this->_v_var); // R_{u},{u}
+
+		libMesh::DenseSubMatrix<libMesh::Number> &KTu = context.get_elem_jacobian(this->_T_var, this->_flow_vars.u_var()); // R_{u},{u}
+		libMesh::DenseSubMatrix<libMesh::Number> &KTv = context.get_elem_jacobian(this->_T_var, this->_flow_vars.v_var()); // R_{u},{u}
 			libMesh::DenseSubMatrix<libMesh::Number>* KTw = NULL;
-		  
+
 		libMesh::DenseSubMatrix<libMesh::Number> &KTT = context.get_elem_jacobian(this->_T_var, this->_T_var); // R_{u},{u}
-			
+
 		if( this->_dim == 3 )
 		  {
-		    KTw = &context.get_elem_jacobian(this->_T_var, this->_w_var); // R_{u},{w}
+		    KTw = &context.get_elem_jacobian(this->_T_var, this->_flow_vars.w_var()); // R_{u},{w}
 		  }
 
 		libMesh::Number k = this->_k(T);
@@ -747,18 +754,18 @@ namespace GRINS
 									 AssemblyContext& context )
   {
     // Element Jacobian * quadrature weights for interior integration
-    const std::vector<libMesh::Real> &JxW = 
-      context.get_element_fe(this->_u_var)->get_JxW();
+    const std::vector<libMesh::Real> &JxW =
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The shape functions at interior quadrature points.
-    const std::vector<std::vector<libMesh::Real> >& p_phi = 
-      context.get_element_fe(this->_p_var)->get_phi();
-  
+    const std::vector<std::vector<libMesh::Real> >& p_phi =
+      context.get_element_fe(this->_flow_vars.p_var())->get_phi();
+
     // The number of local degrees of freedom in each variable
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // The subvectors and submatrices we need to fill:
-    libMesh::DenseSubVector<libMesh::Real> &F_p = context.get_elem_residual(this->_p_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_p = context.get_elem_residual(this->_flow_vars.p_var());
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -789,24 +796,25 @@ namespace GRINS
 								       AssemblyContext& context )
   {
     // Element Jacobian * quadrature weights for interior integration
-    const std::vector<libMesh::Real> &JxW = 
-      context.get_element_fe(this->_u_var)->get_JxW();
+    const std::vector<libMesh::Real> &JxW =
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The shape functions at interior quadrature points.
-    const std::vector<std::vector<libMesh::Real> >& u_phi = 
-      context.get_element_fe(this->_u_var)->get_phi();
-  
-    // The number of local degrees of freedom in each variable
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
+    const std::vector<std::vector<libMesh::Real> >& u_phi =
+      context.get_element_fe(this->_flow_vars.u_var())->get_phi();
 
-    // for convenience
-    if (this->_dim != 3)
-      this->_w_var = this->_u_var;
+    // The number of local degrees of freedom in each variable
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
     // The subvectors and submatrices we need to fill:
-    libMesh::DenseSubVector<libMesh::Real> &F_u = context.get_elem_residual(this->_u_var);
-    libMesh::DenseSubVector<libMesh::Real> &F_v = context.get_elem_residual(this->_v_var);
-    libMesh::DenseSubVector<libMesh::Real> &F_w = context.get_elem_residual(this->_w_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_u = context.get_elem_residual(this->_flow_vars.u_var());
+    libMesh::DenseSubVector<libMesh::Real> &F_v = context.get_elem_residual(this->_flow_vars.v_var());
+    libMesh::DenseSubVector<libMesh::Real>* F_w = NULL;
+
+    if( this->_dim == 3 )
+      {
+        F_w  = &context.get_elem_residual(this->_flow_vars.w_var()); // R_{w}
+      }
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -818,11 +826,11 @@ namespace GRINS
 	// u_fixed will be given by the fixed_interior_value function
 	// while u' will be given by the interior_rate function.
 	libMesh::Real u_dot, v_dot, w_dot = 0.0;
-        context.interior_rate(this->_u_var, qp, u_dot);
-	context.interior_rate(this->_v_var, qp, v_dot);
+        context.interior_rate(this->_flow_vars.u_var(), qp, u_dot);
+	context.interior_rate(this->_flow_vars.v_var(), qp, v_dot);
 
 	if( this->_dim == 3 )
-	  context.interior_rate(this->_w_var, qp, w_dot);
+	  context.interior_rate(this->_flow_vars.w_var(), qp, w_dot);
 
 	libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
       
@@ -834,8 +842,8 @@ namespace GRINS
 	    F_v(i) -= rho*v_dot*u_phi[i][qp]*JxW[qp];
 
 	    if( this->_dim == 3 )
-	      F_w(i) -= rho*w_dot*u_phi[i][qp]*JxW[qp];
-	  
+	      (*F_w)(i) -= rho*w_dot*u_phi[i][qp]*JxW[qp];
+
 	    /*
 	      if( compute_jacobian )
 	      {
@@ -931,10 +939,10 @@ namespace GRINS
 	T = context.interior_value(this->_T_var, qp);
 
 	libMesh::Gradient grad_u, grad_v, grad_w;
-	grad_u = context.interior_gradient(this->_u_var, qp);
-	grad_v = context.interior_gradient(this->_v_var, qp);
+	grad_u = context.interior_gradient(this->_flow_vars.u_var(), qp);
+	grad_v = context.interior_gradient(this->_flow_vars.v_var(), qp);
 	if (this->_dim == 3)
-	  grad_w = context.interior_gradient(this->_w_var, qp);
+	  grad_w = context.interior_gradient(this->_flow_vars.w_var(), qp);
 
 	libMesh::Number divU = grad_u(0) + grad_v(1);
 	if(this->_dim==3)
@@ -979,11 +987,11 @@ namespace GRINS
       {
 	/*
 	libMesh::Number T = context.side_value( this->_T_var, qp );
-	libMesh::Gradient U = ( context.side_value( this->_u_var, qp ),
-				context.side_value( this->_v_var, qp ) );
+	libMesh::Gradient U = ( context.side_value( this->_flow_vars.u_var(), qp ),
+				context.side_value( this->_flow_vars.v_var(), qp ) );
 	libMesh::Gradient grad_T = context.side_gradient( this->_T_var, qp );
 
-	
+
 	libMesh::Number p0 = context.side_value( this->_p0_var, qp );
 
 	libMesh::Number k = this->_k(T);
@@ -1014,7 +1022,7 @@ namespace GRINS
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var).size();
     const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration
     const std::vector<libMesh::Real> &JxW = 
@@ -1026,12 +1034,12 @@ namespace GRINS
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& p_phi =
-      context.get_element_fe(this->_p_var)->get_phi();
+      context.get_element_fe(this->_flow_vars.p_var())->get_phi();
 
     // The subvectors and submatrices we need to fill:
     libMesh::DenseSubVector<libMesh::Real> &F_p0 = context.get_elem_residual(this->_p0_var);
     libMesh::DenseSubVector<libMesh::Real> &F_T = context.get_elem_residual(this->_T_var);
-    libMesh::DenseSubVector<libMesh::Real> &F_p = context.get_elem_residual(this->_p_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_p = context.get_elem_residual(this->_flow_vars.p_var());
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -1095,20 +1103,20 @@ namespace GRINS
 
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {
-	u[qp] = context.interior_value(this->_u_var, qp);
-	v[qp] = context.interior_value(this->_v_var, qp);
+	u[qp] = context.interior_value(this->_flow_vars.u_var(), qp);
+	v[qp] = context.interior_value(this->_flow_vars.v_var(), qp);
 
-	grad_u[qp] = context.interior_gradient(this->_u_var, qp);
-	grad_v[qp] = context.interior_gradient(this->_v_var, qp);
+	grad_u[qp] = context.interior_gradient(this->_flow_vars.u_var(), qp);
+	grad_v[qp] = context.interior_gradient(this->_flow_vars.v_var(), qp);
 	if( this->_dim > 2 )
 	  {
-	    w[qp] = context.interior_value(this->_w_var, qp);
-	    grad_w[qp] = context.interior_gradient(this->_w_var, qp);
+	    w[qp] = context.interior_value(this->_flow_vars.w_var(), qp);
+	    grad_w[qp] = context.interior_gradient(this->_flow_vars.w_var(), qp);
 	  }
 	T[qp] = context.interior_value(this->_T_var, qp);
 	grad_T[qp] = context.interior_gradient(this->_T_var, qp);
 
-	p[qp] = context.interior_value(this->_p_var, qp);
+	p[qp] = context.interior_value(this->_flow_vars.p_var(), qp);
 	p0[qp] = this->get_p0_steady(context, qp);
       }
     

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -924,10 +924,10 @@ namespace GRINS
       context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The number of local degrees of freedom in each variable
-    const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var).size();
+    const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var.p0_var()).size();
 
     // The subvectors and submatrices we need to fill:
-    libMesh::DenseSubVector<libMesh::Real> &F_p0 = context.get_elem_residual(this->_p0_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_p0 = context.get_elem_residual(this->_p0_var.p0_var());
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -951,7 +951,7 @@ namespace GRINS
 	//libMesh::Number gamma = cp/cv;
 	//libMesh::Number gamma_ratio = gamma/(gamma-1.0);
 
-	libMesh::Number p0 = context.interior_value( this->_p0_var, qp );
+	libMesh::Number p0 = context.interior_value( this->_p0_var.p0_var(), qp );
 
 	for (unsigned int i = 0; i != n_p0_dofs; ++i)
 	  {
@@ -968,14 +968,14 @@ namespace GRINS
 									     AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var).size();
+    const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var.p0_var()).size();
 
     // Element Jacobian * quadrature weight for side integration.
     //const std::vector<libMesh::Real> &JxW_side = context.get_side_fe(this->_temp_vars.T_var())->get_JxW();
 
     //const std::vector<Point> &normals = context.get_side_fe(this->_temp_vars.T_var())->get_normals();
 
-    //libMesh::DenseSubVector<libMesh::Number> &F_p0 = context.get_elem_residual(this->_p0_var); // residual
+    //libMesh::DenseSubVector<libMesh::Number> &F_p0 = context.get_elem_residual(this->_p0_var.p0_var()); // residual
 
     // Physical location of the quadrature points
     //const std::vector<libMesh::Point>& qpoint = context.get_side_fe(this->_temp_vars.T_var())->get_xyz();
@@ -990,7 +990,7 @@ namespace GRINS
 	libMesh::Gradient grad_T = context.side_gradient( this->_temp_vars.T_var(), qp );
 
 
-	libMesh::Number p0 = context.side_value( this->_p0_var, qp );
+	libMesh::Number p0 = context.side_value( this->_p0_var.p0_var(), qp );
 
 	libMesh::Number k = this->_k(T);
 	libMesh::Number cp = this->_cp(T);
@@ -1018,7 +1018,7 @@ namespace GRINS
 									   AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var).size();
+    const unsigned int n_p0_dofs = context.get_dof_indices(this->_p0_var.p0_var()).size();
     const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
     const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
@@ -1035,7 +1035,7 @@ namespace GRINS
       context.get_element_fe(this->_flow_vars.p_var())->get_phi();
 
     // The subvectors and submatrices we need to fill:
-    libMesh::DenseSubVector<libMesh::Real> &F_p0 = context.get_elem_residual(this->_p0_var);
+    libMesh::DenseSubVector<libMesh::Real> &F_p0 = context.get_elem_residual(this->_p0_var.p0_var());
     libMesh::DenseSubVector<libMesh::Real> &F_T = context.get_elem_residual(this->_temp_vars.T_var());
     libMesh::DenseSubVector<libMesh::Real> &F_p = context.get_elem_residual(this->_flow_vars.p_var());
 
@@ -1052,9 +1052,9 @@ namespace GRINS
 	libMesh::Number one_over_gamma = 1.0/(gamma-1.0);
 
 	libMesh::Number p0_dot;
-        context.interior_rate(this->_p0_var, qp, p0_dot);
+        context.interior_rate(this->_p0_var.p0_var(), qp, p0_dot);
 
-	libMesh::Number p0 = context.fixed_interior_value(this->_p0_var, qp );
+	libMesh::Number p0 = context.fixed_interior_value(this->_p0_var.p0_var(), qp );
 
 	for (unsigned int i=0; i != n_p0_dofs; i++)
 	  {

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -49,6 +49,7 @@ namespace GRINS
     : Physics(physics_name, input),
       _flow_vars(input, core_physics_name),
       _temp_vars(input, core_physics_name),
+      _p0_var(input, core_physics_name),
       _mu(input,MaterialsParsing::material_name(input,core_physics_name)),
       _cp(input,MaterialsParsing::material_name(input,core_physics_name)),
       _k(input,MaterialsParsing::material_name(input,core_physics_name))
@@ -93,11 +94,6 @@ namespace GRINS
 
     _enable_thermo_press_calc = input("Physics/"+low_mach_navier_stokes+"/enable_thermo_press_calc", false );
 
-    if( _enable_thermo_press_calc )
-      {
-	_p0_var_name = input("Physics/VariableNames/thermo_presure", "p0" );
-      }
-
     // Read gravity vector
     unsigned int g_dim = input.vector_variable_size("Physics/"+low_mach_navier_stokes+"/g");
 
@@ -122,7 +118,7 @@ namespace GRINS
     /* If we need to compute the thermodynamic pressure, we force this to be a first
        order scalar variable. */
     if( _enable_thermo_press_calc )
-      _p0_var = system->add_variable( _p0_var_name, libMesh::FIRST, libMesh::SCALAR);
+      _p0_var.init(system);
 
     return;
   }
@@ -142,7 +138,7 @@ namespace GRINS
     system->time_evolving(_flow_vars.p_var());
 
     if( _enable_thermo_press_calc )
-      system->time_evolving(_p0_var);
+      system->time_evolving(_p0_var.p0_var());
 
     return;
   }

--- a/src/physics/src/low_mach_navier_stokes_braack_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_braack_stab.C
@@ -116,7 +116,7 @@ namespace GRINS
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
 
-	libMesh::Real T = context.interior_value( this->_T_var, qp );
+	libMesh::Real T = context.interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);
@@ -183,7 +183,7 @@ namespace GRINS
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Real T = context.interior_value( this->_T_var, qp );
+	libMesh::Real T = context.interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);
@@ -256,20 +256,20 @@ namespace GRINS
 										     AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_T_var)->get_JxW();
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.get_element_fe(this->_T_var)->get_dphi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& T_hessphi =
-      context.get_element_fe(this->_T_var)->get_d2phi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_temp_vars.T_var()); // R_{T}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -279,13 +279,13 @@ namespace GRINS
 	u = context.interior_value(this->_flow_vars.u_var(), qp);
 	v = context.interior_value(this->_flow_vars.v_var(), qp);
 
-	libMesh::Gradient grad_T = context.interior_gradient(this->_T_var, qp);
+	libMesh::Gradient grad_T = context.interior_gradient(this->_temp_vars.T_var(), qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
 	  U(2) = context.interior_value(this->_flow_vars.w_var(), qp);
 
-	libMesh::Real T = context.interior_value( this->_T_var, qp );
+	libMesh::Real T = context.interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
 	libMesh::Real k = this->_k(T);
@@ -340,7 +340,7 @@ namespace GRINS
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
 
-	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
+	libMesh::Real T = context.fixed_interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);
@@ -406,7 +406,7 @@ namespace GRINS
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
+	libMesh::Real T = context.fixed_interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);
@@ -479,20 +479,20 @@ namespace GRINS
 											AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_T_var)->get_JxW();
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.get_element_fe(this->_T_var)->get_dphi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& T_hessphi =
-      context.get_element_fe(this->_T_var)->get_d2phi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_temp_vars.T_var()); // R_{T}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -502,13 +502,13 @@ namespace GRINS
 	u = context.fixed_interior_value(this->_flow_vars.u_var(), qp);
 	v = context.fixed_interior_value(this->_flow_vars.v_var(), qp);
 
-	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
+	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_temp_vars.T_var(), qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
 	  U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp); // w
 
-	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
+	libMesh::Real T = context.fixed_interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
 
 	libMesh::Real k = this->_k(T);

--- a/src/physics/src/low_mach_navier_stokes_braack_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_braack_stab.C
@@ -434,26 +434,26 @@ namespace GRINS
 
 	libMesh::Real RC_t = this->compute_res_continuity_transient( context, qp );
 	libMesh::RealGradient RM_t = this->compute_res_momentum_transient( context, qp );
-      
+
 	for (unsigned int i=0; i != n_u_dofs; i++)
 	  {
 	    Fu(i) += (  tau_C*RC_t*u_gradphi[i][qp](0)
 			+ tau_M*RM_t(0)*rho*U*u_gradphi[i][qp]
-			+ mu*tau_M*RM_t(0)*(u_hessphi[i][qp](0,0) + u_hessphi[i][qp](1,1) 
-					    + u_hessphi[i][qp](0,0) + u_hessphi[i][qp](0,1) 
-					    - 2.0/3.0*(u_hessphi[i][qp](0,0) + u_hessphi[i][qp](1,0)) ) 
+			+ mu*tau_M*RM_t(0)*(u_hessphi[i][qp](0,0) + u_hessphi[i][qp](1,1)
+					    + u_hessphi[i][qp](0,0) + u_hessphi[i][qp](0,1)
+					    - 2.0/3.0*(u_hessphi[i][qp](0,0) + u_hessphi[i][qp](1,0)) )
 			)*JxW[qp];
 
 	    Fv(i) += ( tau_C*RC_t*u_gradphi[i][qp](1)
 		       + tau_M*RM_t(1)*rho*U*u_gradphi[i][qp]
-		       + mu*tau_M*RM_t(1)*(u_hessphi[i][qp](0,0) + u_hessphi[i][qp](1,1) 
-					   + u_hessphi[i][qp](1,0) + u_hessphi[i][qp](1,1) 
-					   - 2.0/3.0*(u_hessphi[i][qp](0,1) + u_hessphi[i][qp](1,1)) ) 
+		       + mu*tau_M*RM_t(1)*(u_hessphi[i][qp](0,0) + u_hessphi[i][qp](1,1)
+					   + u_hessphi[i][qp](1,0) + u_hessphi[i][qp](1,1)
+					   - 2.0/3.0*(u_hessphi[i][qp](0,1) + u_hessphi[i][qp](1,1)) )
 		       )*JxW[qp];
 
 	    if( this->_dim == 3 )
 	      {
-		(*Fw)(i) -= mu*tau_M*RM_t(0)*(u_hessphi[i][qp](2,2) + u_hessphi[i][qp](0,2)
+		Fu(i) -= mu*tau_M*RM_t(0)*(u_hessphi[i][qp](2,2) + u_hessphi[i][qp](0,2)
 					   - 2.0/3.0*u_hessphi[i][qp](2,0))*JxW[qp];
 
 		Fv(i) -= mu*tau_M*RM_t(1)*(u_hessphi[i][qp](2,2) + u_hessphi[i][qp](1,2)

--- a/src/physics/src/low_mach_navier_stokes_braack_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_braack_stab.C
@@ -95,23 +95,23 @@ namespace GRINS
 											 AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.get_element_fe(this->_p_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.p_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_flow_vars.p_var()); // R_{p}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -123,10 +123,10 @@ namespace GRINS
 	libMesh::Real k = this->_k(T);
 	libMesh::Real cp = this->_cp(T);
 
-	libMesh::RealGradient U( context.interior_value( this->_u_var, qp ),
-				 context.interior_value( this->_v_var, qp ) );
+	libMesh::RealGradient U( context.interior_value( this->_flow_vars.u_var(), qp ),
+				 context.interior_value( this->_flow_vars.v_var(), qp ) );
 	if( this->_dim == 3 )
-	  U(2) = context.interior_value( this->_w_var, qp ); // w
+	  U(2) = context.interior_value( this->_flow_vars.w_var(), qp ); // w
 
 	libMesh::Real tau_M = this->_stab_helper.compute_tau_momentum( context, qp, g, G, rho, U, mu, this->_is_steady );
 	libMesh::Real tau_E = this->_stab_helper.compute_tau_energy( context, qp, g, G, rho, U, k, cp, this->_is_steady );
@@ -152,27 +152,32 @@ namespace GRINS
 										       AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
-    // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
+    // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.w_var()).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.get_element_fe(this->_u_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& u_hessphi =
-      context.get_element_fe(this->_u_var)->get_d2phi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_flow_vars.u_var()); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_flow_vars.v_var()); // R_{v}
+    libMesh::DenseSubVector<libMesh::Real>* Fw = NULL;
+
+    if( this->_dim == 3 )
+      {
+        Fw  = &context.get_elem_residual(this->_flow_vars.w_var()); // R_{w}
+      }
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -183,20 +188,20 @@ namespace GRINS
 
 	libMesh::Real mu = this->_mu(T);
 
-	libMesh::RealGradient U( context.interior_value(this->_u_var, qp),
-				 context.interior_value(this->_v_var, qp) );
+	libMesh::RealGradient U( context.interior_value(this->_flow_vars.u_var(), qp),
+				 context.interior_value(this->_flow_vars.v_var(), qp) );
 
-	libMesh::RealGradient grad_u = context.interior_gradient(this->_u_var, qp);
-	libMesh::RealGradient grad_v = context.interior_gradient(this->_v_var, qp);
+	libMesh::RealGradient grad_u = context.interior_gradient(this->_flow_vars.u_var(), qp);
+	libMesh::RealGradient grad_v = context.interior_gradient(this->_flow_vars.v_var(), qp);
 	libMesh::RealGradient grad_w;
 
 	if( this->_dim == 3 )
 	  {
-	    U(2) = context.interior_value(this->_w_var, qp);
-	    grad_w = context.interior_gradient(this->_w_var, qp);
+	    U(2) = context.interior_value(this->_flow_vars.w_var(), qp);
+	    grad_w = context.interior_gradient(this->_flow_vars.w_var(), qp);
 	  }
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -231,7 +236,7 @@ namespace GRINS
 		Fv(i) += mu*tau_M*RM_s(1)*(u_hessphi[i][qp](2,2) + u_hessphi[i][qp](1,2)
 					   - 2.0/3.0*u_hessphi[i][qp](2,1))*JxW[qp];
 
-		Fw(i) += ( tau_C*RC_s*u_gradphi[i][qp](2)
+		(*Fw)(i) += ( tau_C*RC_s*u_gradphi[i][qp](2)
 			   + tau_M*RM_s(2)*rho*U*u_gradphi[i][qp]
 			   + mu*tau_M*RM_s(2)*(u_hessphi[i][qp](0,0) + u_hessphi[i][qp](1,1) + u_hessphi[i][qp](2,2)
 					       + u_hessphi[i][qp](2,0) + u_hessphi[i][qp](2,1) + u_hessphi[i][qp](2,2)
@@ -271,15 +276,15 @@ namespace GRINS
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Number u, v;
-	u = context.interior_value(this->_u_var, qp);
-	v = context.interior_value(this->_v_var, qp);
+	u = context.interior_value(this->_flow_vars.u_var(), qp);
+	v = context.interior_value(this->_flow_vars.v_var(), qp);
 
 	libMesh::Gradient grad_T = context.interior_gradient(this->_T_var, qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = context.interior_value(this->_w_var, qp);
-      
+	  U(2) = context.interior_value(this->_flow_vars.w_var(), qp);
+
 	libMesh::Real T = context.interior_value( this->_T_var, qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
@@ -288,7 +293,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -314,23 +319,23 @@ namespace GRINS
 											    AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.get_element_fe(this->_p_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.p_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_flow_vars.p_var()); // R_{p}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -342,10 +347,10 @@ namespace GRINS
 	libMesh::Real k = this->_k(T);
 	libMesh::Real cp = this->_cp(T);
 
-	libMesh::RealGradient U( context.fixed_interior_value( this->_u_var, qp ),
-				 context.fixed_interior_value( this->_v_var, qp ) );
+	libMesh::RealGradient U( context.fixed_interior_value( this->_flow_vars.u_var(), qp ),
+				 context.fixed_interior_value( this->_flow_vars.v_var(), qp ) );
 	if( this->_dim == 3 )
-	  U(2) = context.fixed_interior_value( this->_w_var, qp );
+	  U(2) = context.fixed_interior_value( this->_flow_vars.w_var(), qp );
 
 	libMesh::Real tau_M = this->_stab_helper.compute_tau_momentum( context, qp, g, G, rho, U, mu, false );
 	libMesh::RealGradient RM_t = this->compute_res_momentum_transient( context, qp );
@@ -371,27 +376,32 @@ namespace GRINS
 											  AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
-    // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
+    // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.w_var()).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.get_element_fe(this->_u_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_dphi();
 
     const std::vector<std::vector<libMesh::RealTensor> >& u_hessphi =
-      context.get_element_fe(this->_u_var)->get_d2phi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_d2phi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_flow_vars.u_var()); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_flow_vars.v_var()); // R_{v}
+    libMesh::DenseSubVector<libMesh::Real>* Fw = NULL;
+
+    if( this->_dim == 3 )
+      {
+        Fw  = &context.get_elem_residual(this->_flow_vars.w_var()); // R_{w}
+      }
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
@@ -401,20 +411,20 @@ namespace GRINS
 
 	libMesh::Real mu = this->_mu(T);
 
-	libMesh::RealGradient U( context.fixed_interior_value(this->_u_var, qp),
-				 context.fixed_interior_value(this->_v_var, qp) );
+	libMesh::RealGradient U( context.fixed_interior_value(this->_flow_vars.u_var(), qp),
+				 context.fixed_interior_value(this->_flow_vars.v_var(), qp) );
 
-	libMesh::RealGradient grad_u = context.fixed_interior_gradient(this->_u_var, qp);
-	libMesh::RealGradient grad_v = context.fixed_interior_gradient(this->_v_var, qp);
+	libMesh::RealGradient grad_u = context.fixed_interior_gradient(this->_flow_vars.u_var(), qp);
+	libMesh::RealGradient grad_v = context.fixed_interior_gradient(this->_flow_vars.v_var(), qp);
 	libMesh::RealGradient grad_w;
 
 	if( this->_dim == 3 )
 	  {
-	    U(2) = context.fixed_interior_value(this->_w_var, qp);
-	    grad_w = context.fixed_interior_gradient(this->_w_var, qp);
+	    U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp);
+	    grad_w = context.fixed_interior_gradient(this->_flow_vars.w_var(), qp);
 	  }
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -443,13 +453,13 @@ namespace GRINS
 
 	    if( this->_dim == 3 )
 	      {
-		Fw(i) -= mu*tau_M*RM_t(0)*(u_hessphi[i][qp](2,2) + u_hessphi[i][qp](0,2) 
+		(*Fw)(i) -= mu*tau_M*RM_t(0)*(u_hessphi[i][qp](2,2) + u_hessphi[i][qp](0,2)
 					   - 2.0/3.0*u_hessphi[i][qp](2,0))*JxW[qp];
 
 		Fv(i) -= mu*tau_M*RM_t(1)*(u_hessphi[i][qp](2,2) + u_hessphi[i][qp](1,2)
 					   - 2.0/3.0*u_hessphi[i][qp](2,1))*JxW[qp];
 
-		Fw(i) -= ( tau_C*RC_t*u_gradphi[i][qp](2)
+		(*Fw)(i) -= ( tau_C*RC_t*u_gradphi[i][qp](2)
 			   + tau_M*RM_t(2)*rho*U*u_gradphi[i][qp]
 			   + mu*tau_M*RM_t(2)*(u_hessphi[i][qp](0,0) + u_hessphi[i][qp](1,1) + u_hessphi[i][qp](2,2)
 					       + u_hessphi[i][qp](2,0) + u_hessphi[i][qp](2,1) + u_hessphi[i][qp](2,2)
@@ -489,14 +499,14 @@ namespace GRINS
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Number u, v;
-	u = context.fixed_interior_value(this->_u_var, qp);
-	v = context.fixed_interior_value(this->_v_var, qp);
+	u = context.fixed_interior_value(this->_flow_vars.u_var(), qp);
+	v = context.fixed_interior_value(this->_flow_vars.v_var(), qp);
 
 	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = context.fixed_interior_value(this->_w_var, qp); // w
+	  U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp); // w
 
 	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
@@ -506,7 +516,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*cp;
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );

--- a/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
@@ -93,37 +93,37 @@ namespace GRINS
 											AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.get_element_fe(this->_p_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.p_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_flow_vars.p_var()); // R_{p}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
 
 	libMesh::Real T = context.interior_value( this->_T_var, qp );
-      
+
 	libMesh::Real mu = this->_mu(T);
 
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
-	libMesh::RealGradient U( context.interior_value( this->_u_var, qp ),
-				 context.interior_value( this->_v_var, qp ) );
+	libMesh::RealGradient U( context.interior_value( this->_flow_vars.u_var(), qp ),
+				 context.interior_value( this->_flow_vars.v_var(), qp ) );
 	if( this->_dim == 3 )
-	  U(2) = context.interior_value( this->_w_var, qp );
+	  U(2) = context.interior_value( this->_flow_vars.w_var(), qp );
 
 	libMesh::Real tau_M = this->_stab_helper.compute_tau_momentum( context, qp, g, G, rho, U, mu, this->_is_steady );
 
@@ -146,24 +146,29 @@ namespace GRINS
 										      AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
-    // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
+    // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.w_var()).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.get_element_fe(this->_u_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_flow_vars.u_var()); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_flow_vars.v_var()); // R_{v}
+    libMesh::DenseSubVector<libMesh::Real>* Fw = NULL;
+
+    if( this->_dim == 3 )
+      {
+        Fw  = &context.get_elem_residual(this->_flow_vars.w_var()); // R_{w}
+      }
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -172,20 +177,20 @@ namespace GRINS
 	libMesh::Real T = context.interior_value( this->_T_var, qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
-	libMesh::RealGradient U( context.interior_value(this->_u_var, qp),
-				 context.interior_value(this->_v_var, qp) );
+	libMesh::RealGradient U( context.interior_value(this->_flow_vars.u_var(), qp),
+				 context.interior_value(this->_flow_vars.v_var(), qp) );
 
-	libMesh::RealGradient grad_u = context.interior_gradient(this->_u_var, qp);
-	libMesh::RealGradient grad_v = context.interior_gradient(this->_v_var, qp);
+	libMesh::RealGradient grad_u = context.interior_gradient(this->_flow_vars.u_var(), qp);
+	libMesh::RealGradient grad_v = context.interior_gradient(this->_flow_vars.v_var(), qp);
 	libMesh::RealGradient grad_w;
 
 	if( this->_dim == 3 )
 	  {
-	    U(2) = context.interior_value(this->_w_var, qp);
-	    grad_w = context.interior_gradient(this->_w_var, qp);
+	    U(2) = context.interior_value(this->_flow_vars.w_var(), qp);
+	    grad_w = context.interior_gradient(this->_flow_vars.w_var(), qp);
 	  }
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -207,8 +212,8 @@ namespace GRINS
 
 	    if( this->_dim == 3 )
 	      {
-		Fw(i) += ( - tau_C*RC_s*u_gradphi[i][qp](2)
-			   - tau_M*RM_s(2)*rho*U*u_gradphi[i][qp] )*JxW[qp];
+		(*Fw)(i) += ( - tau_C*RC_s*u_gradphi[i][qp](2)
+                              - tau_M*RM_s(2)*rho*U*u_gradphi[i][qp] )*JxW[qp];
 	      }
 	  }
 
@@ -238,14 +243,14 @@ namespace GRINS
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Number u, v;
-	u = context.interior_value(this->_u_var, qp);
-	v = context.interior_value(this->_v_var, qp);
+	u = context.interior_value(this->_flow_vars.u_var(), qp);
+	v = context.interior_value(this->_flow_vars.v_var(), qp);
 
 	libMesh::Gradient grad_T = context.interior_gradient(this->_T_var, qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = context.interior_value(this->_w_var, qp); // w
+	  U(2) = context.interior_value(this->_flow_vars.w_var(), qp); // w
 
 	libMesh::Real T = context.interior_value( this->_T_var, qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
@@ -255,7 +260,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -279,23 +284,23 @@ namespace GRINS
 											   AssemblyContext& context)
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.get_element_fe(this->_p_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.p_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_flow_vars.p_var()); // R_{p}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -305,10 +310,10 @@ namespace GRINS
 
 	libMesh::Real mu = this->_mu(T);
 
-	libMesh::RealGradient U( context.fixed_interior_value( this->_u_var, qp ),
-				 context.fixed_interior_value( this->_v_var, qp ) );
+	libMesh::RealGradient U( context.fixed_interior_value( this->_flow_vars.u_var(), qp ),
+				 context.fixed_interior_value( this->_flow_vars.v_var(), qp ) );
 	if( this->_dim == 3 )
-	  U(2) = context.fixed_interior_value( this->_w_var, qp );
+	  U(2) = context.fixed_interior_value( this->_flow_vars.w_var(), qp );
 
 	libMesh::Real tau_M = this->_stab_helper.compute_tau_momentum( context, qp, g, G, rho, U, mu, false );
 	libMesh::RealGradient RM_t = this->compute_res_momentum_transient( context, qp );
@@ -329,24 +334,29 @@ namespace GRINS
 											 AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
-    // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
+    // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.w_var()).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.get_element_fe(this->_u_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_flow_vars.u_var()); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_flow_vars.v_var()); // R_{v}
+    libMesh::DenseSubVector<libMesh::Real>* Fw = NULL;
+
+    if( this->_dim == 3 )
+      {
+        Fw  = &context.get_elem_residual(this->_flow_vars.w_var()); // R_{w}
+      }
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
@@ -356,20 +366,20 @@ namespace GRINS
 
 	libMesh::Real mu = this->_mu(T);
 
-	libMesh::RealGradient U( context.fixed_interior_value(this->_u_var, qp),
-				 context.fixed_interior_value(this->_v_var, qp) );
+	libMesh::RealGradient U( context.fixed_interior_value(this->_flow_vars.u_var(), qp),
+				 context.fixed_interior_value(this->_flow_vars.v_var(), qp) );
 
-	libMesh::RealGradient grad_u = context.fixed_interior_gradient(this->_u_var, qp);
-	libMesh::RealGradient grad_v = context.fixed_interior_gradient(this->_v_var, qp);
+	libMesh::RealGradient grad_u = context.fixed_interior_gradient(this->_flow_vars.u_var(), qp);
+	libMesh::RealGradient grad_v = context.fixed_interior_gradient(this->_flow_vars.v_var(), qp);
 	libMesh::RealGradient grad_w;
 
 	if( this->_dim == 3 )
 	  {
-	    U(2) = context.fixed_interior_value(this->_w_var, qp);
-	    grad_w = context.fixed_interior_gradient(this->_w_var, qp);
+	    U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp);
+	    grad_w = context.fixed_interior_gradient(this->_flow_vars.w_var(), qp);
 	  }
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -391,8 +401,8 @@ namespace GRINS
 
 	    if( this->_dim == 3 )
 	      {
-		Fw(i) -= ( tau_C*RC_t*u_gradphi[i][qp](2)
-			   + tau_M*RM_t(2)*rho*U*u_gradphi[i][qp] )*JxW[qp];
+		(*Fw)(i) -= ( tau_C*RC_t*u_gradphi[i][qp](2)
+                              + tau_M*RM_t(2)*rho*U*u_gradphi[i][qp] )*JxW[qp];
 	      }
 	  }
 
@@ -422,14 +432,14 @@ namespace GRINS
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Number u, v;
-	u = context.fixed_interior_value(this->_u_var, qp);
-	v = context.fixed_interior_value(this->_v_var, qp);
+	u = context.fixed_interior_value(this->_flow_vars.u_var(), qp);
+	v = context.fixed_interior_value(this->_flow_vars.v_var(), qp);
 
 	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = context.fixed_interior_value(this->_w_var, qp); // w
+	  U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp); // w
 
 	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
@@ -439,7 +449,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );

--- a/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
@@ -114,7 +114,7 @@ namespace GRINS
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
 
-	libMesh::Real T = context.interior_value( this->_T_var, qp );
+	libMesh::Real T = context.interior_value( this->_temp_vars.T_var(), qp );
 
 	libMesh::Real mu = this->_mu(T);
 
@@ -174,7 +174,7 @@ namespace GRINS
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Real T = context.interior_value( this->_T_var, qp );
+	libMesh::Real T = context.interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
 	libMesh::RealGradient U( context.interior_value(this->_flow_vars.u_var(), qp),
@@ -226,17 +226,17 @@ namespace GRINS
 										    AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_T_var)->get_JxW();
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.get_element_fe(this->_T_var)->get_dphi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_temp_vars.T_var()); // R_{T}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -246,13 +246,13 @@ namespace GRINS
 	u = context.interior_value(this->_flow_vars.u_var(), qp);
 	v = context.interior_value(this->_flow_vars.v_var(), qp);
 
-	libMesh::Gradient grad_T = context.interior_gradient(this->_T_var, qp);
+	libMesh::Gradient grad_T = context.interior_gradient(this->_temp_vars.T_var(), qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
 	  U(2) = context.interior_value(this->_flow_vars.w_var(), qp); // w
 
-	libMesh::Real T = context.interior_value( this->_T_var, qp );
+	libMesh::Real T = context.interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
 	libMesh::Real k = this->_k(T);
@@ -305,7 +305,7 @@ namespace GRINS
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
 
-	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
+	libMesh::Real T = context.fixed_interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);
@@ -361,7 +361,7 @@ namespace GRINS
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
+	libMesh::Real T = context.fixed_interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);
@@ -415,17 +415,17 @@ namespace GRINS
 										       AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_T_var)->get_JxW();
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.get_element_fe(this->_T_var)->get_dphi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_temp_vars.T_var()); // R_{T}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -435,13 +435,13 @@ namespace GRINS
 	u = context.fixed_interior_value(this->_flow_vars.u_var(), qp);
 	v = context.fixed_interior_value(this->_flow_vars.v_var(), qp);
 
-	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
+	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_temp_vars.T_var(), qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
 	  U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp); // w
 
-	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
+	libMesh::Real T = context.fixed_interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
 
 	libMesh::Real k = this->_k(T);

--- a/src/physics/src/low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/low_mach_navier_stokes_stab_base.C
@@ -103,8 +103,8 @@ namespace GRINS
 
     if( this->_enable_thermo_press_calc )
       {
-	libMesh::Real p0 = context.fixed_interior_value(this->_p0_var, qp);
-	libMesh::Real p0_dot = context.interior_value(this->_p0_var, qp);
+	libMesh::Real p0 = context.fixed_interior_value(this->_p0_var.p0_var(), qp);
+	libMesh::Real p0_dot = context.interior_value(this->_p0_var.p0_var(), qp);
 
 	RC_t += p0_dot/p0;
       }
@@ -254,7 +254,7 @@ namespace GRINS
 
     if( this->_enable_thermo_press_calc )
       {
-	RE_t -= context.interior_value(this->_p0_var, qp);
+	RE_t -= context.interior_value(this->_p0_var.p0_var(), qp);
       }
   
     return RE_t;

--- a/src/physics/src/low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/low_mach_navier_stokes_stab_base.C
@@ -55,12 +55,12 @@ namespace GRINS
   {
     // First call base class
     LowMachNavierStokesBase<Mu,SH,TC>::init_context(context);
-  
+
     // We need pressure derivatives
-    context.get_element_fe(this->_p_var)->get_dphi();
+    context.get_element_fe(this->_flow_vars.p_var())->get_dphi();
 
     // We also need second derivatives, so initialize those.
-    context.get_element_fe(this->_u_var)->get_d2phi();
+    context.get_element_fe(this->_flow_vars.u_var())->get_d2phi();
     context.get_element_fe(this->_T_var)->get_d2phi();
 
     return;
@@ -73,20 +73,20 @@ namespace GRINS
     libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
     libMesh::RealGradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
 
-    libMesh::RealGradient U( context.fixed_interior_value(this->_u_var, qp),
-			     context.fixed_interior_value(this->_v_var, qp) );  
+    libMesh::RealGradient U( context.fixed_interior_value(this->_flow_vars.u_var(), qp),
+			     context.fixed_interior_value(this->_flow_vars.v_var(), qp) );
 
     libMesh::RealGradient grad_u, grad_v;
 
-    grad_u = context.fixed_interior_gradient(this->_u_var, qp);
-    grad_v = context.fixed_interior_gradient(this->_v_var, qp);
+    grad_u = context.fixed_interior_gradient(this->_flow_vars.u_var(), qp);
+    grad_v = context.fixed_interior_gradient(this->_flow_vars.v_var(), qp);
 
     libMesh::Real divU = grad_u(0) + grad_v(1);
 
     if( this->_dim == 3 )
       {
-	U(2) = context.fixed_interior_value(this->_w_var, qp);
-	divU += (context.fixed_interior_gradient(this->_w_var, qp))(2);
+	U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp);
+	divU += (context.fixed_interior_gradient(this->_flow_vars.w_var(), qp))(2);
       }
 
     return divU - (U*grad_T)/T;
@@ -120,18 +120,18 @@ namespace GRINS
 
     libMesh::Real rho = this->rho(T, this->get_p0_transient(context,qp) );
 
-    libMesh::RealGradient U( context.fixed_interior_value(this->_u_var, qp), 
-			     context.fixed_interior_value(this->_v_var, qp) );
+    libMesh::RealGradient U( context.fixed_interior_value(this->_flow_vars.u_var(), qp),
+			     context.fixed_interior_value(this->_flow_vars.v_var(), qp) );
     if(this->_dim == 3)
-      U(2) = context.fixed_interior_value(this->_w_var, qp);
+      U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp);
 
-    libMesh::RealGradient grad_p = context.fixed_interior_gradient(this->_p_var, qp);
+    libMesh::RealGradient grad_p = context.fixed_interior_gradient(this->_flow_vars.p_var(), qp);
 
-    libMesh::RealGradient grad_u = context.fixed_interior_gradient(this->_u_var, qp);
-    libMesh::RealGradient grad_v = context.fixed_interior_gradient(this->_v_var, qp);
+    libMesh::RealGradient grad_u = context.fixed_interior_gradient(this->_flow_vars.u_var(), qp);
+    libMesh::RealGradient grad_v = context.fixed_interior_gradient(this->_flow_vars.v_var(), qp);
 
-    libMesh::RealTensor hess_u = context.fixed_interior_hessian(this->_u_var, qp);
-    libMesh::RealTensor hess_v = context.fixed_interior_hessian(this->_v_var, qp);
+    libMesh::RealTensor hess_u = context.fixed_interior_hessian(this->_flow_vars.u_var(), qp);
+    libMesh::RealTensor hess_v = context.fixed_interior_hessian(this->_flow_vars.v_var(), qp);
 
     libMesh::RealGradient rhoUdotGradU;
     libMesh::RealGradient divGradU;
@@ -147,9 +147,9 @@ namespace GRINS
       }
     else
       {
-	libMesh::RealGradient grad_w = context.fixed_interior_gradient(this->_w_var, qp);
-	libMesh::RealTensor hess_w = context.fixed_interior_hessian(this->_w_var, qp);
-      
+	libMesh::RealGradient grad_w = context.fixed_interior_gradient(this->_flow_vars.w_var(), qp);
+	libMesh::RealTensor hess_w = context.fixed_interior_hessian(this->_flow_vars.w_var(), qp);
+
 	rhoUdotGradU = rho*_stab_helper.UdotGradU( U, grad_u, grad_v, grad_w );
 
 	divGradU  = _stab_helper.div_GradU( hess_u, hess_v, hess_w );
@@ -163,8 +163,8 @@ namespace GRINS
       {
 	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
 
-	libMesh::Gradient grad_u = context.fixed_interior_gradient(this->_u_var, qp);
-	libMesh::Gradient grad_v = context.fixed_interior_gradient(this->_v_var, qp);
+	libMesh::Gradient grad_u = context.fixed_interior_gradient(this->_flow_vars.u_var(), qp);
+	libMesh::Gradient grad_v = context.fixed_interior_gradient(this->_flow_vars.v_var(), qp);
 
 	libMesh::Gradient gradTgradu( grad_T*grad_u, grad_T*grad_v );
 
@@ -177,7 +177,7 @@ namespace GRINS
 
 	if(this->_dim == 3)
 	  {
-	    libMesh::Gradient grad_w = context.fixed_interior_gradient(this->_w_var, qp);
+	    libMesh::Gradient grad_w = context.fixed_interior_gradient(this->_flow_vars.w_var(), qp);
 
 	    gradTgradu(2) = grad_T*grad_w;
 
@@ -208,10 +208,10 @@ namespace GRINS
     libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
     libMesh::Real rho = this->rho(T, this->get_p0_transient(context,qp) );
 
-    libMesh::RealGradient u_dot( context.interior_value(this->_u_var, qp), context.interior_value(this->_v_var, qp) );
+    libMesh::RealGradient u_dot( context.interior_value(this->_flow_vars.u_var(), qp), context.interior_value(this->_flow_vars.v_var(), qp) );
 
     if(this->_dim == 3)
-      u_dot(2) = context.interior_value(this->_w_var, qp);
+      u_dot(2) = context.interior_value(this->_flow_vars.w_var(), qp);
 
     return rho*u_dot;
   }
@@ -227,10 +227,10 @@ namespace GRINS
     libMesh::Real rho = this->rho(T, this->get_p0_transient(context,qp) );
     libMesh::Real rho_cp = rho*this->_cp(T);
 
-    libMesh::RealGradient rhocpU( rho_cp*context.fixed_interior_value(this->_u_var, qp), 
-				  rho_cp*context.fixed_interior_value(this->_v_var, qp) );
+    libMesh::RealGradient rhocpU( rho_cp*context.fixed_interior_value(this->_flow_vars.u_var(), qp),
+				  rho_cp*context.fixed_interior_value(this->_flow_vars.v_var(), qp) );
     if(this->_dim == 3)
-      rhocpU(2) = rho_cp*context.fixed_interior_value(this->_w_var, qp);
+      rhocpU(2) = rho_cp*context.fixed_interior_value(this->_flow_vars.w_var(), qp);
 
     libMesh::Real hess_term = hess_T(0,0) + hess_T(1,1);
 #if LIBMESH_DIM > 2

--- a/src/physics/src/low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/low_mach_navier_stokes_stab_base.C
@@ -61,7 +61,7 @@ namespace GRINS
 
     // We also need second derivatives, so initialize those.
     context.get_element_fe(this->_flow_vars.u_var())->get_d2phi();
-    context.get_element_fe(this->_T_var)->get_d2phi();
+    context.get_element_fe(this->_temp_vars.T_var())->get_d2phi();
 
     return;
   }
@@ -70,8 +70,8 @@ namespace GRINS
   libMesh::Real LowMachNavierStokesStabilizationBase<Mu,SH,TC>::compute_res_continuity_steady( AssemblyContext& context,
 											       unsigned int qp ) const
   {
-    libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
-    libMesh::RealGradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
+    libMesh::Real T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
+    libMesh::RealGradient grad_T = context.fixed_interior_gradient(this->_temp_vars.T_var(), qp);
 
     libMesh::RealGradient U( context.fixed_interior_value(this->_flow_vars.u_var(), qp),
 			     context.fixed_interior_value(this->_flow_vars.v_var(), qp) );
@@ -96,8 +96,8 @@ namespace GRINS
   libMesh::Real LowMachNavierStokesStabilizationBase<Mu,SH,TC>::compute_res_continuity_transient( AssemblyContext& context,
 												  unsigned int qp ) const
   {
-    libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
-    libMesh::Real T_dot = context.interior_value(this->_T_var, qp);
+    libMesh::Real T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
+    libMesh::Real T_dot = context.interior_value(this->_temp_vars.T_var(), qp);
 
     libMesh::Real RC_t = -T_dot/T;
 
@@ -116,7 +116,7 @@ namespace GRINS
   libMesh::RealGradient LowMachNavierStokesStabilizationBase<Mu,SH,TC>::compute_res_momentum_steady( AssemblyContext& context,
 												     unsigned int qp ) const
   {
-    libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
+    libMesh::Real T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
 
     libMesh::Real rho = this->rho(T, this->get_p0_transient(context,qp) );
 
@@ -161,7 +161,7 @@ namespace GRINS
 
     if( this->_mu.deriv(T) != 0.0 )
       {
-	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
+	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_temp_vars.T_var(), qp);
 
 	libMesh::Gradient grad_u = context.fixed_interior_gradient(this->_flow_vars.u_var(), qp);
 	libMesh::Gradient grad_v = context.fixed_interior_gradient(this->_flow_vars.v_var(), qp);
@@ -205,7 +205,7 @@ namespace GRINS
   libMesh::RealGradient LowMachNavierStokesStabilizationBase<Mu,SH,TC>::compute_res_momentum_transient( AssemblyContext& context,
 													unsigned int qp ) const
   {
-    libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
+    libMesh::Real T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
     libMesh::Real rho = this->rho(T, this->get_p0_transient(context,qp) );
 
     libMesh::RealGradient u_dot( context.interior_value(this->_flow_vars.u_var(), qp), context.interior_value(this->_flow_vars.v_var(), qp) );
@@ -220,9 +220,9 @@ namespace GRINS
   libMesh::Real LowMachNavierStokesStabilizationBase<Mu,SH,TC>::compute_res_energy_steady( AssemblyContext& context,
 											   unsigned int qp ) const
   {
-    libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
-    libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
-    libMesh::Tensor hess_T = context.fixed_interior_hessian(this->_T_var, qp);
+    libMesh::Real T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
+    libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_temp_vars.T_var(), qp);
+    libMesh::Tensor hess_T = context.fixed_interior_hessian(this->_temp_vars.T_var(), qp);
 
     libMesh::Real rho = this->rho(T, this->get_p0_transient(context,qp) );
     libMesh::Real rho_cp = rho*this->_cp(T);
@@ -245,10 +245,10 @@ namespace GRINS
   libMesh::Real LowMachNavierStokesStabilizationBase<Mu,SH,TC>::compute_res_energy_transient( AssemblyContext& context,
 											      unsigned int qp ) const
   {
-    libMesh::Real T = context.fixed_interior_value(this->_T_var, qp);
+    libMesh::Real T = context.fixed_interior_value(this->_temp_vars.T_var(), qp);
     libMesh::Real rho = this->rho(T, this->get_p0_transient(context,qp) );
     libMesh::Real rho_cp = rho*this->_cp(T);
-    libMesh::Real T_dot = context.interior_value(this->_T_var, qp);
+    libMesh::Real T_dot = context.interior_value(this->_temp_vars.T_var(), qp);
 
     libMesh::Real RE_t = rho_cp*T_dot;
 

--- a/src/physics/src/low_mach_navier_stokes_vms_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_vms_stab.C
@@ -116,7 +116,7 @@ namespace GRINS
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
 
-	libMesh::Real T = context.interior_value( this->_T_var, qp );
+	libMesh::Real T = context.interior_value( this->_temp_vars.T_var(), qp );
 
 	libMesh::Real mu = this->_mu(T);
 
@@ -180,7 +180,7 @@ namespace GRINS
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Real T = context.interior_value( this->_T_var, qp );
+	libMesh::Real T = context.interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
 	libMesh::RealGradient U( context.interior_value(this->_flow_vars.u_var(), qp),
@@ -238,21 +238,21 @@ namespace GRINS
 										  AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_T_var)->get_JxW();
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.get_element_fe(this->_T_var)->get_phi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_phi();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.get_element_fe(this->_T_var)->get_dphi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_temp_vars.T_var()); // R_{T}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -262,13 +262,13 @@ namespace GRINS
 	u = context.interior_value(this->_flow_vars.u_var(), qp);
 	v = context.interior_value(this->_flow_vars.v_var(), qp);
 
-	libMesh::Gradient grad_T = context.interior_gradient(this->_T_var, qp);
+	libMesh::Gradient grad_T = context.interior_gradient(this->_temp_vars.T_var(), qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
 	  U(2) = context.interior_value(this->_flow_vars.w_var(), qp); // w
 
-	libMesh::Real T = context.interior_value( this->_T_var, qp );
+	libMesh::Real T = context.interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);
@@ -326,7 +326,7 @@ namespace GRINS
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
 
-	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
+	libMesh::Real T = context.fixed_interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);
@@ -386,7 +386,7 @@ namespace GRINS
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
+	libMesh::Real T = context.fixed_interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);
@@ -449,21 +449,21 @@ namespace GRINS
 										     AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_T_var)->get_JxW();
+      context.get_element_fe(this->_temp_vars.T_var())->get_JxW();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.get_element_fe(this->_T_var)->get_phi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_phi();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.get_element_fe(this->_T_var)->get_dphi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_temp_vars.T_var()); // R_{T}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -473,13 +473,13 @@ namespace GRINS
 	u = context.fixed_interior_value(this->_flow_vars.u_var(), qp);
 	v = context.fixed_interior_value(this->_flow_vars.v_var(), qp);
 
-	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
+	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_temp_vars.T_var(), qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
 	  U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp); // w
 
-	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
+	libMesh::Real T = context.fixed_interior_value( this->_temp_vars.T_var(), qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
 
 	libMesh::Real mu = this->_mu(T);

--- a/src/physics/src/low_mach_navier_stokes_vms_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_vms_stab.C
@@ -95,37 +95,37 @@ namespace GRINS
 										      AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.get_element_fe(this->_p_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.p_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_flow_vars.p_var()); // R_{p}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
 
 	libMesh::Real T = context.interior_value( this->_T_var, qp );
-      
+
 	libMesh::Real mu = this->_mu(T);
 
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
-	libMesh::RealGradient U( context.interior_value( this->_u_var, qp ),
-				 context.interior_value( this->_v_var, qp ) );
+	libMesh::RealGradient U( context.interior_value( this->_flow_vars.u_var(), qp ),
+				 context.interior_value( this->_flow_vars.v_var(), qp ) );
 	if( this->_dim == 3 )
-	  U(2) = context.interior_value( this->_w_var, qp );
+	  U(2) = context.interior_value( this->_flow_vars.w_var(), qp );
 
 	libMesh::Real tau_M = this->_stab_helper.compute_tau_momentum( context, qp, g, G, rho, U, mu, this->_is_steady );
 
@@ -148,28 +148,33 @@ namespace GRINS
 										    AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
-    // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
+    // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.w_var()).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.get_element_fe(this->_u_var)->get_phi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_phi();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.get_element_fe(this->_u_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_flow_vars.u_var()); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_flow_vars.v_var()); // R_{v}
+    libMesh::DenseSubVector<libMesh::Real>* Fw = NULL;
+
+    if( this->_dim == 3 )
+      {
+        Fw  = &context.get_elem_residual(this->_flow_vars.w_var()); // R_{w}
+      }
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -178,20 +183,20 @@ namespace GRINS
 	libMesh::Real T = context.interior_value( this->_T_var, qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
 
-	libMesh::RealGradient U( context.interior_value(this->_u_var, qp),
-				 context.interior_value(this->_v_var, qp) );
+	libMesh::RealGradient U( context.interior_value(this->_flow_vars.u_var(), qp),
+				 context.interior_value(this->_flow_vars.v_var(), qp) );
 
-	libMesh::RealGradient grad_u = context.interior_gradient(this->_u_var, qp);
-	libMesh::RealGradient grad_v = context.interior_gradient(this->_v_var, qp);
+	libMesh::RealGradient grad_u = context.interior_gradient(this->_flow_vars.u_var(), qp);
+	libMesh::RealGradient grad_v = context.interior_gradient(this->_flow_vars.v_var(), qp);
 	libMesh::RealGradient grad_w;
 
 	if( this->_dim == 3 )
 	  {
-	    U(2) = context.interior_value(this->_w_var, qp);
-	    grad_w = context.interior_gradient(this->_w_var, qp);
+	    U(2) = context.interior_value(this->_flow_vars.w_var(), qp);
+	    grad_w = context.interior_gradient(this->_flow_vars.w_var(), qp);
 	  }
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -217,10 +222,10 @@ namespace GRINS
 
 	    if( this->_dim == 3 )
 	      {
-		Fw(i) += ( -tau_C*RC_s*u_gradphi[i][qp](2)
-			   - tau_M*RM_s(2)*rho*U*u_gradphi[i][qp]
-			   + rho*tau_M*RM_s*grad_w*u_phi[i][qp]
-			   + tau_M*RM_s(2)*rho*tau_M*RM_s*u_gradphi[i][qp] )*JxW[qp];
+		(*Fw)(i) += ( -tau_C*RC_s*u_gradphi[i][qp](2)
+                              - tau_M*RM_s(2)*rho*U*u_gradphi[i][qp]
+                              + rho*tau_M*RM_s*grad_w*u_phi[i][qp]
+                              + tau_M*RM_s(2)*rho*tau_M*RM_s*u_gradphi[i][qp] )*JxW[qp];
 	      }
 	  }
 
@@ -254,14 +259,14 @@ namespace GRINS
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Number u, v;
-	u = context.interior_value(this->_u_var, qp);
-	v = context.interior_value(this->_v_var, qp);
+	u = context.interior_value(this->_flow_vars.u_var(), qp);
+	v = context.interior_value(this->_flow_vars.v_var(), qp);
 
 	libMesh::Gradient grad_T = context.interior_gradient(this->_T_var, qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = context.interior_value(this->_w_var, qp); // w
+	  U(2) = context.interior_value(this->_flow_vars.w_var(), qp); // w
 
 	libMesh::Real T = context.interior_value( this->_T_var, qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_steady( context, qp ) );
@@ -272,7 +277,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -300,23 +305,23 @@ namespace GRINS
 											 AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& p_dphi =
-      context.get_element_fe(this->_p_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.p_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_p_var); // R_{p}
+    libMesh::DenseSubVector<libMesh::Number> &Fp = context.get_elem_residual(this->_flow_vars.p_var()); // R_{p}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -326,10 +331,10 @@ namespace GRINS
 
 	libMesh::Real mu = this->_mu(T);
 
-	libMesh::RealGradient U( context.fixed_interior_value( this->_u_var, qp ),
-				 context.fixed_interior_value( this->_v_var, qp ) );
+	libMesh::RealGradient U( context.fixed_interior_value( this->_flow_vars.u_var(), qp ),
+				 context.fixed_interior_value( this->_flow_vars.v_var(), qp ) );
 	if( this->_dim == 3 )
-	  U(2) = context.fixed_interior_value( this->_w_var, qp );
+	  U(2) = context.fixed_interior_value( this->_flow_vars.w_var(), qp );
 
 	libMesh::Real tau_M = this->_stab_helper.compute_tau_momentum( context, qp, g, G, rho, U, mu, false );
 	libMesh::RealGradient RM_t = this->compute_res_momentum_transient( context, qp );
@@ -350,28 +355,33 @@ namespace GRINS
 										       AssemblyContext& context )
   {
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
 
-    // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
+    // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.w_var()).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real> &JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.get_element_fe(this->_u_var)->get_phi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_phi();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.get_element_fe(this->_u_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_dphi();
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_flow_vars.u_var()); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_flow_vars.v_var()); // R_{v}
+    libMesh::DenseSubVector<libMesh::Real>* Fw = NULL;
+
+    if( this->_dim == 3 )
+      {
+        Fw  = &context.get_elem_residual(this->_flow_vars.w_var()); // R_{w}
+      }
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
@@ -381,20 +391,20 @@ namespace GRINS
 
 	libMesh::Real mu = this->_mu(T);
 
-	libMesh::RealGradient U( context.fixed_interior_value(this->_u_var, qp),
-				 context.fixed_interior_value(this->_v_var, qp) );
+	libMesh::RealGradient U( context.fixed_interior_value(this->_flow_vars.u_var(), qp),
+				 context.fixed_interior_value(this->_flow_vars.v_var(), qp) );
 
-	libMesh::RealGradient grad_u = context.fixed_interior_gradient(this->_u_var, qp);
-	libMesh::RealGradient grad_v = context.fixed_interior_gradient(this->_v_var, qp);
+	libMesh::RealGradient grad_u = context.fixed_interior_gradient(this->_flow_vars.u_var(), qp);
+	libMesh::RealGradient grad_v = context.fixed_interior_gradient(this->_flow_vars.v_var(), qp);
 	libMesh::RealGradient grad_w;
 
 	if( this->_dim == 3 )
 	  {
-	    U(2) = context.fixed_interior_value(this->_w_var, qp);
-	    grad_w = context.fixed_interior_gradient(this->_w_var, qp);
+	    U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp);
+	    grad_w = context.fixed_interior_gradient(this->_flow_vars.w_var(), qp);
 	  }
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );
@@ -422,11 +432,11 @@ namespace GRINS
 
 	    if( this->_dim == 3 )
 	      {
-		Fw(i) -= ( tau_C*RC_t*u_gradphi[i][qp](2)
-			   - rho*tau_M*RM_t*grad_w*u_phi[i][qp]
-			   + tau_M*RM_t(2)*rho*U*u_gradphi[i][qp]
-			   - tau_M*(RM_s(2)+RM_t(2))*rho*tau_M*RM_t*u_gradphi[i][qp]
-			   - tau_M*RM_t(2)*rho*tau_M*RM_s*u_gradphi[i][qp] )*JxW[qp];
+		(*Fw)(i) -= ( tau_C*RC_t*u_gradphi[i][qp](2)
+                              - rho*tau_M*RM_t*grad_w*u_phi[i][qp]
+                              + tau_M*RM_t(2)*rho*U*u_gradphi[i][qp]
+                              - tau_M*(RM_s(2)+RM_t(2))*rho*tau_M*RM_t*u_gradphi[i][qp]
+                              - tau_M*RM_t(2)*rho*tau_M*RM_s*u_gradphi[i][qp] )*JxW[qp];
 	      }
 	  }
 
@@ -460,14 +470,14 @@ namespace GRINS
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
 	libMesh::Number u, v;
-	u = context.fixed_interior_value(this->_u_var, qp);
-	v = context.fixed_interior_value(this->_v_var, qp);
+	u = context.fixed_interior_value(this->_flow_vars.u_var(), qp);
+	v = context.fixed_interior_value(this->_flow_vars.v_var(), qp);
 
 	libMesh::Gradient grad_T = context.fixed_interior_gradient(this->_T_var, qp);
 
 	libMesh::NumberVectorValue U(u,v);
 	if (this->_dim == 3)
-	  U(2) = context.fixed_interior_value(this->_w_var, qp); // w
+	  U(2) = context.fixed_interior_value(this->_flow_vars.w_var(), qp); // w
 
 	libMesh::Real T = context.fixed_interior_value( this->_T_var, qp );
 	libMesh::Real rho = this->rho( T, this->get_p0_transient( context, qp ) );
@@ -478,7 +488,7 @@ namespace GRINS
 
 	libMesh::Number rho_cp = rho*this->_cp(T);
 
-	libMesh::FEBase* fe = context.get_element_fe(this->_u_var);
+	libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u_var());
 
 	libMesh::RealGradient g = this->_stab_helper.compute_g( fe, context, qp );
 	libMesh::RealTensor G = this->_stab_helper.compute_G( fe, context, qp );

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -195,7 +195,7 @@ namespace GRINS
         libmesh_not_implemented();
       }
     // Convenience
-    const VariableIndex s0_var = this->_species_vars[0];
+    const VariableIndex s0_var = this->_species_vars.species_var(0);
 
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
@@ -343,7 +343,7 @@ namespace GRINS
         for(unsigned int s=0; s < this->_n_species; s++ )
           {
             libMesh::DenseSubVector<libMesh::Number> &Fs =
-              context.get_elem_residual(this->_species_vars[s]); // R_{s}
+              context.get_elem_residual(this->_species_vars.species_var(s)); // R_{s}
 
             const libMesh::Real term1 = -rho*(U*grad_ws[s]) + omega_dot[s];
             const libMesh::Gradient term2 = -rho*D[s]*grad_ws[s];
@@ -517,8 +517,8 @@ namespace GRINS
 	  {
 	    /*! \todo Need to figure out something smarter for controling species
 	              that go slightly negative. */
-	    mass_fractions[qp][s] = std::max( context.interior_value(this->_species_vars[s],qp), 0.0 );
-	    grad_mass_fractions[qp][s] = context.interior_gradient(this->_species_vars[s],qp);
+	    mass_fractions[qp][s] = std::max( context.interior_value(this->_species_vars.species_var(s),qp), 0.0 );
+	    grad_mass_fractions[qp][s] = context.interior_gradient(this->_species_vars.species_var(s),qp);
 	  }
 	
 	M[qp] = gas_evaluator.M_mix( mass_fractions[qp] );
@@ -628,7 +628,7 @@ namespace GRINS
 	  {
 	    /*! \todo Need to figure out something smarter for controling species
 	              that go slightly negative. */
-	    mass_fractions[qp][s] = std::max( context.side_value(this->_species_vars[s],qp), 0.0 );
+	    mass_fractions[qp][s] = std::max( context.side_value(this->_species_vars.species_var(s),qp), 0.0 );
 	  }
 	const libMesh::Real p0 = this->get_p0_steady_side(context, qp);
 

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -172,15 +172,15 @@ namespace GRINS
     ReactingLowMachNavierStokesBase<Mixture,Evaluator>::init_context(context);
 
     // We also need the side shape functions, etc.
-    context.get_side_fe(this->_u_var)->get_JxW();
-    context.get_side_fe(this->_u_var)->get_phi();
-    context.get_side_fe(this->_u_var)->get_dphi();
-    context.get_side_fe(this->_u_var)->get_xyz();
+    context.get_side_fe(this->_flow_vars.u_var())->get_JxW();
+    context.get_side_fe(this->_flow_vars.u_var())->get_phi();
+    context.get_side_fe(this->_flow_vars.u_var())->get_dphi();
+    context.get_side_fe(this->_flow_vars.u_var())->get_xyz();
 
-    context.get_side_fe(this->_T_var)->get_JxW();
-    context.get_side_fe(this->_T_var)->get_phi();
-    context.get_side_fe(this->_T_var)->get_dphi();
-    context.get_side_fe(this->_T_var)->get_xyz();
+    context.get_side_fe(this->_temp_vars.T_var())->get_JxW();
+    context.get_side_fe(this->_temp_vars.T_var())->get_phi();
+    context.get_side_fe(this->_temp_vars.T_var())->get_dphi();
+    context.get_side_fe(this->_temp_vars.T_var())->get_xyz();
 
     return;
   }
@@ -198,23 +198,23 @@ namespace GRINS
     const VariableIndex s0_var = this->_species_vars[0];
 
     // The number of local degrees of freedom in each variable.
-    const unsigned int n_p_dofs = context.get_dof_indices(this->_p_var).size();
+    const unsigned int n_p_dofs = context.get_dof_indices(this->_flow_vars.p_var()).size();
     const unsigned int n_s_dofs = context.get_dof_indices(s0_var).size();
-    const unsigned int n_u_dofs = context.get_dof_indices(this->_u_var).size();
-    const unsigned int n_T_dofs = context.get_dof_indices(this->_T_var).size();
+    const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u_var()).size();
+    const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T_var()).size();
 
-    // Check number of dofs is same for _u_var, v_var and w_var.
-    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_v_var).size());
+    // Check number of dofs is same for _flow_vars.u_var(), v_var and w_var.
+    libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.v_var()).size());
     if (this->_dim == 3)
-      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_w_var).size());
+      libmesh_assert (n_u_dofs == context.get_dof_indices(this->_flow_vars.w_var()).size());
 
     // Element Jacobian * quadrature weights for interior integration.
     const std::vector<libMesh::Real>& JxW =
-      context.get_element_fe(this->_u_var)->get_JxW();
+      context.get_element_fe(this->_flow_vars.u_var())->get_JxW();
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& p_phi =
-      context.get_element_fe(this->_p_var)->get_phi();
+      context.get_element_fe(this->_flow_vars.p_var())->get_phi();
 
     // The species shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& s_phi = context.get_element_fe(s0_var)->get_phi();
@@ -224,30 +224,35 @@ namespace GRINS
 
     // The pressure shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& u_phi =
-      context.get_element_fe(this->_u_var)->get_phi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_phi();
 
     // The velocity shape function gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& u_gradphi =
-      context.get_element_fe(this->_u_var)->get_dphi();
+      context.get_element_fe(this->_flow_vars.u_var())->get_dphi();
 
     // The temperature shape functions at interior quadrature points.
     const std::vector<std::vector<libMesh::Real> >& T_phi =
-      context.get_element_fe(this->_T_var)->get_phi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_phi();
 
     // The temperature shape functions gradients at interior quadrature points.
     const std::vector<std::vector<libMesh::RealGradient> >& T_gradphi =
-      context.get_element_fe(this->_T_var)->get_dphi();
+      context.get_element_fe(this->_temp_vars.T_var())->get_dphi();
 
     const std::vector<libMesh::Point>& u_qpoint =
-      context.get_element_fe(this->_u_var)->get_xyz();
+      context.get_element_fe(this->_flow_vars.u_var())->get_xyz();
 
-    libMesh::DenseSubVector<libMesh::Number>& Fp = context.get_elem_residual(this->_p_var); // R_{p}
+    libMesh::DenseSubVector<libMesh::Number>& Fp = context.get_elem_residual(this->_flow_vars.p_var()); // R_{p}
 
-    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_u_var); // R_{u}
-    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_v_var); // R_{v}
-    libMesh::DenseSubVector<libMesh::Number> &Fw = context.get_elem_residual(this->_w_var); // R_{w}
+    libMesh::DenseSubVector<libMesh::Number> &Fu = context.get_elem_residual(this->_flow_vars.u_var()); // R_{u}
+    libMesh::DenseSubVector<libMesh::Number> &Fv = context.get_elem_residual(this->_flow_vars.v_var()); // R_{v}
+    libMesh::DenseSubVector<libMesh::Real>* Fw = NULL;
 
-    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_T_var); // R_{T}
+    if( this->_dim == 3 )
+      {
+        Fw  = &context.get_elem_residual(this->_flow_vars.w_var()); // R_{w}
+      }
+
+    libMesh::DenseSubVector<libMesh::Number> &FT = context.get_elem_residual(this->_temp_vars.T_var()); // R_{T}
 
     unsigned int n_qpoints = context.get_element_qrule().n_points();
     for (unsigned int qp=0; qp != n_qpoints; qp++)
@@ -376,12 +381,12 @@ namespace GRINS
 
             if (this->_dim == 3)
               {
-                Fw(i) += ( -rho*U*grad_w*u_phi[i][qp]
-                           + p*u_gradphi[i][qp](2)
-                           - mu*(u_gradphi[i][qp]*grad_w + u_gradphi[i][qp]*grad_wT
-                                 - 2.0/3.0*divU*u_gradphi[i][qp](2) )
-                           + rho*this->_g(2)*u_phi[i][qp]
-                           )*jac;
+                (*Fw)(i) += ( -rho*U*grad_w*u_phi[i][qp]
+                              + p*u_gradphi[i][qp](2)
+                              - mu*(u_gradphi[i][qp]*grad_w + u_gradphi[i][qp]*grad_wT
+                                    - 2.0/3.0*divU*u_gradphi[i][qp](2) )
+                              + rho*this->_g(2)*u_phi[i][qp]
+                              )*jac;
               }
           }
 
@@ -431,7 +436,7 @@ namespace GRINS
     // Pin p = p_value at p_point
     if( this->_pin_pressure )
       {
-	_p_pinning.pin_value( context, compute_jacobian, this->_p_var );
+	_p_pinning.pin_value( context, compute_jacobian, this->_flow_vars.p_var() );
       }
 
     return;
@@ -489,20 +494,20 @@ namespace GRINS
 
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {
-	u[qp] = context.interior_value(this->_u_var, qp);
-	v[qp] = context.interior_value(this->_v_var, qp);
+	u[qp] = context.interior_value(this->_flow_vars.u_var(), qp);
+	v[qp] = context.interior_value(this->_flow_vars.v_var(), qp);
 
-	grad_u[qp] = context.interior_gradient(this->_u_var, qp);
-	grad_v[qp] = context.interior_gradient(this->_v_var, qp);
+	grad_u[qp] = context.interior_gradient(this->_flow_vars.u_var(), qp);
+	grad_v[qp] = context.interior_gradient(this->_flow_vars.v_var(), qp);
 	if( this->_dim > 2 )
 	  {
-	    w[qp] = context.interior_value(this->_w_var, qp);
-	    grad_w[qp] = context.interior_gradient(this->_w_var, qp);
+	    w[qp] = context.interior_value(this->_flow_vars.w_var(), qp);
+	    grad_w[qp] = context.interior_gradient(this->_flow_vars.w_var(), qp);
 	  }
-	T[qp] = context.interior_value(this->_T_var, qp);
-	grad_T[qp] = context.interior_gradient(this->_T_var, qp);
+	T[qp] = context.interior_value(this->_temp_vars.T_var(), qp);
+	grad_T[qp] = context.interior_gradient(this->_temp_vars.T_var(), qp);
 
-	p[qp] = context.interior_value(this->_p_var, qp);
+	p[qp] = context.interior_value(this->_flow_vars.p_var(), qp);
 	p0[qp] = this->get_p0_steady(context, qp);
 
 	mass_fractions[qp].resize(this->_n_species);
@@ -616,7 +621,7 @@ namespace GRINS
 
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {
-	T[qp] = context.side_value(this->_T_var, qp);
+	T[qp] = context.side_value(this->_temp_vars.T_var(), qp);
 
 	mass_fractions[qp].resize(this->_n_species);
 	for( unsigned int s = 0; s < this->_n_species; s++ )

--- a/src/physics/src/reacting_low_mach_navier_stokes_base.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_base.C
@@ -50,6 +50,7 @@ namespace GRINS
       _gas_mixture(input,MaterialsParsing::material_name(input,reacting_low_mach_navier_stokes)),
       _flow_vars(input, reacting_low_mach_navier_stokes),
       _temp_vars(input, reacting_low_mach_navier_stokes),
+      _p0_var(input, reacting_low_mach_navier_stokes),
       _fixed_density( input("Physics/"+reacting_low_mach_navier_stokes+"/fixed_density", false ) ),
       _fixed_rho_value(0.0)
   {
@@ -91,11 +92,6 @@ namespace GRINS
 
     _enable_thermo_press_calc = input("Physics/"+reacting_low_mach_navier_stokes+"/enable_thermo_press_calc", false );
 
-    if( _enable_thermo_press_calc )
-      {
-	_p0_var_name = input("Physics/VariableNames/thermo_presure", "p0" );
-      }
-
     // Read gravity vector
     unsigned int g_dim = input.vector_variable_size("Physics/"+reacting_low_mach_navier_stokes+"/g");
 
@@ -127,7 +123,7 @@ namespace GRINS
     /* If we need to compute the thermodynamic pressure, we force this to be a first
        order scalar variable. */
     if( _enable_thermo_press_calc )
-      _p0_var = system->add_variable( _p0_var_name, libMesh::FIRST, libMesh::SCALAR);
+      _p0_var.init(system);
 
     return;
   }
@@ -152,7 +148,7 @@ namespace GRINS
     system->time_evolving(_flow_vars.p_var());
 
     if( _enable_thermo_press_calc )
-      system->time_evolving(_p0_var);
+      system->time_evolving(_p0_var.p0_var());
 
     return;
   }

--- a/src/physics/src/species_mass_fracs_fe_variables.C
+++ b/src/physics/src/species_mass_fracs_fe_variables.C
@@ -1,0 +1,61 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/species_mass_fracs_fe_variables.h"
+
+// GRINS
+#include "grins/grins_enums.h"
+#include "grins/variable_name_defaults.h"
+#include "grins/materials_parsing.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+#include "libmesh/string_to_enum.h"
+#include "libmesh/fem_system.h"
+
+namespace GRINS
+{
+  SpeciesMassFractionsFEVariables::SpeciesMassFractionsFEVariables( const GetPot& input,
+                                                                    const std::string& physics_name )
+    : SpeciesMassFractionsVariables( input, MaterialsParsing::material_name(input,physics_name) )
+  {
+    this->_species_FE_family = libMesh::Utility::string_to_enum<GRINSEnums::FEFamily>( input("Physics/"+physics_name+"/species_FE_family", "LAGRANGE") );
+
+    // Read FE family info
+    this->_species_order = libMesh::Utility::string_to_enum<GRINSEnums::Order>( input("Physics/"+physics_name+"/species_order", "SECOND") );
+  }
+
+  void SpeciesMassFractionsFEVariables::init( libMesh::FEMSystem* system )
+  {
+    this->_species_vars.resize(this->n_species());
+    for( unsigned int s = 0; s < this->n_species(); s++ )
+      {
+	this->_species_vars[s] = system->add_variable( this->_species_var_names[s],
+                                                       this->_species_order,
+                                                       this->_species_FE_family);
+      }
+  }
+
+} // end namespace GRINS

--- a/src/physics/src/species_mass_fracs_variables.C
+++ b/src/physics/src/species_mass_fracs_variables.C
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/species_mass_fracs_variables.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+#include "libmesh/fem_system.h"
+
+// GRINS
+#include "grins/variable_name_defaults.h"
+#include "grins/materials_parsing.h"
+
+namespace GRINS
+{
+  SpeciesMassFractionsVariables::SpeciesMassFractionsVariables( const GetPot& input,
+                                                                const std::string& material_name )
+  {
+    MaterialsParsing::parse_species_varnames(input, material_name, _species_var_names);
+  }
+
+  void SpeciesMassFractionsVariables::init( libMesh::FEMSystem* system )
+  {
+    unsigned int n_species = this->n_species();
+
+#ifndef NDEBUG
+    for( unsigned int s = 0; s < n_species; s++)
+      libmesh_assert( system->has_variable( _species_var_names[s] ) );
+#endif
+
+    _species_vars.resize(n_species);
+    for( unsigned int s = 0; s < n_species; s++)
+      _species_vars[s] = system->variable_number( _species_var_names[s] );
+  }
+
+} // end namespace GRINS

--- a/src/physics/src/thermo_pressure_fe_variable.C
+++ b/src/physics/src/thermo_pressure_fe_variable.C
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/thermo_pressure_fe_variable.h"
+
+// GRINS
+#include "grins/grins_enums.h"
+#include "grins/variable_name_defaults.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+#include "libmesh/fem_system.h"
+
+namespace GRINS
+{
+  ThermoPressureFEVariable::ThermoPressureFEVariable( const GetPot& input, const std::string& /*physics_name*/ )
+    :  ThermoPressureVariable(input),
+       _P_FE_family( libMesh::SCALAR ),
+       _P_order( libMesh::FIRST )
+  {}
+
+  void ThermoPressureFEVariable::init( libMesh::FEMSystem* system )
+  {
+    _p0_var = system->add_variable( _p0_var_name, libMesh::FIRST, libMesh::SCALAR );
+  }
+
+} // end namespace GRINS

--- a/src/physics/src/thermo_pressure_variable.C
+++ b/src/physics/src/thermo_pressure_variable.C
@@ -1,0 +1,46 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/thermo_pressure_variable.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+#include "libmesh/fem_system.h"
+
+namespace GRINS
+{
+  ThermoPressureVariable::ThermoPressureVariable( const GetPot& input )
+    : _p0_var(invalid_var_index),
+      _p0_var_name( input("Physics/VariableNames/thermo_presure", "p0" ) )
+  {}
+
+  void ThermoPressureVariable::init( libMesh::FEMSystem* system )
+  {
+    libmesh_assert( system->has_variable( _p0_var_name ) );
+
+    _p0_var = system->variable_number( _p0_var_name );
+  }
+
+} // end namespace GRINS

--- a/test/input_files/axi_thermally_driven_flow.in
+++ b/test/input_files/axi_thermally_driven_flow.in
@@ -103,9 +103,5 @@ g = '0 -9.8'
 Temperature = 'T'
 u_velocity = 'u'
 v_velocity = 'v'
-w_velocity = 'w'
 pressure = 'p'
-# Made these u and v as well to reuse test.
-r_velocity = 'u'
-z_velocity = 'v'
 []


### PR DESCRIPTION
This effectively completes what was started in #73, namely encapsulating the variable name parsing and variable initialization with the `libMesh::System` into standalone classes. Then, updating `Physics` classes to only use these objects to handle variables. This is opposed to the scattered mess that was there before. The design follows as before: `*Variable` classes for basic handling of variable name and index (primarily used in `BCHandling` classes) and `*FEVariable` subclasses for the finite element space (used in the `Physics` classes).

The first set of commits updates the `Physics` and `BCHandling` classes that could've used already existing `(FE)Variable` classes. Then, I added thermodynamic pressure and species mass fraction versions of the `(FE)Variable` classes and then used them. The vast majority of the addition/deletions in this PR are search replace from hardcoded variable index to using the `Variable` object.

I believe I got everything except the QoIs (and there's only a couple that need changing) and two specialized `Physics` classes. The QoIs currently don't take a GetPot object in the constructor, so I can drop these objects in there yet. It seemed overkill to create such `Variable` classes for the specialized `Physics`.

This is the precursor to redoing the input file sectioning for the FEM variables, ala the discussion in [this grins-devel](https://groups.google.com/forum/#!topic/grins-devel/AGVvODmfzh8) thread. After this, we should be able to limit the changes needed to (slightly more than) a handful of classes.