### PR TITLE
Multiply Enabled Physics From Input

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -129,6 +129,7 @@ libgrins_la_SOURCES += physics/src/nonlinear_elasticity_instantiate.C
 libgrins_la_SOURCES += physics/src/source_term_base.C
 libgrins_la_SOURCES += physics/src/constant_source_term.C
 libgrins_la_SOURCES += physics/src/parsed_source_term.C
+libgrins_la_SOURCES += physics/src/physics_naming.C
 
 
 # src/properties files

--- a/src/physics/include/grins/physics_factory.h
+++ b/src/physics/include/grins/physics_factory.h
@@ -78,6 +78,18 @@ namespace GRINS
     virtual void check_physics_consistency( const GRINS::PhysicsList& physics_list );
 
     //! Utility function
+    /*! The elements in the physics_list may have suffixes attached while
+        the required_physics is assumed not to when this function is called.
+        So, this helper method will do the check by stripping the suffixes
+        from the physics_list element during the search and check if the required
+        physics is present.
+
+        \todo This is a linear search, but it really shouldn't matter unless the
+              physics_list gets big. */
+    bool find_physics( const std::string& required_physics,
+                       const GRINS::PhysicsList& physics_list ) const;
+
+    //! Utility function
     void physics_consistency_error( const std::string physics_checked,
 				    const std::string physics_required ) const;
 

--- a/src/physics/include/grins/physics_naming.h
+++ b/src/physics/include/grins/physics_naming.h
@@ -167,6 +167,9 @@ namespace GRINS
 
   private:
 
+    static std::string physics_name_delimiter()
+    { return ":"; }
+
     static std::string _suffix;
 
   };

--- a/src/physics/include/grins/physics_naming.h
+++ b/src/physics/include/grins/physics_naming.h
@@ -42,6 +42,23 @@ namespace GRINS
     static void clear_suffix()
     { _suffix.clear(); }
 
+    //! Extract the physics name and the suffix from the full_name
+    /*! Note returned suffix includes the delimiter */
+    static void extract_physics_and_suffix( const std::string& full_name,
+                                            std::string& physics_name,
+                                            std::string& suffix );
+
+    //! Extract the physics name from the full_name.
+    /*! If the delimiter is not present in the full_name, then
+        the physics_name is the full_name. */
+    static std::string extract_physics( const std::string& full_name );
+
+    //! Extract the suffix from the full_name.
+    /*! Note returned suffix includes the delimiter. If there is
+        no delimiter present, then the returned suffix is an empty
+        string. */
+    static std::string extract_suffix( const std::string& full_name );
+
     static PhysicsName stokes()
     { return "Stokes"+_suffix; }
 

--- a/src/physics/include/grins/physics_naming.h
+++ b/src/physics/include/grins/physics_naming.h
@@ -36,128 +36,139 @@ namespace GRINS
   {
   public:
 
+    static void set_suffix( const std::string& suffix )
+    { _suffix = suffix; }
+
+    static void clear_suffix()
+    { _suffix.clear(); }
+
     static PhysicsName stokes()
-    { return "Stokes"; }
+    { return "Stokes"+_suffix; }
 
     static PhysicsName incompressible_navier_stokes()
-    { return "IncompressibleNavierStokes"; }
+    { return "IncompressibleNavierStokes"+_suffix; }
 
     static PhysicsName incompressible_navier_stokes_adjoint_stab()
-    { return  "IncompressibleNavierStokesAdjointStabilization"; }
+    { return  "IncompressibleNavierStokesAdjointStabilization"+_suffix; }
 
     static PhysicsName incompressible_navier_stokes_spgsm_stab()
-    { return "IncompressibleNavierStokesSPGSMStabilization"; }
+    { return "IncompressibleNavierStokesSPGSMStabilization"+_suffix; }
 
     static PhysicsName velocity_drag()
-    { return "VelocityDrag"; }
+    { return "VelocityDrag"+_suffix; }
 
     static PhysicsName velocity_drag_adjoint_stab()
-    { return "VelocityDragAdjointStabilization"; }
+    { return "VelocityDragAdjointStabilization"+_suffix; }
 
     static PhysicsName velocity_penalty()
-    { return "VelocityPenalty"; }
+    { return "VelocityPenalty"+_suffix; }
 
     static PhysicsName velocity_penalty2()
-    { return "VelocityPenalty2"; }
+    { return "VelocityPenalty2"+_suffix; }
 
     static PhysicsName velocity_penalty3()
-    { return "VelocityPenalty3"; }
+    { return "VelocityPenalty3"+_suffix; }
 
     static PhysicsName velocity_penalty_adjoint_stab()
-    { return "VelocityPenaltyAdjointStabilization"; }
+    { return "VelocityPenaltyAdjointStabilization"+_suffix; }
 
     static PhysicsName velocity_penalty2_adjoint_stab()
-    { return "VelocityPenalty2AdjointStabilization"; }
+    { return "VelocityPenalty2AdjointStabilization"+_suffix; }
 
     static PhysicsName velocity_penalty3_adjoint_stab()
-    { return "VelocityPenalty3AdjointStabilization"; }
+    { return "VelocityPenalty3AdjointStabilization"+_suffix; }
 
     static PhysicsName parsed_velocity_source()
-    { return "ParsedVelocitySource"; }
+    { return "ParsedVelocitySource"+_suffix; }
 
     static PhysicsName parsed_velocity_source_adjoint_stab()
-    { return "ParsedVelocitySourceAdjointStabilization"; }
+    { return "ParsedVelocitySourceAdjointStabilization"+_suffix; }
 
     static PhysicsName averaged_fan()
-    { return "AveragedFan"; }
+    { return "AveragedFan"+_suffix; }
 
     static PhysicsName averaged_fan_adjoint_stab()
-    { return "AveragedFanAdjointStabilization"; }
+    { return "AveragedFanAdjointStabilization"+_suffix; }
 
     static PhysicsName averaged_turbine()
-    { return "AveragedTurbine"; }
+    { return "AveragedTurbine"+_suffix; }
 
     static PhysicsName spalart_allmaras()
-    { return "SpalartAllmaras"; }
+    { return "SpalartAllmaras"+_suffix; }
 
     static PhysicsName spalart_allmaras_spgsm_stab()
-    { return "SpalartAllmarasSPGSMStabilization"; }
+    { return "SpalartAllmarasSPGSMStabilization"+_suffix; }
 
     static PhysicsName scalar_ode()
-    { return "ScalarODE"; }
+    { return "ScalarODE"+_suffix; }
 
     static PhysicsName heat_conduction()
-    { return "HeatConduction"; }
+    { return "HeatConduction"+_suffix; }
 
     static PhysicsName heat_transfer()
-    { return "HeatTransfer"; }
+    { return "HeatTransfer"+_suffix; }
 
     static PhysicsName heat_transfer_source()
-    { return "HeatTransferSource"; }
+    { return "HeatTransferSource"+_suffix; }
 
     static PhysicsName heat_transfer_adjoint_stab()
-    { return "HeatTransferAdjointStabilization"; }
+    { return "HeatTransferAdjointStabilization"+_suffix; }
 
     static PhysicsName heat_transfer_spgsm_stab()
-    { return "HeatTransferSPGSMStabilization"; }
+    { return "HeatTransferSPGSMStabilization"+_suffix; }
 
     static PhysicsName axisymmetric_heat_transfer()
-    { return "AxisymmetricHeatTransfer"; }
+    { return "AxisymmetricHeatTransfer"+_suffix; }
 
     static PhysicsName boussinesq_buoyancy()
-    { return "BoussinesqBuoyancy"; }
+    { return "BoussinesqBuoyancy"+_suffix; }
 
     static PhysicsName boussinesq_buoyancy_adjoint_stab()
-    { return "BoussinesqBuoyancyAdjointStabilization"; }
+    { return "BoussinesqBuoyancyAdjointStabilization"+_suffix; }
 
     static PhysicsName boussinesq_buoyancy_spgsm_stab()
-    { return "BoussinesqBuoyancySPGSMStabilization"; }
+    { return "BoussinesqBuoyancySPGSMStabilization"+_suffix; }
 
     static PhysicsName axisymmetric_boussinesq_buoyancy()
-    { return "AxisymmetricBoussinesqBuoyancy"; }
+    { return "AxisymmetricBoussinesqBuoyancy"+_suffix; }
 
     static PhysicsName low_mach_navier_stokes()
-    { return "LowMachNavierStokes"; }
+    { return "LowMachNavierStokes"+_suffix; }
 
     static PhysicsName low_mach_navier_stokes_braack_stab()
-    { return "LowMachNavierStokesBraackStabilization"; }
+    { return "LowMachNavierStokesBraackStabilization"+_suffix; }
 
     static PhysicsName low_mach_navier_stokes_spgsm_stab()
-    { return "LowMachNavierStokesSPGSMStabilization"; }
+    { return "LowMachNavierStokesSPGSMStabilization"+_suffix; }
 
     static PhysicsName low_mach_navier_stokes_vms_stab()
-    { return "LowMachNavierStokesVMSStabilization"; }
+    { return "LowMachNavierStokesVMSStabilization"+_suffix; }
 
     static PhysicsName reacting_low_mach_navier_stokes()
-    { return "ReactingLowMachNavierStokes"; }
+    { return "ReactingLowMachNavierStokes"+_suffix; }
 
     static PhysicsName elastic_membrane()
-    { return "ElasticMembrane"; }
+    { return "ElasticMembrane"+_suffix; }
 
     static PhysicsName elastic_cable()
-    { return "ElasticCable"; }
+    { return "ElasticCable"+_suffix; }
 
     static PhysicsName elastic_membrane_constant_pressure()
-    { return "ElasticMembraneConstantPressure"; }
+    { return "ElasticMembraneConstantPressure"+_suffix; }
 
     static PhysicsName elastic_cable_constant_gravity()
-    { return "ElasticCableConstantGravity"; }
+    { return "ElasticCableConstantGravity"+_suffix; }
 
     static PhysicsName constant_source_term()
-    { return "ConstantSourceTerm"; }
+    { return "ConstantSourceTerm"+_suffix; }
 
     static PhysicsName parsed_source_term()
-    { return "ParsedSourceTerm"; }
+    { return "ParsedSourceTerm"+_suffix; }
+
+  private:
+
+    static std::string _suffix;
+
   };
 
 }

--- a/src/physics/src/physics_factory.C
+++ b/src/physics/src/physics_factory.C
@@ -928,6 +928,25 @@ namespace GRINS
     return;
   }
 
+  bool PhysicsFactory::find_physics( const std::string& required_physics,
+                                     const GRINS::PhysicsList& physics_list ) const
+  {
+    bool found_physics = false;
+
+    for( PhysicsListIter physics = physics_list.begin();
+	 physics != physics_list.end();
+	 physics++ )
+      {
+        if( required_physics == PhysicsNaming::extract_physics(physics->first) )
+          {
+            found_physics = true;
+            break;
+          }
+      }
+
+    return found_physics;
+  }
+
   void PhysicsFactory::physics_consistency_error( const std::string physics_checked,
 						  const std::string physics_required ) const
   {

--- a/src/physics/src/physics_factory.C
+++ b/src/physics/src/physics_factory.C
@@ -563,6 +563,10 @@ namespace GRINS
 				    const std::string& physics_to_add,
 				    PhysicsList& physics_list )
   {
+    std::string physics_suffix =  PhysicsNaming::extract_suffix( physics_to_add );
+
+    PhysicsNaming::set_suffix(physics_suffix);
+
     if( physics_to_add == PhysicsNaming::incompressible_navier_stokes() )
       {
 	physics_list[physics_to_add] =
@@ -799,7 +803,7 @@ namespace GRINS
         libmesh_error();
       }
 
-    return;
+    PhysicsNaming::clear_suffix();
   }
 
   void PhysicsFactory::check_physics_consistency( const PhysicsList& physics_list )

--- a/src/physics/src/physics_factory.C
+++ b/src/physics/src/physics_factory.C
@@ -810,34 +810,36 @@ namespace GRINS
 	 physics != physics_list.end();
 	 physics++ )
       {
+        PhysicsName current_physics = PhysicsNaming::extract_physics(physics->first);
+
 	// For IncompressibleNavierStokes*Stabilization, we'd better have IncompressibleNavierStokes
-        if( (physics->first == PhysicsNaming::incompressible_navier_stokes_adjoint_stab()) ||
-            (physics->first == PhysicsNaming::incompressible_navier_stokes_spgsm_stab()) )
+        if( (current_physics == PhysicsNaming::incompressible_navier_stokes_adjoint_stab()) ||
+            (current_physics == PhysicsNaming::incompressible_navier_stokes_spgsm_stab()) )
           {
-            if( physics_list.find(PhysicsNaming::incompressible_navier_stokes()) == physics_list.end() )
+            if( !this->find_physics(PhysicsNaming::incompressible_navier_stokes(), physics_list) )
               {
-                this->physics_consistency_error( physics->first, PhysicsNaming::incompressible_navier_stokes()  );
+                this->physics_consistency_error( current_physics, PhysicsNaming::incompressible_navier_stokes()  );
               }
           }
 
 	// For HeatTransfer, we need IncompressibleNavierStokes
-	if( physics->first == PhysicsNaming::heat_transfer() )
+	if( current_physics == PhysicsNaming::heat_transfer() )
 	  {
-	    if( physics_list.find(PhysicsNaming::incompressible_navier_stokes()) == physics_list.end() )
+	    if( !this->find_physics(PhysicsNaming::incompressible_navier_stokes(), physics_list) )
 	      {
 		this->physics_consistency_error( PhysicsNaming::heat_transfer(), PhysicsNaming::incompressible_navier_stokes()  );
 	      }
 	  }
 
 	// For BoussinesqBuoyancy, we need both HeatTransfer and IncompressibleNavierStokes
-	if( physics->first == PhysicsNaming::boussinesq_buoyancy() )
+	if( current_physics == PhysicsNaming::boussinesq_buoyancy() )
 	  {
-	    if( physics_list.find(PhysicsNaming::incompressible_navier_stokes()) == physics_list.end() )
+	    if( !this->find_physics(PhysicsNaming::incompressible_navier_stokes(), physics_list) )
 	      {
 		this->physics_consistency_error( PhysicsNaming::boussinesq_buoyancy(), PhysicsNaming::incompressible_navier_stokes()  );
 	      }
 
-	    if( physics_list.find(PhysicsNaming::heat_transfer()) == physics_list.end() )
+	    if( !this->find_physics(PhysicsNaming::heat_transfer(), physics_list) )
 	      {
 		this->physics_consistency_error( PhysicsNaming::boussinesq_buoyancy(), PhysicsNaming::heat_transfer()  );
 	      }
@@ -845,10 +847,10 @@ namespace GRINS
 
 	/* For AxisymmetricBoussinesqBuoyancy, we need both AxisymmetricHeatTransfer
 	   and AxisymmetricIncompNavierStokes */
-	if( physics->first == PhysicsNaming::axisymmetric_boussinesq_buoyancy() )
+	if( current_physics == PhysicsNaming::axisymmetric_boussinesq_buoyancy() )
 	  {
 
-	    if( physics_list.find(PhysicsNaming::axisymmetric_heat_transfer()) == physics_list.end() )
+	    if( !this->find_physics(PhysicsNaming::axisymmetric_heat_transfer(), physics_list) )
 	      {
 		this->physics_consistency_error( PhysicsNaming::axisymmetric_boussinesq_buoyancy(),
 						 PhysicsNaming::axisymmetric_heat_transfer()  );
@@ -857,7 +859,7 @@ namespace GRINS
 
 	/* For LowMachNavierStokes, there should be nothing else loaded, except
 	   for stabilization. */
-	if( physics->first == PhysicsNaming::low_mach_navier_stokes() )
+	if( current_physics == PhysicsNaming::low_mach_navier_stokes() )
 	  {
 	    if( physics_list.size() > 2 )
 	      {
@@ -869,7 +871,7 @@ namespace GRINS
 		     iter != physics_list.end();
 		     iter++ )
 		  {
-		    std::cerr << physics->first << std::endl;
+		    std::cerr << current_physics << std::endl;
 		  }
 		std::cerr << "=======================================================" << std::endl;
 		libmesh_error();
@@ -877,35 +879,35 @@ namespace GRINS
 	  }
 
 	/* For HeatTransferSource, we'd better have HeatTransfer */
-	if( physics->first == PhysicsNaming::heat_transfer_source() )
+	if( current_physics == PhysicsNaming::heat_transfer_source() )
 	  {
-	    if( physics_list.find(PhysicsNaming::heat_transfer()) == physics_list.end() )
+	    if( !this->find_physics(PhysicsNaming::heat_transfer(), physics_list) )
 	      {
-		this->physics_consistency_error( physics->first, PhysicsNaming::heat_transfer()  );
+		this->physics_consistency_error( current_physics, PhysicsNaming::heat_transfer()  );
 	      }
 	  }
 
 	/* For HeatTransferAdjointStabilization, we'd better have HeatTransfer */
-	if( physics->first == PhysicsNaming::heat_transfer_adjoint_stab() )
+	if( current_physics == PhysicsNaming::heat_transfer_adjoint_stab() )
 	  {
-	    if( physics_list.find(PhysicsNaming::heat_transfer()) == physics_list.end() )
+	    if( !this->find_physics(PhysicsNaming::heat_transfer(), physics_list) )
 	      {
-		this->physics_consistency_error( physics->first, PhysicsNaming::heat_transfer()  );
+		this->physics_consistency_error( current_physics, PhysicsNaming::heat_transfer()  );
 	      }
 	  }
 
         /* For BoussinesqBuoyancyAdjointStabilization, we'd better have IncompressibleNavierStokes */
-	if( physics->first == PhysicsNaming::boussinesq_buoyancy_adjoint_stab() )
+	if( current_physics == PhysicsNaming::boussinesq_buoyancy_adjoint_stab() )
 	  {
-	    if( physics_list.find(PhysicsNaming::incompressible_navier_stokes()) == physics_list.end() )
+	    if( !this->find_physics(PhysicsNaming::incompressible_navier_stokes(), physics_list) )
 	      {
-		this->physics_consistency_error( physics->first, PhysicsNaming::incompressible_navier_stokes()  );
+		this->physics_consistency_error( current_physics, PhysicsNaming::incompressible_navier_stokes()  );
 	      }
 	  }
 
 	/* For ReactingLowMachNavierStokes, there should be nothing else loaded, except
 	   for stabilization. */
-	if( physics->first == PhysicsNaming::reacting_low_mach_navier_stokes() )
+	if( current_physics == PhysicsNaming::reacting_low_mach_navier_stokes() )
 	  {
 	    if( physics_list.size() > 2 )
 	      {
@@ -917,7 +919,7 @@ namespace GRINS
 		     iter != physics_list.end();
 		     iter++ )
 		  {
-		    std::cerr << physics->first << std::endl;
+		    std::cerr << current_physics << std::endl;
 		  }
 		std::cerr << "=======================================================" << std::endl;
 		libmesh_error();

--- a/src/physics/src/physics_naming.C
+++ b/src/physics/src/physics_naming.C
@@ -1,0 +1,33 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/physics_naming.h"
+
+namespace GRINS
+{
+
+  std::string PhysicsNaming::_suffix = std::string("");
+
+} // end namespace GRINS

--- a/src/physics/src/physics_naming.C
+++ b/src/physics/src/physics_naming.C
@@ -30,4 +30,55 @@ namespace GRINS
 
   std::string PhysicsNaming::_suffix = std::string("");
 
+  void PhysicsNaming::extract_physics_and_suffix( const std::string& full_name,
+                                                  std::string& physics_name,
+                                                  std::string& suffix )
+  {
+    physics_name = PhysicsNaming::extract_physics(full_name);
+    suffix = PhysicsNaming::extract_suffix(full_name);
+  }
+
+  std::string PhysicsNaming::extract_physics( const std::string& full_name )
+  {
+    // We look for this delimiter to separate the physics name from
+    // the user-supplied suffix
+    std::string delimiter = PhysicsNaming::physics_name_delimiter();
+
+    std::size_t idx = full_name.find_first_of( delimiter );
+
+    std::string physics_name;
+
+    // If this delimiter is not found, then the full_name is the physics_name
+    if( idx == full_name.npos )
+        physics_name = full_name;
+
+    // If it is found, the first part is the physics_name
+    // and the second part is the suffix
+    else
+        physics_name = full_name.substr(0,idx);
+
+    return physics_name;
+  }
+
+  std::string PhysicsNaming::extract_suffix( const std::string& full_name )
+  {
+    // We look for this delimiter to separate the physics name from
+    // the user-supplied suffix
+    std::string delimiter = PhysicsNaming::physics_name_delimiter();
+
+    std::size_t idx = full_name.find_first_of( delimiter );
+
+    std::string suffix;
+
+    // If this delimiter is not found, then there's no suffix
+    // So no need to do anything in that case.
+    // If it is found, the first part is the physics_name
+    // and the second part is the suffix.
+    // Note the suffix extraction *includes* the delimiter
+    if( idx != full_name.npos )
+        suffix = full_name.substr(idx,full_name.npos);
+
+    return suffix;
+  }
+
 } // end namespace GRINS

--- a/test/input_files/convection_cell_regression.in
+++ b/test/input_files/convection_cell_regression.in
@@ -22,10 +22,15 @@
 # Options related to all Physics
 [Physics]
 
-enabled_physics = 'IncompressibleNavierStokes IncompressibleNavierStokesAdjointStabilization HeatTransfer HeatTransferAdjointStabilization BoussinesqBuoyancy BoussinesqBuoyancyAdjointStabilization'
+enabled_physics = 'IncompressibleNavierStokes:TestDelimiter
+                   IncompressibleNavierStokesAdjointStabilization:TestDelimiter
+                   HeatTransfer:TestDelimiter
+                   HeatTransferAdjointStabilization:TestDelimiter
+                   BoussinesqBuoyancy:TestDelimiter
+                   BoussinesqBuoyancyAdjointStabilization:TestDelimiter'
 
 # Options for Incompressible Navier-Stokes physics
-[./IncompressibleNavierStokes]
+[./IncompressibleNavierStokes:TestDelimiter]
 
 material = 'TestMaterial'
 
@@ -47,7 +52,7 @@ ic_types = 'parsed'
 ic_variables = 'v'
 ic_values = '(abs(x)<=2)*0.001'
 
-[../HeatTransfer]
+[../HeatTransfer:TestDelimiter]
 
 material = 'TestMaterial'
 
@@ -69,7 +74,7 @@ ic_types = 'constant'
 ic_variables = 'T'
 ic_values = '300.0'
 
-[../BoussinesqBuoyancy]
+[../BoussinesqBuoyancy:TestDelimiter]
 
 material = 'TestMaterial'
 

--- a/test/input_files/convection_cell_regression.in
+++ b/test/input_files/convection_cell_regression.in
@@ -24,10 +24,10 @@
 
 enabled_physics = 'IncompressibleNavierStokes:TestDelimiter
                    IncompressibleNavierStokesAdjointStabilization:TestDelimiter
-                   HeatTransfer:TestDelimiter
-                   HeatTransferAdjointStabilization:TestDelimiter
-                   BoussinesqBuoyancy:TestDelimiter
-                   BoussinesqBuoyancyAdjointStabilization:TestDelimiter'
+                   HeatTransfer:MySuffix
+                   HeatTransferAdjointStabilization:MySuffix
+                   BoussinesqBuoyancy:YourSuffix
+                   BoussinesqBuoyancyAdjointStabilization:YourSuffix'
 
 # Options for Incompressible Navier-Stokes physics
 [./IncompressibleNavierStokes:TestDelimiter]
@@ -52,7 +52,7 @@ ic_types = 'parsed'
 ic_variables = 'v'
 ic_values = '(abs(x)<=2)*0.001'
 
-[../HeatTransfer:TestDelimiter]
+[../HeatTransfer:MySuffix]
 
 material = 'TestMaterial'
 
@@ -74,7 +74,7 @@ ic_types = 'constant'
 ic_variables = 'T'
 ic_values = '300.0'
 
-[../BoussinesqBuoyancy:TestDelimiter]
+[../BoussinesqBuoyancy:YourSuffix]
 
 material = 'TestMaterial'
 

--- a/test/input_files/couette_flow_input_2d_x.in
+++ b/test/input_files/couette_flow_input_2d_x.in
@@ -43,10 +43,10 @@ echo_physics = 'true'
 # Options related to all Physics
 [Physics]
 
-enabled_physics = 'IncompressibleNavierStokes'
+enabled_physics = 'IncompressibleNavierStokes:TestDelimiter'
 
 # Options for Incompressible Navier-Stokes physics
-[./IncompressibleNavierStokes]
+[./IncompressibleNavierStokes:TestDelimiter]
 
 material = 'TestMaterial'
 

--- a/test/input_files/elastic_mooney_rivlin_circle_hookean_stiffeners_regression.in.in
+++ b/test/input_files/elastic_mooney_rivlin_circle_hookean_stiffeners_regression.in.in
@@ -29,12 +29,12 @@
 
 ##### Options related to all Physics #####
 [Physics]
-enabled_physics = 'ElasticMembrane
-                   ElasticMembraneConstantPressure
-                   ElasticCable'
+enabled_physics = 'ElasticMembrane:Membrane1
+                   ElasticMembraneConstantPressure:AllMembranes
+                   ElasticCable:Cables'
 
 ##### Options for Elastic Membrane Physics #####
-[./ElasticMembrane]
+[./ElasticMembrane:Membrane1]
 
 material = 'Membrane'
 
@@ -48,14 +48,14 @@ ic_types     = 'parsed'
 ic_variables = 'w'
 ic_values    = '-0.5*cos(pi/2*sqrt(x^2+y^2))'
 
-[../ElasticMembraneConstantPressure]
+[../ElasticMembraneConstantPressure:AllMembranes]
 
 enabled_subdomains = '1'
 
 pressure = '1.0'
 
 ##### Options for Elastic Cable Physics #####
-[../ElasticCable]
+[../ElasticCable:Cables]
 
 material = 'Cable'
 


### PR DESCRIPTION
This PR enables using `:` in the input physics name and putting whatever suffix you want. This will allow us to use the same physics in different ways. For example:

<pre>
[Physics]
   enabled_physics = 'ElasticMembrane ElasticCable:Stringer ElasticCable:RingCable]
   [./ElasticMembrane]
   [../ElasticCable:Stringer]
      enabled_subdomains = '0'
      material = 'Kevlar'
   [../ElasticCable:RingCable]
      enabled_subdomains = '1'
      material = 'ThickKevlar'
[]
</pre>

The way I did this is by stashing the suffix in `PhysicsNaming`. The returned physics name will always have a suffix appended to it; the suffix is empty until the user sets it. For each physics we build, we first extract the suffix, set it, then it will propagate all the way through during the build phase of the physics, e.g. for stabilization classes that are tied to a "core" physics and its options. Then, when the building of the physics is done, we clear the suffix.

This is not 100% ready yet, hence marked do not merge. I need to refactor the variable naming first before merging this. Since variables are still tied to the physics section, you get surprises if you don't have matched suffixes between the physics. (The variable input refactoring shouldn't take long.) In the meantime, this can at least have eyes on the principal implementation (and the principle of the implementation). Then, once the variables bit is done, I'll throw in a few more tests here (and fix any lingering problems that might crop up). Then should be good to go.

Since we only do parsing in the physics at construction time, I think we still satisfy the principle of least surprise (modulo the variables input refactoring), but it's certainly possible I overlooked something.