### PR TITLE
Solver Restructuring

### DIFF
--- a/src/solver/include/grins/grins_solver.h
+++ b/src/solver/include/grins/grins_solver.h
@@ -87,6 +87,8 @@ namespace GRINS
 
     void print_scalar_vars( SolverContext& context );
 
+    void print_qoi( SolverContext& context, std::ostream& output );
+
   protected:
 
     // Linear/Nonlinear solver options

--- a/src/solver/include/grins/grins_solver.h
+++ b/src/solver/include/grins/grins_solver.h
@@ -85,6 +85,8 @@ namespace GRINS
         in multiple different steady solves. */
     void steady_adjoint_solve( SolverContext& context );
 
+    void print_scalar_vars( SolverContext& context );
+
   protected:
 
     // Linear/Nonlinear solver options

--- a/src/solver/include/grins/grins_unsteady_solver.h
+++ b/src/solver/include/grins/grins_unsteady_solver.h
@@ -51,6 +51,12 @@ namespace GRINS
     template <typename T>
     void set_theta( libMesh::UnsteadySolver* time_solver );
 
+    //! Updates Dirichlet boundary conditions
+    /*! If the Dirichlet boundary condition is nonlinear, we need
+        to update the constraints with the new solution.
+        \todo We're not updating time-dependent BCs right now! */
+    void update_dirichlet_bcs( SolverContext& context );
+
     std::string _time_solver_name;
 
     unsigned int _n_timesteps;

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -91,6 +91,8 @@ namespace GRINS
 
     void flag_elements_for_refinement( const libMesh::ErrorVector& error );
 
+    void estimate_error_for_amr( SolverContext& context, libMesh::ErrorVector& error );
+
   private:
 
     MeshAdaptiveSolverBase();

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -28,9 +28,6 @@
 // C++
 #include <string>
 
-// GRINS
-#include "grins/grins_solver.h"
-
 //libMesh
 #include "libmesh/libmesh.h"
 #include "libmesh/mesh_refinement.h"
@@ -45,7 +42,9 @@ namespace libMesh
 
 namespace GRINS
 {
-  class MeshAdaptiveSolverBase : public Solver
+  class SolverContext;
+
+  class MeshAdaptiveSolverBase
   {
   public:
 

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -93,6 +93,8 @@ namespace GRINS
 
     void estimate_error_for_amr( SolverContext& context, libMesh::ErrorVector& error );
 
+    void perform_amr( SolverContext& context, const libMesh::ErrorVector& error );
+
   private:
 
     MeshAdaptiveSolverBase();

--- a/src/solver/include/grins/steady_mesh_adaptive_solver.h
+++ b/src/solver/include/grins/steady_mesh_adaptive_solver.h
@@ -26,6 +26,7 @@
 #define GRINS_STEADY_MESH_ADAPTIVE_SOLVER_H
 
 // GRINS
+#include "grins/grins_solver.h"
 #include "grins/mesh_adaptive_solver_base.h"
 
 namespace GRINS
@@ -34,7 +35,8 @@ namespace GRINS
   class SolverContext;
   class MultiphysicsSystem;
 
-  class SteadyMeshAdaptiveSolver : public MeshAdaptiveSolverBase
+  class SteadyMeshAdaptiveSolver : public Solver,
+                                   public MeshAdaptiveSolverBase
   {
   public:
 

--- a/src/solver/src/grins_solver.C
+++ b/src/solver/src/grins_solver.C
@@ -38,6 +38,7 @@
 #include "libmesh/fem_system.h"
 #include "libmesh/diff_solver.h"
 #include "libmesh/newton_solver.h"
+#include "libmesh/dof_map.h"
 
 namespace GRINS
 {
@@ -125,6 +126,28 @@ namespace GRINS
 
     context.system->adjoint_solve();
     context.system->set_adjoint_already_solved(true);
+  }
+
+  void Solver::print_scalar_vars( SolverContext& context )
+  {
+    for (unsigned int v=0; v != context.system->n_vars(); ++v)
+      if (context.system->variable(v).type().family ==
+          libMesh::SCALAR)
+        {
+          std::cout << context.system->variable_name(v) <<
+            " = {";
+          std::vector<libMesh::dof_id_type> scalar_indices;
+          context.system->get_dof_map().SCALAR_dof_indices
+            (scalar_indices, v);
+          if (scalar_indices.size())
+            std::cout <<
+              context.system->current_solution(scalar_indices[0]);
+          for (unsigned int i=1; i < scalar_indices.size();
+               ++i)
+            std::cout << ", " <<
+              context.system->current_solution(scalar_indices[i]);
+          std::cout << '}' << std::endl;
+        }
   }
 
 } // namespace GRINS

--- a/src/solver/src/grins_solver.C
+++ b/src/solver/src/grins_solver.C
@@ -25,6 +25,7 @@
 
 // C++
 #include <iostream>
+#include <iomanip>
 
 // This class
 #include "grins/grins_solver.h"
@@ -32,6 +33,7 @@
 // GRINS
 #include "grins/multiphysics_sys.h"
 #include "grins/solver_context.h"
+#include "grins/composite_qoi.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -148,6 +150,15 @@ namespace GRINS
               context.system->current_solution(scalar_indices[i]);
           std::cout << '}' << std::endl;
         }
+  }
+
+  void Solver::print_qoi( SolverContext& context, std::ostream& output )
+  {
+    context.system->assemble_qoi();
+    const CompositeQoI* my_qoi = libMesh::libmesh_cast_ptr<const CompositeQoI*>(context.system->get_qoi());
+
+    my_qoi->output_qoi( output );
+    output << std::endl;
   }
 
 } // namespace GRINS

--- a/src/solver/src/grins_steady_solver.C
+++ b/src/solver/src/grins_steady_solver.C
@@ -73,24 +73,7 @@ namespace GRINS
     context.system->solve();
 
     if ( context.print_scalars )
-      for (unsigned int v=0; v != context.system->n_vars(); ++v)
-        if (context.system->variable(v).type().family ==
-            libMesh::SCALAR)
-          {
-            std::cout << context.system->variable_name(v) <<
-                         " = {";
-            std::vector<libMesh::dof_id_type> scalar_indices;
-            context.system->get_dof_map().SCALAR_dof_indices
-              (scalar_indices, v);
-            if (scalar_indices.size())
-              std::cout <<
-                context.system->current_solution(scalar_indices[0]);
-            for (unsigned int i=1; i < scalar_indices.size();
-                 ++i)
-              std::cout << ", " <<
-                context.system->current_solution(scalar_indices[i]);
-            std::cout << '}' << std::endl;
-          }
+      this->print_scalar_vars(context);
 
     if( context.do_adjoint_solve )
       {

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -135,32 +135,7 @@ namespace GRINS
 
         // If we have any solution-dependent Dirichlet boundaries, we
         // need to update them with the current solution.
-        //
-        // FIXME: This needs to be much more efficient and intuitive.
-        bool have_nonlinear_dirichlet_bc = false;
-        {
-        const libMesh::DirichletBoundaries &db =
-          *context.system->get_dof_map().get_dirichlet_boundaries();
-        for (libMesh::DirichletBoundaries::const_iterator
-               it = db.begin(); it != db.end(); ++it)
-          {
-            const libMesh::DirichletBoundary* bdy = *it;
-            if (bdy->f_fem.get())
-              {
-                have_nonlinear_dirichlet_bc = true;
-                break;
-              }
-          }
-        }
-
-        // Nonlinear Dirichlet constraints change as the solution does
-        if (have_nonlinear_dirichlet_bc)
-          {
-            context.system->reinit_constraints();
-            context.system->get_dof_map().enforce_constraints_exactly(*context.system);
-            context.system->get_dof_map().enforce_constraints_exactly(*context.system,
-                                                                      dynamic_cast<libMesh::UnsteadySolver*>(context.system->time_solver.get())->old_local_nonlinear_solution.get());
-          }
+        this->update_dirichlet_bcs(context);
 
 	// GRVY timers contained in here (if enabled)
 	context.system->solve();
@@ -199,4 +174,34 @@ namespace GRINS
     return;
   }
 
+  void UnsteadySolver::update_dirichlet_bcs( SolverContext& context )
+  {
+    // FIXME: This needs to be much more efficient and intuitive.
+    // FIXME: This is only checking for nonlinear bc! This is not checking for time-dependence!
+    bool have_nonlinear_dirichlet_bc = false;
+    {
+      const libMesh::DirichletBoundaries &db =
+        *context.system->get_dof_map().get_dirichlet_boundaries();
+      for (libMesh::DirichletBoundaries::const_iterator
+             it = db.begin(); it != db.end(); ++it)
+        {
+          const libMesh::DirichletBoundary* bdy = *it;
+          if (bdy->f_fem.get())
+            {
+              have_nonlinear_dirichlet_bc = true;
+              break;
+            }
+        }
+    }
+
+    // Nonlinear Dirichlet constraints change as the solution does
+    // FIXME: We should be updating with time-dependent BCs as well!
+    if (have_nonlinear_dirichlet_bc)
+      {
+        context.system->reinit_constraints();
+        context.system->get_dof_map().enforce_constraints_exactly(*context.system);
+        context.system->get_dof_map().enforce_constraints_exactly(*context.system,
+                                                                  dynamic_cast<libMesh::UnsteadySolver*>(context.system->time_solver.get())->old_local_nonlinear_solution.get());
+      }
+  }
 } // namespace GRINS

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -182,24 +182,7 @@ namespace GRINS
           libMesh::perflog.print_log();
 
         if ( context.print_scalars )
-          for (unsigned int v=0; v != context.system->n_vars(); ++v)
-            if (context.system->variable(v).type().family ==
-                libMesh::SCALAR)
-              {
-                std::cout << context.system->variable_name(v) <<
-                             " = {";
-                std::vector<libMesh::dof_id_type> scalar_indices;
-                context.system->get_dof_map().SCALAR_dof_indices
-                  (scalar_indices, v);
-                if (scalar_indices.size())
-                  std::cout <<
-                    context.system->current_solution(scalar_indices[0]);
-                for (unsigned int i=1; i < scalar_indices.size();
-                     ++i)
-                  std::cout << ", " <<
-                    context.system->current_solution(scalar_indices[i]);
-                std::cout << '}' << std::endl;
-              }
+          this->print_scalar_vars(context);
 
 	// Advance to the next timestep
 	context.system->time_solver->advance_timestep();

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -37,8 +37,7 @@
 namespace GRINS
 {
   MeshAdaptiveSolverBase::MeshAdaptiveSolverBase( const GetPot& input )
-    : Solver( input ),
-      _max_refinement_steps( input("MeshAdaptivity/max_refinement_steps", 5) ),
+    : _max_refinement_steps( input("MeshAdaptivity/max_refinement_steps", 5) ),
       _coarsen_by_parents(true),
       _absolute_global_tolerance( input("MeshAdaptivity/absolute_global_tolerance", 0) ),
       _nelem_target( input("MeshAdaptivity/nelem_target", 0) ),

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -148,6 +148,10 @@ namespace GRINS
   bool MeshAdaptiveSolverBase::check_for_convergence( SolverContext& context,
                                                       const libMesh::ErrorVector& error ) const
   {
+    std::cout << "==========================================================" << std::endl
+              << "Checking convergence" << std::endl
+              << "==========================================================" << std::endl;
+
     bool converged = false;
 
     libMesh::Real error_estimate = 0.0;

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -226,4 +226,20 @@ namespace GRINS
     return;
   }
 
+  void MeshAdaptiveSolverBase::estimate_error_for_amr( SolverContext& context, libMesh::ErrorVector& error )
+  {
+    std::cout << "==========================================================" << std::endl
+              << "Estimating error" << std::endl
+              << "==========================================================" << std::endl;
+    context.error_estimator->estimate_error( *context.system, error );
+
+    libMesh::MeshBase& mesh = context.equation_system->get_mesh();
+
+    // Plot error vector
+    if( this->_plot_cell_errors )
+      {
+        error.plot_error( this->_error_plot_prefix+".exo", mesh );
+      }
+  }
+
 } // end namespace GRINS

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -24,6 +24,7 @@
 
 // C++
 #include <numeric>
+#include <iomanip>
 
 // This class
 #include "grins/mesh_adaptive_solver_base.h"
@@ -244,6 +245,29 @@ namespace GRINS
       {
         error.plot_error( this->_error_plot_prefix+".exo", mesh );
       }
+  }
+
+  void MeshAdaptiveSolverBase::perform_amr( SolverContext& context, const libMesh::ErrorVector& error )
+  {
+    libMesh::MeshBase& mesh = context.equation_system->get_mesh();
+
+    std::cout << "==========================================================" << std::endl
+              << "Performing Mesh Refinement" << std::endl
+              << "==========================================================" << std::endl;
+
+    this->flag_elements_for_refinement( error );
+    _mesh_refinement->refine_and_coarsen_elements();
+
+    // Dont forget to reinit the system after each adaptive refinement!
+    context.equation_system->reinit();
+
+    // This output cannot be toggled in the input file.
+    std::cout << "==========================================================" << std::endl
+              << "Refined mesh to " << std::setw(12) << mesh.n_active_elem()
+              << " active elements" << std::endl
+              << "            " << std::setw(16) << context.system->n_active_dofs()
+              << " active dofs" << std::endl
+              << "==========================================================" << std::endl;
   }
 
 } // end namespace GRINS

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -146,23 +146,7 @@ namespace GRINS
             // Only bother refining if we're on the last step.
             if( r_step < this->_max_refinement_steps -1 )
               {
-                std::cout << "==========================================================" << std::endl
-                          << "Performing Mesh Refinement" << std::endl
-                          << "==========================================================" << std::endl;
-
-                this->flag_elements_for_refinement( error );
-                _mesh_refinement->refine_and_coarsen_elements();
-
-                // Dont forget to reinit the system after each adaptive refinement!
-                context.equation_system->reinit();
-
-                // This output cannot be toggled in the input file.
-                std::cout << "==========================================================" << std::endl
-                          << "Refined mesh to " << std::setw(12) << mesh.n_active_elem()
-                          << " active elements" << std::endl
-                          << "            " << std::setw(16) << context.system->n_active_dofs()
-                          << " active dofs" << std::endl
-                          << "==========================================================" << std::endl;
+                this->perform_amr(context, error);
 
                 // It's helpful to print the qoi along the way, but only do it if the user
                 // asks for it

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -40,7 +40,8 @@ namespace GRINS
 {
 
   SteadyMeshAdaptiveSolver::SteadyMeshAdaptiveSolver( const GetPot& input )
-    : MeshAdaptiveSolverBase( input )
+    : Solver(input),
+      MeshAdaptiveSolverBase( input )
   {
     return;
   }

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -120,17 +120,7 @@ namespace GRINS
 
         // Now we construct the data structures for the mesh refinement process
         libMesh::ErrorVector error;
-
-        std::cout << "==========================================================" << std::endl
-                  << "Estimating error" << std::endl
-                  << "==========================================================" << std::endl;
-        context.error_estimator->estimate_error( *context.system, error );
-
-        // Plot error vector
-        if( this->_plot_cell_errors )
-          {
-            error.plot_error( this->_error_plot_prefix+".exo", mesh );
-          }
+        this->estimate_error_for_amr( context, error );
 
 	// Get the global error estimate if you can and are asked to
 	if( this->_compute_qoi_error_estimate )

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -131,9 +131,6 @@ namespace GRINS
 	  }
 
         // Check for convergence of error
-        std::cout << "==========================================================" << std::endl
-                  << "Checking convergence" << std::endl
-                  << "==========================================================" << std::endl;
         bool converged = this->check_for_convergence( context, error );
 
         if( converged )

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -25,10 +25,12 @@
 // This class
 #include "grins/steady_mesh_adaptive_solver.h"
 
+// C++
+#include <iomanip>
+
 // GRINS
 #include "grins/solver_context.h"
 #include "grins/multiphysics_sys.h"
-#include "grins/composite_qoi.h"
 #include "grins/common.h"
 
 // libMesh
@@ -178,12 +180,7 @@ namespace GRINS
                 // It's helpful to print the qoi along the way, but only do it if the user
                 // asks for it
                 if( context.print_qoi )
-                  {
-                    context.system->assemble_qoi();
-                    const CompositeQoI* my_qoi = libMesh::libmesh_cast_ptr<const CompositeQoI*>(context.system->get_qoi());
-                    my_qoi->output_qoi( std::cout );
-                    std::cout << std::endl;
-                  }
+                  this->print_qoi(context,std::cout);
               }
           }
 


### PR DESCRIPTION
Internal restructuring of `Solvers`. Mostly creating helper functions to promote future reuse. Also made `MeshAdaptiveSolverBase` standalone from `Solver`. 

In doing the restructuring, I also noted that we're not calling `reinit_constraints` for time-dependence in the boundary conditions, only nonlinear dependence. Will fix that in a subsequent PR.