### PR TITLE
Refactor unsteady solver options

### DIFF
--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -326,3 +326,42 @@
             # Poisson's ratio
             nu = '0.3'
 []
+
+
+# The block below illustrates specifying options for the solver.
+# Solvers are things like linear solver, nonlinear solver, and
+# time stepping.
+[SolverOptions]
+
+   # Options related for time stepping algorithms
+   [./TimeStepping]
+
+      # This is the algorithm for time-stepping. Time stepping
+      # is triggered by setting this option, so if it is not
+      # set, then an unsteady algorithm will not be selected.
+      #
+      # Current valid options are:
+      #   libmesh_euler_solver
+      #   libmesh_euler2_solver
+      solver_type = 'libmesh_euler_solver'
+
+      # This sets the time step size. There is no default.
+      # If using an unsteady algorithm, this option must be
+      # set or an error occurs.
+      delta_t = '1.0'
+
+      # This sets the number of time steps to take. There is no default.
+      # If using an unsteady algorithm, this option must be
+      # set or an error occurs.
+      n_timesteps = '10'
+
+
+      # Set the theta value for the theta methods.
+      # This option is only relevant for the following solver_types:
+      #    libmesh_euler_solver
+      #    libmesh_euler2_solver
+      #
+      # The value of theta should be between 0.0 and 1.0
+      # The default value if not specified is theta = '0.5'
+      theta = '1.0'
+[]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -187,6 +187,7 @@ libgrins_la_SOURCES += solver/src/steady_mesh_adaptive_solver.C
 libgrins_la_SOURCES += solver/src/displacement_continuation_solver.C
 libgrins_la_SOURCES += solver/src/solver_parsing.C
 libgrins_la_SOURCES += solver/src/strategies_parsing.C
+libgrins_la_SOURCES += solver/src/time_stepping_parsing.C
 
 #src/variables
 libgrins_la_SOURCES += variables/src/variables_base.C
@@ -426,6 +427,7 @@ include_HEADERS += solver/include/grins/displacement_continuation_solver.h
 include_HEADERS += solver/include/grins/solver_parsing.h
 include_HEADERS += solver/include/grins/solver_names.h
 include_HEADERS += solver/include/grins/strategies_parsing.h
+include_HEADERS += solver/include/grins/time_stepping_parsing.h
 
 #src/variables headers
 include_HEADERS += variables/include/grins/fe_variables_base.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -421,6 +421,7 @@ include_HEADERS += solver/include/grins/parameter_manager.h
 include_HEADERS += solver/include/grins/parameter_user.h
 include_HEADERS += solver/include/grins/steady_mesh_adaptive_solver.h
 include_HEADERS += solver/include/grins/displacement_continuation_solver.h
+include_HEADERS += solver/include/grins/solver_names.h
 
 #src/variables headers
 include_HEADERS += variables/include/grins/fe_variables_base.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -185,6 +185,7 @@ libgrins_la_SOURCES += solver/src/parameter_manager.C
 libgrins_la_SOURCES += solver/src/parameter_user.C
 libgrins_la_SOURCES += solver/src/steady_mesh_adaptive_solver.C
 libgrins_la_SOURCES += solver/src/displacement_continuation_solver.C
+libgrins_la_SOURCES += solver/src/strategies_parsing.C
 
 #src/variables
 libgrins_la_SOURCES += variables/src/variables_base.C
@@ -422,6 +423,7 @@ include_HEADERS += solver/include/grins/parameter_user.h
 include_HEADERS += solver/include/grins/steady_mesh_adaptive_solver.h
 include_HEADERS += solver/include/grins/displacement_continuation_solver.h
 include_HEADERS += solver/include/grins/solver_names.h
+include_HEADERS += solver/include/grins/strategies_parsing.h
 
 #src/variables headers
 include_HEADERS += variables/include/grins/fe_variables_base.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -185,6 +185,7 @@ libgrins_la_SOURCES += solver/src/parameter_manager.C
 libgrins_la_SOURCES += solver/src/parameter_user.C
 libgrins_la_SOURCES += solver/src/steady_mesh_adaptive_solver.C
 libgrins_la_SOURCES += solver/src/displacement_continuation_solver.C
+libgrins_la_SOURCES += solver/src/solver_parsing.C
 libgrins_la_SOURCES += solver/src/strategies_parsing.C
 
 #src/variables
@@ -422,6 +423,7 @@ include_HEADERS += solver/include/grins/parameter_manager.h
 include_HEADERS += solver/include/grins/parameter_user.h
 include_HEADERS += solver/include/grins/steady_mesh_adaptive_solver.h
 include_HEADERS += solver/include/grins/displacement_continuation_solver.h
+include_HEADERS += solver/include/grins/solver_parsing.h
 include_HEADERS += solver/include/grins/solver_names.h
 include_HEADERS += solver/include/grins/strategies_parsing.h
 

--- a/src/solver/include/grins/grins_unsteady_solver.h
+++ b/src/solver/include/grins/grins_unsteady_solver.h
@@ -47,6 +47,8 @@ namespace GRINS
 
     virtual void init_time_solver(GRINS::MultiphysicsSystem* system);
 
+    std::string _time_solver_name;
+
     unsigned int _n_timesteps;
     unsigned int _backtrack_deltat;
     double _theta;

--- a/src/solver/include/grins/grins_unsteady_solver.h
+++ b/src/solver/include/grins/grins_unsteady_solver.h
@@ -31,6 +31,7 @@
 
 //libMesh
 #include "libmesh/system_norm.h"
+#include "libmesh/unsteady_solver.h"
 
 namespace GRINS
 {
@@ -47,6 +48,9 @@ namespace GRINS
 
     virtual void init_time_solver(GRINS::MultiphysicsSystem* system);
 
+    template <typename T>
+    void set_theta( libMesh::UnsteadySolver* time_solver );
+
     std::string _time_solver_name;
 
     unsigned int _n_timesteps;
@@ -60,6 +64,14 @@ namespace GRINS
     double _max_growth;
     libMesh::SystemNorm _component_norm;
   };
+
+  template <typename T>
+  inline
+  void UnsteadySolver::set_theta( libMesh::UnsteadySolver* time_solver )
+  {
+    T* deriv_solver = libMesh::libmesh_cast_ptr<T*>(time_solver);
+    deriv_solver->theta = this->_theta;
+  }
 
 } // end namespace GRINS
 #endif // GRINS_UNSTEADY_SOLVER_H

--- a/src/solver/include/grins/grins_unsteady_solver.h
+++ b/src/solver/include/grins/grins_unsteady_solver.h
@@ -39,7 +39,7 @@ namespace GRINS
   public:
 
     UnsteadySolver( const GetPot& input );
-    virtual ~UnsteadySolver();
+    virtual ~UnsteadySolver(){};
 
     virtual void solve( SolverContext& context );
 

--- a/src/solver/include/grins/solver_factory.h
+++ b/src/solver/include/grins/solver_factory.h
@@ -41,8 +41,8 @@ namespace GRINS
   {
   public:
 
-    SolverFactory();
-    virtual ~SolverFactory();
+    SolverFactory(){};
+    virtual ~SolverFactory(){};
 
     //! Builds GRINS::Solver object.
     /*! Users should override this method to construct 

--- a/src/solver/include/grins/solver_names.h
+++ b/src/solver/include/grins/solver_names.h
@@ -46,5 +46,10 @@ namespace GRINS
     static const std::string displacement_continuation()
     { return "displacement_continuation"; }
 
+    static const std::string libmesh_euler_solver()
+    { return "libmesh_euler_solver"; }
+
+    static const std::string libmesh_euler2_solver()
+    { return "libmesh_euler2_solver"; }
   };
 } // end namespace GRINS

--- a/src/solver/include/grins/solver_names.h
+++ b/src/solver/include/grins/solver_names.h
@@ -1,0 +1,50 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// C++
+#include <string>
+
+namespace GRINS
+{
+  class SolverNames
+  {
+  public:
+
+    static const std::string steady_solver()
+    { return "grins_steady_solver"; }
+
+    static const std::string unsteady_solver()
+    { return "grins_unsteady_solver"; }
+
+    static const std::string steady_mesh_adaptive_solver()
+    { return "grins_steady_mesh_adaptive_solver"; }
+
+    static const std::string unsteady_mesh_adaptive_solver()
+    { return "grins_unsteady_mesh_adaptive_solver"; }
+
+    static const std::string displacement_continuation()
+    { return "displacement_continuation"; }
+
+  };
+} // end namespace GRINS

--- a/src/solver/include/grins/solver_parsing.h
+++ b/src/solver/include/grins/solver_parsing.h
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_SOLVER_PARSING_H
+#define GRINS_SOLVER_PARSING_H
+
+// C++
+#include <string>
+
+// Forward declarations
+class GetPot;
+
+namespace GRINS
+{
+  class SolverParsing
+  {
+  public:
+
+    SolverParsing(){};
+
+    ~SolverParsing(){};
+
+    static std::string solver_type(const GetPot& input);
+
+    static bool is_transient( const GetPot& input );
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_SOLVER_PARSING_H

--- a/src/solver/include/grins/solver_parsing.h
+++ b/src/solver/include/grins/solver_parsing.h
@@ -45,8 +45,6 @@ namespace GRINS
 
     static bool is_transient( const GetPot& input );
 
-  protected:
-
     static void dup_solver_option_check( const GetPot& input,
                                          const std::string& option1,
                                          const std::string& option2 );

--- a/src/solver/include/grins/solver_parsing.h
+++ b/src/solver/include/grins/solver_parsing.h
@@ -44,6 +44,12 @@ namespace GRINS
     static std::string solver_type(const GetPot& input);
 
     static bool is_transient( const GetPot& input );
+
+  protected:
+
+    static void dup_solver_option_check( const GetPot& input,
+                                         const std::string& option1,
+                                         const std::string& option2 );
   };
 
 } // end namespace GRINS

--- a/src/solver/include/grins/strategies_parsing.h
+++ b/src/solver/include/grins/strategies_parsing.h
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_STRATEGIES_PARSING_H
+#define GRINS_STRATEGIES_PARSING_H
+
+// C++
+#include <string>
+
+// Forward declarations
+class GetPot;
+
+namespace GRINS
+{
+  class StrategiesParsing
+  {
+  public:
+
+    StrategiesParsing(){};
+
+    ~StrategiesParsing(){};
+
+    static bool is_mesh_adaptive( const GetPot& input );
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_STRATEGIES_PARSING_H

--- a/src/solver/include/grins/strategies_parsing.h
+++ b/src/solver/include/grins/strategies_parsing.h
@@ -43,6 +43,18 @@ namespace GRINS
 
     //! Checks input to see if mesh adaptivity options are present
     static bool is_mesh_adaptive( const GetPot& input );
+
+    //! Parses target tolerance parameter for adaptive time stepping
+    /*! 0.0 means there is no adaptive time stepping enabled. To enable
+        adaptive time stepping with the libMesh::TwostepTimeSolver, this
+        parameter should be positive. */
+    static double parse_target_tolerance( const GetPot& input );
+
+    //! Parses upper tolerance parameter for adaptive time stepping
+    static double parse_upper_tolerance( const GetPot& input );
+
+    //! Parses max growth parameter for adaptive time stepping
+    static double parse_max_growth( const GetPot& input );
   };
 
 } // end namespace GRINS

--- a/src/solver/include/grins/strategies_parsing.h
+++ b/src/solver/include/grins/strategies_parsing.h
@@ -30,7 +30,10 @@
 
 // Forward declarations
 class GetPot;
-
+namespace libMesh
+{
+  class SystemNorm;
+}
 namespace GRINS
 {
   class StrategiesParsing
@@ -55,6 +58,9 @@ namespace GRINS
 
     //! Parses max growth parameter for adaptive time stepping
     static double parse_max_growth( const GetPot& input );
+
+    //! Parses the norm to use for each solution variable for adaptive time stepping
+    static void parse_component_norm( const GetPot& input, libMesh::SystemNorm& component_norm );
   };
 
 } // end namespace GRINS

--- a/src/solver/include/grins/strategies_parsing.h
+++ b/src/solver/include/grins/strategies_parsing.h
@@ -41,6 +41,7 @@ namespace GRINS
 
     ~StrategiesParsing(){};
 
+    //! Checks input to see if mesh adaptivity options are present
     static bool is_mesh_adaptive( const GetPot& input );
   };
 

--- a/src/solver/include/grins/time_stepping_parsing.h
+++ b/src/solver/include/grins/time_stepping_parsing.h
@@ -1,0 +1,55 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_TIME_STEPPING_PARSING_H
+#define GRINS_TIME_STEPPING_PARSING_H
+
+// C++
+#include <string>
+
+// Forward declarations
+class GetPot;
+
+namespace GRINS
+{
+  class TimeSteppingParsing
+  {
+  public:
+
+    TimeSteppingParsing(){};
+
+    ~TimeSteppingParsing(){};
+
+    static unsigned int parse_n_timesteps( const GetPot& input );
+
+    static unsigned int parse_backtrack_deltat( const GetPot& input );
+
+    static double parse_theta( const GetPot& input );
+
+    static double parse_deltat( const GetPot& input );
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_TIME_STEPPING_PARSING_H

--- a/src/solver/include/grins/time_stepping_parsing.h
+++ b/src/solver/include/grins/time_stepping_parsing.h
@@ -43,6 +43,9 @@ namespace GRINS
 
     static unsigned int parse_n_timesteps( const GetPot& input );
 
+    //! Parse option to retry failed time steps with smaller \f$ \Delta t \f$
+    /*! backtrack_deltat is the number of time the TimeSolver will try
+        to resolve the timestep with a smaller \f$ \Delta t \f$. Default is 0. */
     static unsigned int parse_backtrack_deltat( const GetPot& input );
 
     static double parse_theta( const GetPot& input );

--- a/src/solver/include/grins/time_stepping_parsing.h
+++ b/src/solver/include/grins/time_stepping_parsing.h
@@ -48,6 +48,9 @@ namespace GRINS
         to resolve the timestep with a smaller \f$ \Delta t \f$. Default is 0. */
     static unsigned int parse_backtrack_deltat( const GetPot& input );
 
+    //! Parse value of \f$ \theta \f$ for theta method time stepping.
+    /*! \f$ \theta \in [0,1] \f$ Option only used for theta method-based
+         time solvers. Defaults to 0.5. */
     static double parse_theta( const GetPot& input );
 
     static double parse_deltat( const GetPot& input );

--- a/src/solver/include/grins/time_stepping_parsing.h
+++ b/src/solver/include/grins/time_stepping_parsing.h
@@ -54,6 +54,8 @@ namespace GRINS
     static double parse_theta( const GetPot& input );
 
     static double parse_deltat( const GetPot& input );
+
+    static std::string parse_time_stepper_name( const GetPot& input );
   };
 
 } // end namespace GRINS

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -57,19 +57,7 @@ namespace GRINS
       _upper_tolerance( StrategiesParsing::parse_upper_tolerance(input) ),
       _max_growth( StrategiesParsing::parse_max_growth(input) )
   {
-    const unsigned int n_component_norm =
-      input.vector_variable_size("unsteady-solver/component_norm");
-    for (unsigned int i=0; i != n_component_norm; ++i)
-      {
-        const std::string current_norm = input("component_norm", std::string("L2"), i);
-        // TODO: replace this with string_to_enum with newer libMesh
-        if (current_norm == "GRINSEnums::L2")
-          _component_norm.set_type(i, libMesh::L2);
-        else if (current_norm == "GRINSEnums::H1")
-          _component_norm.set_type(i, libMesh::H1);
-        else
-          libmesh_not_implemented();
-      }
+    StrategiesParsing::parse_component_norm(input,_component_norm);
   }
 
   void UnsteadySolver::init_time_solver(MultiphysicsSystem* system)

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -48,10 +48,10 @@ namespace GRINS
 
   UnsteadySolver::UnsteadySolver( const GetPot& input )
     : Solver(input),
+      _time_solver_name(TimeSteppingParsing::parse_time_stepper_name(input)),
       _n_timesteps( TimeSteppingParsing::parse_n_timesteps(input) ),
       _backtrack_deltat( TimeSteppingParsing::parse_backtrack_deltat(input) ),
       _theta( TimeSteppingParsing::parse_theta(input) ),
-      /*! \todo Is this the best default for delta t?*/
       _deltat( TimeSteppingParsing::parse_deltat(input) ),
       _target_tolerance( StrategiesParsing::parse_target_tolerance(input) ),
       _upper_tolerance( StrategiesParsing::parse_upper_tolerance(input) ),

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -72,11 +72,6 @@ namespace GRINS
       }
   }
 
-  UnsteadySolver::~UnsteadySolver()
-  {
-    return;
-  }
-
   void UnsteadySolver::init_time_solver(MultiphysicsSystem* system)
   {
     libMesh::EulerSolver* time_solver = new libMesh::EulerSolver( *(system) );

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -69,8 +69,7 @@ namespace GRINS
       {
         time_solver = new libMesh::EulerSolver( *(system) );
 
-        libMesh::EulerSolver* euler_solver = libMesh::libmesh_cast_ptr<libMesh::EulerSolver*>(time_solver);
-        euler_solver->theta = this->_theta;
+        this->set_theta<libMesh::EulerSolver>(time_solver);
       }
     else
       libmesh_error_msg("ERROR: Unsupported time stepper "+_time_solver_name);

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -39,6 +39,7 @@
 #include "libmesh/dof_map.h"
 #include "libmesh/getpot.h"
 #include "libmesh/euler_solver.h"
+#include "libmesh/euler2_solver.h"
 #include "libmesh/twostep_time_solver.h"
 
 // C++
@@ -70,6 +71,12 @@ namespace GRINS
         time_solver = new libMesh::EulerSolver( *(system) );
 
         this->set_theta<libMesh::EulerSolver>(time_solver);
+      }
+    else if( _time_solver_name == SolverNames::libmesh_euler2_solver() )
+      {
+        time_solver = new libMesh::Euler2Solver( *(system) );
+
+        this->set_theta<libMesh::Euler2Solver>(time_solver);
       }
     else
       libmesh_error_msg("ERROR: Unsupported time stepper "+_time_solver_name);

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -31,6 +31,7 @@
 #include "grins/solver_context.h"
 #include "grins/multiphysics_sys.h"
 #include "grins/time_stepping_parsing.h"
+#include "grins/strategies_parsing.h"
 
 // libMesh
 #include "libmesh/dirichlet_boundaries.h"
@@ -52,9 +53,9 @@ namespace GRINS
       _theta( TimeSteppingParsing::parse_theta(input) ),
       /*! \todo Is this the best default for delta t?*/
       _deltat( TimeSteppingParsing::parse_deltat(input) ),
-      _target_tolerance( input("unsteady-solver/target_tolerance", 0.0 ) ),
-      _upper_tolerance( input("unsteady-solver/upper_tolerance", 0.0 ) ),
-      _max_growth( input("unsteady-solver/max_growth", 0.0 ) )
+      _target_tolerance( StrategiesParsing::parse_target_tolerance(input) ),
+      _upper_tolerance( StrategiesParsing::parse_upper_tolerance(input) ),
+      _max_growth( StrategiesParsing::parse_max_growth(input) )
   {
     const unsigned int n_component_norm =
       input.vector_variable_size("unsteady-solver/component_norm");

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -30,6 +30,7 @@
 #include "grins/grins_enums.h"
 #include "grins/solver_context.h"
 #include "grins/multiphysics_sys.h"
+#include "grins/time_stepping_parsing.h"
 
 // libMesh
 #include "libmesh/dirichlet_boundaries.h"
@@ -46,11 +47,11 @@ namespace GRINS
 
   UnsteadySolver::UnsteadySolver( const GetPot& input )
     : Solver(input),
-      _n_timesteps( input("unsteady-solver/n_timesteps", 1 ) ),
-      _backtrack_deltat( input("unsteady-solver/backtrack_deltat", 0 ) ),
-      _theta( input("unsteady-solver/theta", 0.5 ) ),
+      _n_timesteps( TimeSteppingParsing::parse_n_timesteps(input) ),
+      _backtrack_deltat( TimeSteppingParsing::parse_backtrack_deltat(input) ),
+      _theta( TimeSteppingParsing::parse_theta(input) ),
       /*! \todo Is this the best default for delta t?*/
-      _deltat( input("unsteady-solver/deltat", 0.0 ) ),
+      _deltat( TimeSteppingParsing::parse_deltat(input) ),
       _target_tolerance( input("unsteady-solver/target_tolerance", 0.0 ) ),
       _upper_tolerance( input("unsteady-solver/upper_tolerance", 0.0 ) ),
       _max_growth( input("unsteady-solver/max_growth", 0.0 ) )
@@ -68,8 +69,6 @@ namespace GRINS
         else
           libmesh_not_implemented();
       }
-
-
   }
 
   UnsteadySolver::~UnsteadySolver()

--- a/src/solver/src/solver_factory.C
+++ b/src/solver/src/solver_factory.C
@@ -36,16 +36,6 @@
 
 namespace GRINS
 {
-  SolverFactory::SolverFactory()
-  {
-    return;
-  }
-
-  SolverFactory::~SolverFactory()
-  {
-    return;
-  }
-
   SharedPtr<Solver> SolverFactory::build(const GetPot& input)
   {
     bool mesh_adaptive = input("MeshAdaptivity/mesh_adaptive", false );

--- a/src/solver/src/solver_factory.C
+++ b/src/solver/src/solver_factory.C
@@ -26,6 +26,8 @@
 #include "grins/solver_factory.h"
 
 // GRINS
+#include "grins/solver_names.h"
+#include "grins/solver_parsing.h"
 #include "grins/grins_steady_solver.h"
 #include "grins/grins_unsteady_solver.h"
 #include "grins/steady_mesh_adaptive_solver.h"
@@ -38,37 +40,33 @@ namespace GRINS
 {
   SharedPtr<Solver> SolverFactory::build(const GetPot& input)
   {
-    bool mesh_adaptive = input("MeshAdaptivity/mesh_adaptive", false );
-
-    bool transient = input("unsteady-solver/transient", false );
+    std::string solver_type = SolverParsing::solver_type(input);
 
     SharedPtr<Solver> solver;  // Effectively NULL
 
-    std::string solver_type = input("SolverOptions/solver_type", "DIE!");
-
-    if( solver_type == std::string("displacement_continuation") )
+    if( solver_type == SolverNames::displacement_continuation() )
       {
         solver.reset( new DisplacementContinuationSolver(input) );
       }
-    else if(transient && !mesh_adaptive)
+    else if(solver_type == SolverNames::unsteady_solver() )
       {
         solver.reset( new UnsteadySolver(input) );
       }
-    else if( !transient && !mesh_adaptive )
+    else if( solver_type == SolverNames::steady_solver() )
       {
         solver.reset( new SteadySolver(input) );
       }
-    else if( !transient && mesh_adaptive )
+    else if( solver_type == SolverNames::steady_mesh_adaptive_solver() )
       {
         solver.reset( new SteadyMeshAdaptiveSolver(input) );
       }
-    else if( transient && mesh_adaptive )
+    else if( solver_type == SolverNames::unsteady_mesh_adaptive_solver() )
       {
         libmesh_not_implemented();
       }
     else
       {
-        std::cerr << "Invalid solver options!" << std::endl;
+        libmesh_error_msg("Invalid solver_type: "+solver_type);
       }
 
     return solver;

--- a/src/solver/src/solver_parsing.C
+++ b/src/solver/src/solver_parsing.C
@@ -1,0 +1,76 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// These functions
+#include "grins/solver_names.h"
+#include "grins/solver_parsing.h"
+#include "grins/strategies_parsing.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+
+namespace GRINS
+{
+  std::string SolverParsing::solver_type(const GetPot& input)
+  {
+    bool mesh_adaptive = StrategiesParsing::is_mesh_adaptive(input);
+
+    bool transient = SolverParsing::is_transient(input);
+
+    std::string solver_type = input("SolverOptions/solver_type", "DIE!");
+
+    if( solver_type == SolverNames::displacement_continuation() )
+      {
+        // Don't need to do anything
+      }
+    else if(transient && !mesh_adaptive)
+      {
+        solver_type = SolverNames::unsteady_solver();
+      }
+    else if( !transient && !mesh_adaptive )
+      {
+        solver_type = SolverNames::steady_solver();
+      }
+    else if( !transient && mesh_adaptive )
+      {
+        solver_type = SolverNames::steady_mesh_adaptive_solver();
+      }
+    else if( transient && mesh_adaptive )
+      {
+        solver_type = SolverNames::unsteady_mesh_adaptive_solver();
+      }
+    else
+      {
+        libmesh_error_msg("Unsupported combination of solver options!");
+      }
+
+    return solver_type;
+  }
+
+  bool SolverParsing::is_transient( const GetPot& input )
+  {
+    return input("unsteady-solver/transient", false );
+  }
+
+} // end namespace GRINS

--- a/src/solver/src/solver_parsing.C
+++ b/src/solver/src/solver_parsing.C
@@ -27,6 +27,9 @@
 #include "grins/solver_parsing.h"
 #include "grins/strategies_parsing.h"
 
+// GRINS
+#include "grins/common.h"
+
 // libMesh
 #include "libmesh/getpot.h"
 
@@ -70,7 +73,29 @@ namespace GRINS
 
   bool SolverParsing::is_transient( const GetPot& input )
   {
-    return input("unsteady-solver/transient", false );
+    // Can't specify both old and new version
+    SolverParsing::dup_solver_option_check(input,
+                                           "unsteady-solver/transient",
+                                           "SolverOptions/TimeStepping/solver_type");
+
+    bool transient = false;
+
+    if( input.have_variable("unsteady-solver/transient") )
+      {
+        transient = input("unsteady-solver/transient",false);
+
+        std::string warning = "WARNING: unsteady-solver/transient is DEPRECATED!\n";
+        warning += "        Please use SolverOptions/TimeStepping/solver_type to specify time stepping solver.\n";
+        grins_warning(warning);
+      }
+
+    // In the new version, we set the solver type so we just need to
+    // check if the variable is present. Solver class will figure
+    // out the type.
+    if( input.have_variable("SolverOptions/TimeStepping/solver_type") )
+      transient = true;
+
+    return transient;
   }
 
   void SolverParsing::dup_solver_option_check( const GetPot& input,

--- a/src/solver/src/solver_parsing.C
+++ b/src/solver/src/solver_parsing.C
@@ -73,4 +73,15 @@ namespace GRINS
     return input("unsteady-solver/transient", false );
   }
 
+  void SolverParsing::dup_solver_option_check( const GetPot& input,
+                                               const std::string& option1,
+                                               const std::string& option2 )
+  {
+    // Can't specify both old and new version
+    if( input.have_variable(option1) && input.have_variable(option2) )
+      {
+        libmesh_error_msg("ERROR: Cannot specify both "+option1+" and "+option2);
+      }
+  }
+
 } // end namespace GRINS

--- a/src/solver/src/strategies_parsing.C
+++ b/src/solver/src/strategies_parsing.C
@@ -27,6 +27,7 @@
 
 // libMesh
 #include "libmesh/getpot.h"
+#include "libmesh/system_norm.h"
 
 namespace GRINS
 {
@@ -50,4 +51,20 @@ namespace GRINS
     return input("unsteady-solver/max_growth", 0.0 );
   }
 
+  void StrategiesParsing::parse_component_norm( const GetPot& input, libMesh::SystemNorm& component_norm )
+  {
+    const unsigned int n_component_norm =
+      input.vector_variable_size("unsteady-solver/component_norm");
+    for (unsigned int i=0; i != n_component_norm; ++i)
+      {
+        const std::string current_norm = input("component_norm", std::string("L2"), i);
+        // TODO: replace this with string_to_enum with newer libMesh
+        if (current_norm == "GRINSEnums::L2")
+          component_norm.set_type(i, libMesh::L2);
+        else if (current_norm == "GRINSEnums::H1")
+          component_norm.set_type(i, libMesh::H1);
+        else
+          libmesh_not_implemented();
+      }
+  }
 } // end namespace GRINS

--- a/src/solver/src/strategies_parsing.C
+++ b/src/solver/src/strategies_parsing.C
@@ -34,4 +34,20 @@ namespace GRINS
   {
     return input("MeshAdaptivity/mesh_adaptive", false );
   }
+
+  double StrategiesParsing::parse_target_tolerance( const GetPot& input )
+  {
+    return input("unsteady-solver/target_tolerance", 0.0 );
+  }
+
+  double StrategiesParsing::parse_upper_tolerance( const GetPot& input )
+  {
+    return input("unsteady-solver/upper_tolerance", 0.0 );
+  }
+
+  double StrategiesParsing::parse_max_growth( const GetPot& input )
+  {
+    return input("unsteady-solver/max_growth", 0.0 );
+  }
+
 } // end namespace GRINS

--- a/src/solver/src/strategies_parsing.C
+++ b/src/solver/src/strategies_parsing.C
@@ -1,0 +1,37 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// These functions
+#include "grins/strategies_parsing.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+
+namespace GRINS
+{
+  bool StrategiesParsing::is_mesh_adaptive( const GetPot& input )
+  {
+    return input("MeshAdaptivity/mesh_adaptive", false );
+  }
+} // end namespace GRINS

--- a/src/solver/src/time_stepping_parsing.C
+++ b/src/solver/src/time_stepping_parsing.C
@@ -82,7 +82,27 @@ namespace GRINS
 
   double TimeSteppingParsing::parse_theta( const GetPot& input )
   {
-    return input("unsteady-solver/theta", 0.5 );
+    double theta = 0.0;
+
+    if( input.have_variable("unsteady-solver/theta") )
+      {
+        theta = input("unsteady-solver/theta",0.5);
+
+        std::string warning = "WARNING: unsteady-solver/theta is DEPRECATED!\n";
+        warning += "        Please use SolverOptions/TimeStepping/theta to set theta.\n";
+        grins_warning(warning);
+      }
+    else
+      theta = input("SolverOptions/TimeStepping/theta",0.5);
+
+    if( theta < 0.0 || theta > 1.0 )
+      {
+        std::stringstream ts;
+        ts << theta;
+        libmesh_error_msg("ERROR: theta must be between 0.0 and 1.0. Found: "+ts.str());
+      }
+
+    return theta;
   }
 
   double TimeSteppingParsing::parse_deltat( const GetPot& input )

--- a/src/solver/src/time_stepping_parsing.C
+++ b/src/solver/src/time_stepping_parsing.C
@@ -25,6 +25,10 @@
 // This class
 #include "grins/time_stepping_parsing.h"
 
+// GRINS
+#include "grins/common.h"
+#include "grins/solver_parsing.h"
+
 // libMesh
 #include "libmesh/getpot.h"
 
@@ -32,7 +36,26 @@ namespace GRINS
 {
   unsigned int TimeSteppingParsing::parse_n_timesteps( const GetPot& input )
   {
-    return input("unsteady-solver/n_timesteps", 1 );
+    SolverParsing::dup_solver_option_check(input,
+                                           "unsteady-solver/n_timesteps",
+                                           "SolverOptions/TimeStepping/n_timesteps");
+
+    unsigned int n_timesteps = 0;
+
+    if( input.have_variable("unsteady-solver/n_timesteps") )
+      {
+        n_timesteps = input("unsteady-solver/n_timesteps",0);
+
+        std::string warning = "WARNING: unsteady-solver/n_timesteps is DEPRECATED!\n";
+        warning += "        Please use SolverOptions/TimeStepping/n_timesteps to specify # of timesteps.\n";
+        grins_warning(warning);
+      }
+    else if( input.have_variable("SolverOptions/TimeStepping/n_timesteps") )
+        n_timesteps = input("SolverOptions/TimeStepping/n_timesteps",0);
+    else
+      libmesh_error_msg("ERROR: Could not find valid entry for n_timesteps!");
+
+    return n_timesteps;
   }
 
   unsigned int TimeSteppingParsing::parse_backtrack_deltat( const GetPot& input )

--- a/src/solver/src/time_stepping_parsing.C
+++ b/src/solver/src/time_stepping_parsing.C
@@ -60,7 +60,24 @@ namespace GRINS
 
   unsigned int TimeSteppingParsing::parse_backtrack_deltat( const GetPot& input )
   {
-    return input("unsteady-solver/backtrack_deltat", 0 );
+    SolverParsing::dup_solver_option_check(input,
+                                           "unsteady-solver/backtrack_deltat",
+                                           "SolverOptions/TimeStepping/backtrack_deltat");
+
+    unsigned int backtrack_deltat = 0;
+
+    if( input.have_variable("unsteady-solver/backtrack_deltat") )
+      {
+        backtrack_deltat = input("unsteady-solver/backtrack_deltat",0);
+
+        std::string warning = "WARNING: unsteady-solver/backtrack_deltat is DEPRECATED!\n";
+        warning += "        Please use SolverOptions/TimeStepping/backtrack_deltat to set backtrack_deltat.\n";
+        grins_warning(warning);
+      }
+    else
+      backtrack_deltat = input("SolverOptions/TimeStepping/backtrack_deltat",0);
+
+    return backtrack_deltat;
   }
 
   double TimeSteppingParsing::parse_theta( const GetPot& input )

--- a/src/solver/src/time_stepping_parsing.C
+++ b/src/solver/src/time_stepping_parsing.C
@@ -107,7 +107,22 @@ namespace GRINS
 
   double TimeSteppingParsing::parse_deltat( const GetPot& input )
   {
-    return input("unsteady-solver/deltat", 0.0 );
+    double delta_t = 0.0;
+
+    if( input.have_variable("unsteady-solver/deltat") )
+      {
+        delta_t = input("unsteady-solver/deltat",0.0);
+
+        std::string warning = "WARNING: unsteady-solver/deltat is DEPRECATED!\n";
+        warning += "        Please use SolverOptions/TimeStepping/delta_t to set delta_t.\n";
+        grins_warning(warning);
+      }
+    else if( input.have_variable("SolverOptions/TimeStepping/delta_t") )
+      delta_t = input("SolverOptions/TimeStepping/delta_t",0.0);
+    else
+      libmesh_error_msg("ERROR: Could not find valid entry for delta_t!");
+
+    return delta_t;
   }
 
 } // end namespace GRINS

--- a/src/solver/src/time_stepping_parsing.C
+++ b/src/solver/src/time_stepping_parsing.C
@@ -27,6 +27,7 @@
 
 // GRINS
 #include "grins/common.h"
+#include "grins/solver_names.h"
 #include "grins/solver_parsing.h"
 
 // libMesh
@@ -123,6 +124,27 @@ namespace GRINS
       libmesh_error_msg("ERROR: Could not find valid entry for delta_t!");
 
     return delta_t;
+  }
+
+  std::string TimeSteppingParsing::parse_time_stepper_name( const GetPot& input )
+  {
+    std::string default_stepper = SolverNames::libmesh_euler_solver();
+    std::string time_stepper = default_stepper;
+
+    // Before, we didn't actually set the solver name, we just set whether we
+    // were transient or not. So, if we see this option was set to true, then
+    // we were time stepping with the only option available then (EulerSolver)
+    if( input("unsteady-solver/transient", false) )
+      {
+        std::string warning = "WARNING: using unsteady-solver options is DEPRECATED!\n";
+        warning += "        Please use SolverOptions/TimeStepping/solver_type to set the time\n";
+        warning += "        stepping algorithm.\n";
+        grins_warning(warning);
+      }
+    else
+      time_stepper = input("SolverOptions/TimeStepping/solver_type", default_stepper);
+
+    return time_stepper;
   }
 
 } // end namespace GRINS

--- a/src/solver/src/time_stepping_parsing.C
+++ b/src/solver/src/time_stepping_parsing.C
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/time_stepping_parsing.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+
+namespace GRINS
+{
+  unsigned int TimeSteppingParsing::parse_n_timesteps( const GetPot& input )
+  {
+    return input("unsteady-solver/n_timesteps", 1 );
+  }
+
+  unsigned int TimeSteppingParsing::parse_backtrack_deltat( const GetPot& input )
+  {
+    return input("unsteady-solver/backtrack_deltat", 0 );
+  }
+
+  double TimeSteppingParsing::parse_theta( const GetPot& input )
+  {
+    return input("unsteady-solver/theta", 0.5 );
+  }
+
+  double TimeSteppingParsing::parse_deltat( const GetPot& input )
+  {
+    return input("unsteady-solver/deltat", 0.0 );
+  }
+
+} // end namespace GRINS

--- a/test/input_files/2d_fantrick.in
+++ b/test/input_files/2d_fantrick.in
@@ -78,11 +78,13 @@ pressure = 'p'
 []
 
 # Options for time solvers
-[unsteady-solver]
-transient = 'true' 
-theta = '1.0'
-n_timesteps = '10'
-deltat = '0.01'
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '1.0'
+      n_timesteps = '10'
+      delta_t = '0.01'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/2d_proptrick.in
+++ b/test/input_files/2d_proptrick.in
@@ -87,11 +87,13 @@ pressure = 'p'
 []
 
 # Options for time solvers
-[unsteady-solver]
-transient = 'true' 
-theta = '1.0'
-n_timesteps = '10'
-deltat = '0.01'
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '1.0'
+      n_timesteps = '10'
+      delta_t = '0.01'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/2d_pseudofan.in
+++ b/test/input_files/2d_pseudofan.in
@@ -71,11 +71,13 @@ pressure = 'p'
 []
 
 # Options for time solvers
-[unsteady-solver]
-transient = 'true' 
-theta = '1.0'
-n_timesteps = '10'
-deltat = '0.01'
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '1.0'
+      n_timesteps = '10'
+      delta_t = '0.01'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/2d_pseudoprop.in
+++ b/test/input_files/2d_pseudoprop.in
@@ -78,11 +78,13 @@ pressure = 'p'
 []
 
 # Options for time solvers
-[unsteady-solver]
-transient = 'true' 
-theta = '1.0'
-n_timesteps = '10'
-deltat = '0.01'
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '1.0'
+      n_timesteps = '10'
+      delta_t = '0.01'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/2d_vsource.in
+++ b/test/input_files/2d_vsource.in
@@ -68,11 +68,13 @@ pressure = 'p'
 []
 
 # Options for time solvers
-[unsteady-solver]
-transient = 'true' 
-theta = '1.0'
-n_timesteps = '10'
-deltat = '0.01'
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '1.0'
+      n_timesteps = '10'
+      delta_t = '0.01'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/3d_low_mach_jacobians_xy.in
+++ b/test/input_files/3d_low_mach_jacobians_xy.in
@@ -99,8 +99,8 @@ scaling = '0.0332262120257623' #'${/ ${Pr_over_TwomuT} ${Physics/LowMachNavierSt
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/3d_low_mach_jacobians_xz.in
+++ b/test/input_files/3d_low_mach_jacobians_xz.in
@@ -96,8 +96,8 @@ scaling = '0.0332262120257623' #'${/ ${Pr_over_TwomuT} ${Physics/LowMachNavierSt
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/3d_low_mach_jacobians_yz.in
+++ b/test/input_files/3d_low_mach_jacobians_yz.in
@@ -95,8 +95,8 @@ scaling = '0.0332262120257623' #'${/ ${Pr_over_TwomuT} ${Physics/LowMachNavierSt
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/axi_con_cyl_flow.in
+++ b/test/input_files/axi_con_cyl_flow.in
@@ -10,8 +10,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/axi_poiseuille_flow_input.in
+++ b/test/input_files/axi_poiseuille_flow_input.in
@@ -19,8 +19,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/axi_thermally_driven_flow.in
+++ b/test/input_files/axi_thermally_driven_flow.in
@@ -8,8 +8,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/axisym_reacting_low_mach_antioch_cea_constant_regression.in.in
+++ b/test/input_files/axisym_reacting_low_mach_antioch_cea_constant_regression.in.in
@@ -101,8 +101,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/backward_facing_step.in.in
+++ b/test/input_files/backward_facing_step.in.in
@@ -73,8 +73,8 @@ tau_factor = '0.05'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/convection_cell_parsed_regression.in
+++ b/test/input_files/convection_cell_parsed_regression.in
@@ -117,11 +117,13 @@ tau_factor_T = '3.0'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'true' 
-theta = 1.0
-n_timesteps = '10'
-deltat = '1.0'
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '1.0'
+      n_timesteps = '10'
+      delta_t = '1.0'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/convection_cell_regression.in
+++ b/test/input_files/convection_cell_regression.in
@@ -111,11 +111,13 @@ tau_factor_T = '3.0'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'true' 
-theta = 1.0
-n_timesteps = '10'
-deltat = '1.0'
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '1.0'
+      n_timesteps = '10'
+      delta_t = '1.0'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/couette_flow_input_2d_x.in
+++ b/test/input_files/couette_flow_input_2d_x.in
@@ -14,8 +14,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/couette_flow_input_2d_y.in
+++ b/test/input_files/couette_flow_input_2d_y.in
@@ -11,8 +11,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/coupled_stokes_ns.in.in
+++ b/test/input_files/coupled_stokes_ns.in.in
@@ -7,8 +7,8 @@
 #uniformly_refine = '2'
 
 # Options for time solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/dirichlet_fem.in
+++ b/test/input_files/dirichlet_fem.in
@@ -10,11 +10,13 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = true
-theta = 0.5
-n_timesteps = 10
-deltat = 0.1
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '0.5'
+      n_timesteps = '10'
+      delta_t = '0.1'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/dirichlet_nan.in
+++ b/test/input_files/dirichlet_nan.in
@@ -10,8 +10,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/ins_invalid_pin_location_unit.in
+++ b/test/input_files/ins_invalid_pin_location_unit.in
@@ -9,8 +9,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 []
 
 # Options for print info to the screen

--- a/test/input_files/laplace_parsed_source_regression.in
+++ b/test/input_files/laplace_parsed_source_regression.in
@@ -52,8 +52,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-   transient = 'false'
+
+   
 []
 
 #Linear and nonlinear solver options

--- a/test/input_files/lmns_invalid_pin_location_unit.in
+++ b/test/input_files/lmns_invalid_pin_location_unit.in
@@ -102,8 +102,8 @@ tau_factor = '0.05'
 
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/locally_refine.in.in
+++ b/test/input_files/locally_refine.in.in
@@ -72,8 +72,8 @@ tau_factor = '0.05'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/low_mach_cavity_benchmark_regression_input.in
+++ b/test/input_files/low_mach_cavity_benchmark_regression_input.in
@@ -118,8 +118,8 @@ tau_factor = '0.05'
 
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/parsed_qoi.in.in
+++ b/test/input_files/parsed_qoi.in.in
@@ -10,8 +10,8 @@
 []
 
 # Options for time solvers
-[unsteady-solver]
-transient = false
+
+
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/penalty_poiseuille.in
+++ b/test/input_files/penalty_poiseuille.in
@@ -11,8 +11,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/penalty_poiseuille_stab.in
+++ b/test/input_files/penalty_poiseuille_stab.in
@@ -11,8 +11,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/poiseuille_flow_input.in
+++ b/test/input_files/poiseuille_flow_input.in
@@ -10,8 +10,8 @@
 
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/poisson_weighted_flux_regression.in
+++ b/test/input_files/poisson_weighted_flux_regression.in
@@ -75,8 +75,8 @@ weights = 'y*(1-y)' # This 'fixes' the spill
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-   transient = 'false'
+
+   
 []
 
 #Linear and nonlinear solver options

--- a/test/input_files/reacting_low_mach_antioch_cea_constant_prandtl_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_cea_constant_prandtl_regression.in.in
@@ -102,8 +102,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_antioch_cea_constant_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_cea_constant_regression.in.in
@@ -103,8 +103,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_antioch_kinetics_theory_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_kinetics_theory_regression.in.in
@@ -98,8 +98,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in.in
@@ -108,8 +108,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_catalytic_wall_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_catalytic_wall_regression.in.in
@@ -106,8 +106,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_gassolid_catalytic_wall_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_gassolid_catalytic_wall_regression.in.in
@@ -112,8 +112,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in.in
@@ -108,8 +108,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_regression.in.in
@@ -100,8 +100,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_constant_prandtl_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_constant_prandtl_regression.in.in
@@ -104,8 +104,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_antioch_statmech_constant_regression.in.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_constant_regression.in.in
@@ -104,8 +104,8 @@ pressure = 'p'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/reacting_low_mach_cantera_regression.in.in
+++ b/test/input_files/reacting_low_mach_cantera_regression.in.in
@@ -93,8 +93,8 @@ pin_pressure = 'false'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/redistribute.in.in
+++ b/test/input_files/redistribute.in.in
@@ -76,8 +76,8 @@ tau_factor = '0.05'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'false' 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/sa_2d_turbulent_channel_regression.in
+++ b/test/input_files/sa_2d_turbulent_channel_regression.in
@@ -15,8 +15,8 @@
 []
 
 # Options for time solvers
-[unsteady-solver]
-transient = false
+
+
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/simple_ode.in
+++ b/test/input_files/simple_ode.in
@@ -9,11 +9,14 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = true
-theta = 0.5
-n_timesteps = 100
-deltat = 0.1
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '0.5'
+      n_timesteps = '100'
+      delta_t = '0.1'
+[]
+
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/stokes_invalid_pin_location_unit.in
+++ b/test/input_files/stokes_invalid_pin_location_unit.in
@@ -9,8 +9,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/stokes_poiseuille_flow_input.in
+++ b/test/input_files/stokes_poiseuille_flow_input.in
@@ -9,8 +9,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/stokes_poiseuille_flow_parsed_viscosity_input.in
+++ b/test/input_files/stokes_poiseuille_flow_parsed_viscosity_input.in
@@ -9,8 +9,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity_input.in
+++ b/test/input_files/stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity_input.in
@@ -9,8 +9,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/thermally_driven_2d_flow.in
+++ b/test/input_files/thermally_driven_2d_flow.in
@@ -8,8 +8,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/thermally_driven_3d_flow.in
+++ b/test/input_files/thermally_driven_3d_flow.in
@@ -9,8 +9,8 @@
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/ufo_unit.in
+++ b/test/input_files/ufo_unit.in
@@ -122,11 +122,13 @@ tau_factor_T = '3.0'
 []
 
 # Options for tiem solvers
-[unsteady-solver]
-transient = 'true' 
-theta = 1.0
-n_timesteps = '10'
-deltat = '1.0'
+[SolverOptions]
+   [./TimeStepping]
+      solver_type = 'libmesh_euler_solver'
+      theta = '1.0'
+      n_timesteps = '10'
+      delta_t = '1.0'
+[]
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]

--- a/test/input_files/vorticity_qoi.in.in
+++ b/test/input_files/vorticity_qoi.in.in
@@ -5,8 +5,8 @@
 []
 
 # Options for time solvers
-[unsteady-solver]
-transient = false 
+
+ 
 
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]


### PR DESCRIPTION
The is part 1 of the refactoring of parsing solver options. Overall, the interim plan is to separate the "solver" (e.g. linear solver, nonlinear solver, time stepping, etc.) options from "strategy" options (AMR, adaptive time stepping, continuation, etc.). To that end new classes (mostly with static methods) have been created for parsing those various things.  This PR is only focused on the time stepping options. Thus, the `StrategiesParsing` is very trim right now and, in particular, I haven't updated those options yet.

A nice side-effect is that we can now specify the time solver instead of only using `EulerSolver`. Now you can use `Euler2Solver`! :P But this should have a lot of the groundwork for easily extending this.

So, the new input options for time stepping look like:
<pre>
[SolverOptions]
   [./TimeStepping]
      solver_type = 'libmesh_euler_solver'
      delta_t = '0.1'
      n_timesteps = '10'
      theta = '1.0'
[]
</pre>

There are no defaults for `delta_t` and `n_timesteps` and, thus, you get an error if you don't have them. To trigger an unsteady solve, we look for `[SolverOptions/TimeStepping/solver_type]` --- if it's not set, then an unsteady solver will not be used. The user would get UFO errors then about other `TimeStepping` options in that case (unless they foolishly disabled that...). The default for `[SolverOptions/TimeStepping/theta]` is `0.5`. 

All the tests pass with and without these changes through the whole history of the PR. Thus, I feel pretty good about this being backward compatible, particularly since there's several tests hit by these options.