### PR TITLE
Update Examples to use parsed_dirichlet Boundary Condition

### DIFF
--- a/examples/backward_facing_step/backward_facing_step.in
+++ b/examples/backward_facing_step/backward_facing_step.in
@@ -31,12 +31,11 @@ P_order = 'FIRST'
 # 2 - no slip walls
 # 3 - outlet
 
-bc_ids = '1 2'
-bc_types = 'parabolic_profile no_slip'
+bc_ids = '1 1 2'
+bc_types = 'parsed_dirichlet constant_dirichlet no_slip'
 
-parabolic_profile_coeffs_1 = '0.0 0.0 -480.0 0.0 240.0 0.0'
-parabolic_profile_var_1 = 'u'
-parabolic_profile_fix_1 = 'v'
+bc_variables = 'u v'
+bc_values = '240.0*y*(1.0-2.0*y) 0.0'
 
 pin_pressure = 'false'
 

--- a/examples/coupled_stokes_navierstokes/stokes_ns.in
+++ b/examples/coupled_stokes_navierstokes/stokes_ns.in
@@ -62,12 +62,11 @@ FE_family = LAGRANGE
 V_order = SECOND
 P_order = FIRST
 
-bc_ids = '4 6 7 8'
-bc_types = 'no_slip no_slip parabolic_profile no_slip'
+bc_ids = '7 7 4 6 8'
+bc_types = 'parsed_dirichlet constant_dirichlet no_slip no_slip no_slip'
 
-parabolic_profile_coeffs_7 = '0.0 0.0 -4.0 0.0 4.0 0.0'
-parabolic_profile_var_7 = 'u'
-parabolic_profile_fix_7 = 'v'
+bc_variables = 'u v'
+bc_values = '4.0*y*(1.0-y) 0.0'
 
 # Options for Navier Stokes physics
 [../IncompressibleNavierStokes]


### PR DESCRIPTION
Instead of outdated `ParabolicProfile`