### PR TITLE
Fix test that was failing with PETSc >= 3.6.x

### DIFF
--- a/test/test_axi_ns_con_cyl_flow.sh.in
+++ b/test/test_axi_ns_con_cyl_flow.sh.in
@@ -5,6 +5,6 @@ PROG="@top_builddir@/test/test_axi_ns_con_cyl_flow"
 INPUT="@top_srcdir@/test/input_files/axi_con_cyl_flow.in"
 
 # A MOAB preconditioner
-PETSC_OPTIONS="-pc_type asm -pc_asm_overlap 12 -sub_pc_type ilu -sub_pc_factor_mat_ordering_type 1wd -sub_pc_factor_levels 4"
+PETSC_OPTIONS="-pc_type asm -pc_asm_overlap 12 -sub_pc_type ilu -sub_pc_factor_mat_ordering_type 1wd -sub_pc_factor_levels 4 -sub_pc_factor_shift_type nonzero"
 
 ${LIBMESH_RUN:-} $PROG $INPUT $PETSC_OPTIONS


### PR DESCRIPTION
The change was in the default behavior on the shift type for PC ilu.
See this thread: http://lists.mcs.anl.gov/pipermail/petsc-users/2016-January/028210.html

@dknez I have a vague memory of you mentioning some failures that happened with PETSc >= 3.6.0, but I can't find the thread now. I'd bet this was the culprit. If I'm misremembering, sorry for the noise.

Merging right away.