### PR TITLE
__LIBMESH_<DATE,TIME>__ are no longer defined

### DIFF
--- a/src/common/include/grins/common.h
+++ b/src/common/include/grins/common.h
@@ -27,13 +27,13 @@
 #define grins_warning_once(message) \
   libmesh_do_once(libMesh::out <<"==========================================================" << std::endl \
                   << message \
-                  << __FILE__ << ", line " << __LINE__ << ", compiled " << __LIBMESH_DATE__ << " at " << __LIBMESH_TIME__ << " ***" << std::endl \
+                  << __FILE__ << ", line " << __LINE__ << ", compiled " << __DATE__ << " at " << __TIME__ << " ***" << std::endl \
                   <<"==========================================================" \
                   << std::endl;)
 
 #define grins_warning(message) \
   libMesh::out <<"==========================================================" << std::endl \
                << message \
-               << __FILE__ << ", line " << __LINE__ << ", compiled " << __LIBMESH_DATE__ << " at " << __LIBMESH_TIME__ << " ***" << std::endl \
+               << __FILE__ << ", line " << __LINE__ << ", compiled " << __DATE__ << " at " << __TIME__ << " ***" << std::endl \
                <<"==========================================================" \
                << std::endl;


### PR DESCRIPTION
And that's OK because we were *lying*. The source was built at __DATE__
and __TIME__ since this is GRINS and not libMesh.