### PR TITLE
Refactor Antioch/Cantera Interface

### DIFF
--- a/src/apps/antioch_transport_values.C
+++ b/src/apps/antioch_transport_values.C
@@ -71,6 +71,8 @@ int do_transport_eval( const GetPot& input )
 
   libMesh::Real T = T0;
 
+  libMesh::Real p0 = rho*T*evaluator.R_mix(Y);
+
   std::ofstream output;
   output.open( "transport.dat", std::ios::trunc );
   
@@ -93,7 +95,7 @@ int do_transport_eval( const GetPot& input )
       libMesh::Real mu;
       libMesh::Real k;
       std::vector<libMesh::Real> D(n_species);
-      evaluator.mu_and_k_and_D( T, rho, evaluator.cp(T,Y), Y, mu, k, D );
+      evaluator.mu_and_k_and_D( T, rho, evaluator.cp(T,p0,Y), Y, mu, k, D );
 
       output <<  mu << " ";
       output << k << " ";

--- a/src/apps/cantera_kinetic_rates.C
+++ b/src/apps/cantera_kinetic_rates.C
@@ -92,10 +92,8 @@ int main(int argc, char* argv[])
   output.close();
 
   while( T < T1 )
-    { 
-      libMesh::Real p = rho*R_mix*T;
-
-      kinetics.omega_dot_TPY( T, p, Y, omega_dot );
+    {
+      kinetics.omega_dot( T, rho, Y, omega_dot );
 
       output.open( "omega_dot.dat", std::ios::app );
       output << T << " ";

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -471,76 +471,11 @@ namespace GRINS
     std::vector<libMesh::Real> rho;
     rho.resize(n_qpoints);
 
-    for (unsigned int qp = 0; qp != n_qpoints; ++qp)
-      {
-	u[qp] = context.interior_value(this->_flow_vars.u(), qp);
-	v[qp] = context.interior_value(this->_flow_vars.v(), qp);
-
-	grad_u[qp] = context.interior_gradient(this->_flow_vars.u(), qp);
-	grad_v[qp] = context.interior_gradient(this->_flow_vars.v(), qp);
-	if( this->_dim > 2 )
-	  {
-	    w[qp] = context.interior_value(this->_flow_vars.w(), qp);
-	    grad_w[qp] = context.interior_gradient(this->_flow_vars.w(), qp);
-	  }
-	T[qp] = context.interior_value(this->_temp_vars.T(), qp);
-	grad_T[qp] = context.interior_gradient(this->_temp_vars.T(), qp);
-
-	p[qp] = context.interior_value(this->_press_var.p(), qp);
-	p0[qp] = this->get_p0_steady(context, qp);
-
-	mass_fractions[qp].resize(this->_n_species);
-	grad_mass_fractions[qp].resize(this->_n_species);
-
-	for( unsigned int s = 0; s < this->_n_species; s++ )
-	  {
-	    /*! \todo Need to figure out something smarter for controling species
-	              that go slightly negative. */
-	    mass_fractions[qp][s] = std::max( context.interior_value(this->_species_vars.species(s),qp), 0.0 );
-	    grad_mass_fractions[qp][s] = context.interior_gradient(this->_species_vars.species(s),qp);
-	  }
-	
-	M[qp] = gas_evaluator.M_mix( mass_fractions[qp] );
-
-	R[qp] = gas_evaluator.R_mix( mass_fractions[qp] );
-
-	rho[qp] = this->rho( T[qp], p0[qp], R[qp] );
-      }
-    
-    cache.set_values(Cache::X_VELOCITY, u);
-    cache.set_values(Cache::Y_VELOCITY, v);
-    
-    cache.set_gradient_values(Cache::X_VELOCITY_GRAD, grad_u);
-    cache.set_gradient_values(Cache::Y_VELOCITY_GRAD, grad_v);
-    
-    if(this->_dim > 2)
-      {
-	cache.set_values(Cache::Z_VELOCITY, w);
-	cache.set_gradient_values(Cache::Z_VELOCITY_GRAD, grad_w);
-      }
-
-    cache.set_values(Cache::TEMPERATURE, T);
-    cache.set_gradient_values(Cache::TEMPERATURE_GRAD, grad_T);
-
-    cache.set_values(Cache::PRESSURE, p);
-    cache.set_values(Cache::THERMO_PRESSURE, p0);
-
-    cache.set_vector_values(Cache::MASS_FRACTIONS, mass_fractions);
-    cache.set_vector_gradient_values(Cache::MASS_FRACTIONS_GRAD, grad_mass_fractions);
-
-    cache.set_values(Cache::MOLAR_MASS, M);
-
-    cache.set_values(Cache::MIXTURE_GAS_CONSTANT, R);
-
-    cache.set_values(Cache::MIXTURE_DENSITY, rho);
-
-    /* These quantities must be computed after T, mass_fractions, p0
-       are set into the cache. */
-    std::vector<libMesh::Real> mu;
-    mu.resize(n_qpoints);
-
     std::vector<libMesh::Real> cp;
     cp.resize(n_qpoints);
+
+    std::vector<libMesh::Real> mu;
+    mu.resize(n_qpoints);
 
     std::vector<libMesh::Real> k;
     k.resize(n_qpoints);
@@ -556,28 +491,79 @@ namespace GRINS
 
     for (unsigned int qp = 0; qp != n_qpoints; ++qp)
       {
-        cp[qp] = gas_evaluator.cp(cache,qp);
+	u[qp] = context.interior_value(this->_flow_vars.u(), qp);
+	v[qp] = context.interior_value(this->_flow_vars.v(), qp);
+
+	grad_u[qp] = context.interior_gradient(this->_flow_vars.u(), qp);
+	grad_v[qp] = context.interior_gradient(this->_flow_vars.v(), qp);
+	if( this->_dim > 2 )
+	  {
+	    w[qp] = context.interior_value(this->_flow_vars.w(), qp);
+	    grad_w[qp] = context.interior_gradient(this->_flow_vars.w(), qp);
+	  }
+
+	T[qp] = context.interior_value(this->_temp_vars.T(), qp);
+	grad_T[qp] = context.interior_gradient(this->_temp_vars.T(), qp);
+
+	p[qp] = context.interior_value(this->_press_var.p(), qp);
+	p0[qp] = this->get_p0_steady(context, qp);
+
+	mass_fractions[qp].resize(this->_n_species);
+	grad_mass_fractions[qp].resize(this->_n_species);
+        h_s[qp].resize(this->_n_species);
+
+	for( unsigned int s = 0; s < this->_n_species; s++ )
+	  {
+	    /*! \todo Need to figure out something smarter for controling species
+	              that go slightly negative. */
+	    mass_fractions[qp][s] = std::max( context.interior_value(this->_species_vars.species(s),qp), 0.0 );
+	    grad_mass_fractions[qp][s] = context.interior_gradient(this->_species_vars.species(s),qp);
+            h_s[qp][s] = gas_evaluator.h_s( T[qp], s );
+	  }
+	
+	M[qp] = gas_evaluator.M_mix( mass_fractions[qp] );
+
+	R[qp] = gas_evaluator.R_mix( mass_fractions[qp] );
+
+	rho[qp] = this->rho( T[qp], p0[qp], R[qp] );
+
+        cp[qp] = gas_evaluator.cp(T[qp], p0[qp], mass_fractions[qp]);
 
         D_s[qp].resize(this->_n_species);
 
         gas_evaluator.mu_and_k_and_D( T[qp], rho[qp], cp[qp], mass_fractions[qp],
                                       mu[qp], k[qp], D_s[qp] );
 
-	h_s[qp].resize(this->_n_species);
-	gas_evaluator.h_s( cache, qp, h_s[qp] );
-
-	omega_dot_s[qp].resize(this->_n_species);
-	gas_evaluator.omega_dot( cache, qp, omega_dot_s[qp] );
+        omega_dot_s[qp].resize(this->_n_species);
+        gas_evaluator.omega_dot( T[qp], rho[qp], mass_fractions[qp], omega_dot_s[qp] );
+      }
+    
+    cache.set_values(Cache::X_VELOCITY, u);
+    cache.set_values(Cache::Y_VELOCITY, v);
+    cache.set_gradient_values(Cache::X_VELOCITY_GRAD, grad_u);
+    cache.set_gradient_values(Cache::Y_VELOCITY_GRAD, grad_v);
+    
+    if(this->_dim > 2)
+      {
+	cache.set_values(Cache::Z_VELOCITY, w);
+	cache.set_gradient_values(Cache::Z_VELOCITY_GRAD, grad_w);
       }
 
-    cache.set_values(Cache::MIXTURE_VISCOSITY, mu);
+    cache.set_values(Cache::TEMPERATURE, T);
+    cache.set_gradient_values(Cache::TEMPERATURE_GRAD, grad_T);
+    cache.set_values(Cache::PRESSURE, p);
+    cache.set_values(Cache::THERMO_PRESSURE, p0);
+    cache.set_vector_values(Cache::MASS_FRACTIONS, mass_fractions);
+    cache.set_vector_gradient_values(Cache::MASS_FRACTIONS_GRAD, grad_mass_fractions);
+    cache.set_values(Cache::MOLAR_MASS, M);
+    cache.set_values(Cache::MIXTURE_GAS_CONSTANT, R);
+    cache.set_values(Cache::MIXTURE_DENSITY, rho);
     cache.set_values(Cache::MIXTURE_SPECIFIC_HEAT_P, cp);
+    cache.set_values(Cache::MIXTURE_VISCOSITY, mu);
     cache.set_values(Cache::MIXTURE_THERMAL_CONDUCTIVITY, k);
-    cache.set_vector_values(Cache::SPECIES_ENTHALPY, h_s);
     cache.set_vector_values(Cache::DIFFUSION_COEFFS, D_s);
+    cache.set_vector_values(Cache::SPECIES_ENTHALPY, h_s);
     cache.set_vector_values(Cache::OMEGA_DOT, omega_dot_s);
-
-    return;
   }
 
   template<typename Mixture, typename Evaluator>

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -643,16 +643,18 @@ namespace GRINS
         std::vector<libMesh::Real> Y( this->_n_species );
         libMesh::Real T = this->T(point,context);
         this->mass_fractions( point, context, Y );
+        libMesh::Real p0 = this->get_p0_steady(context,point);
 
-        value = gas_evaluator.mu( T, Y );
+        value = gas_evaluator.mu( T, p0, Y );
       }
     else if( quantity_index == this->_k_index )
       {
         std::vector<libMesh::Real> Y( this->_n_species );
         libMesh::Real T = this->T(point,context);
         this->mass_fractions( point, context, Y );
+        libMesh::Real p0 = this->get_p0_steady(context,point);
 
-        value = gas_evaluator.k( T, Y );
+        value = gas_evaluator.k( T, p0, Y );
       }
     else if( quantity_index == this->_cp_index )
       {

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -659,8 +659,9 @@ namespace GRINS
         std::vector<libMesh::Real> Y( this->_n_species );
         libMesh::Real T = this->T(point,context);
         this->mass_fractions( point, context, Y );
+        libMesh::Real p0 = this->get_p0_steady(context,point);
 
-        value = gas_evaluator.cp( T, Y );
+        value = gas_evaluator.cp( T, p0, Y );
       }
     // Now check for species dependent stuff
     else

--- a/src/properties/include/grins/antioch_constant_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_constant_transport_evaluator.h
@@ -58,13 +58,6 @@ namespace GRINS
     AntiochConstantTransportEvaluator( const AntiochConstantTransportMixture<Conductivity>& mixture );
 
     virtual ~AntiochConstantTransportEvaluator();
-    
-    libMesh::Real mu( const CachedValues& cache, unsigned int qp );
-
-    libMesh::Real k( const CachedValues& cache, unsigned int qp );
-
-    void mu_and_k( const CachedValues& cache, unsigned int qp,
-                   libMesh::Real& mu, libMesh::Real& k );
 
     libMesh::Real mu( const libMesh::Real T,
                       const libMesh::Real P,

--- a/src/properties/include/grins/antioch_constant_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_constant_transport_evaluator.h
@@ -66,9 +66,6 @@ namespace GRINS
     void mu_and_k( const CachedValues& cache, unsigned int qp,
                    libMesh::Real& mu, libMesh::Real& k );
 
-    void D( const CachedValues& cache, unsigned int qp,
-	    std::vector<libMesh::Real>& D );
-
     libMesh::Real mu( const libMesh::Real T,
                       const libMesh::Real P,
                       const std::vector<libMesh::Real>& Y );
@@ -76,10 +73,6 @@ namespace GRINS
     libMesh::Real k( const libMesh::Real T,
                      const libMesh::Real P,
                      const std::vector<libMesh::Real>& Y );
-
-    void D( const libMesh::Real rho, const libMesh::Real cp,
-            const libMesh::Real k,
-	    std::vector<libMesh::Real>& D );
 
     void mu_and_k_and_D( const libMesh::Real T,
                          const libMesh::Real rho,

--- a/src/properties/include/grins/antioch_constant_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_constant_transport_evaluator.h
@@ -70,9 +70,11 @@ namespace GRINS
 	    std::vector<libMesh::Real>& D );
 
     libMesh::Real mu( const libMesh::Real T,
+                      const libMesh::Real P,
                       const std::vector<libMesh::Real>& Y );
 
     libMesh::Real k( const libMesh::Real T,
+                     const libMesh::Real P,
                      const std::vector<libMesh::Real>& Y );
 
     void D( const libMesh::Real rho, const libMesh::Real cp,

--- a/src/properties/include/grins/antioch_evaluator.h
+++ b/src/properties/include/grins/antioch_evaluator.h
@@ -79,24 +79,13 @@ namespace GRINS
     std::string species_name( unsigned int species_index ) const;
 
     // Thermo
-    libMesh::Real cp( const CachedValues& cache, unsigned int qp );
-
     libMesh::Real cp( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
-    libMesh::Real cv( const CachedValues& cache, unsigned int qp );
-
     libMesh::Real cv( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
-
-    libMesh::Real h_s(const CachedValues& cache, unsigned int qp, unsigned int species);
-
-    void h_s(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h_s);
 
     libMesh::Real h_s( const libMesh::Real& T, unsigned int species );
 
     // Kinetics
-    void omega_dot( const CachedValues& cache, unsigned int qp,
-		    std::vector<libMesh::Real>& omega_dot );
-
     void omega_dot( const libMesh::Real& T, libMesh::Real rho,
                     const std::vector<libMesh::Real> mass_fractions,
                     std::vector<libMesh::Real>& omega_dot );
@@ -211,28 +200,6 @@ namespace GRINS
   {
     if( _temp_cache->T != T )
       _temp_cache.reset( new Antioch::TempCache<libMesh::Real>(T) );
-  }
-
-  template<typename Thermo>
-  inline
-  libMesh::Real AntiochEvaluator<Thermo>::cp( const CachedValues& cache,unsigned int qp )
-  {
-    const libMesh::Real& T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    // Second T is dummy
-    return this->cp( T, T, Y );
-  }
-
-  template<typename Thermo>
-  inline
-  libMesh::Real AntiochEvaluator<Thermo>::cv( const CachedValues& cache,unsigned int qp )
-  {
-    const libMesh::Real& T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    // Second T is dummy
-    return this->cv( T, T, Y );
   }
 
 } // end namespace GRINS

--- a/src/properties/include/grins/antioch_evaluator.h
+++ b/src/properties/include/grins/antioch_evaluator.h
@@ -58,7 +58,7 @@ namespace GRINS
 
     AntiochEvaluator( const AntiochMixture& mixture );
 
-    virtual ~AntiochEvaluator();
+    virtual ~AntiochEvaluator(){};
 
     // Chemistry
     libMesh::Real M( unsigned int species ) const;

--- a/src/properties/include/grins/antioch_evaluator.h
+++ b/src/properties/include/grins/antioch_evaluator.h
@@ -81,16 +81,17 @@ namespace GRINS
     // Thermo
     libMesh::Real cp( const CachedValues& cache, unsigned int qp );
 
+    libMesh::Real cp( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
+
     libMesh::Real cv( const CachedValues& cache, unsigned int qp );
-     
+
+    libMesh::Real cv( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
+
     libMesh::Real h_s(const CachedValues& cache, unsigned int qp, unsigned int species);
 
     void h_s(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h_s);
 
     libMesh::Real h_s( const libMesh::Real& T, unsigned int species );
-
-    libMesh::Real cp( const libMesh::Real& T,
-                      const std::vector<libMesh::Real>& Y );
 
     // Kinetics
     void omega_dot( const CachedValues& cache, unsigned int qp,
@@ -210,6 +211,28 @@ namespace GRINS
   {
     if( _temp_cache->T != T )
       _temp_cache.reset( new Antioch::TempCache<libMesh::Real>(T) );
+  }
+
+  template<typename Thermo>
+  inline
+  libMesh::Real AntiochEvaluator<Thermo>::cp( const CachedValues& cache,unsigned int qp )
+  {
+    const libMesh::Real& T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
+    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
+
+    // Second T is dummy
+    return this->cp( T, T, Y );
+  }
+
+  template<typename Thermo>
+  inline
+  libMesh::Real AntiochEvaluator<Thermo>::cv( const CachedValues& cache,unsigned int qp )
+  {
+    const libMesh::Real& T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
+    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
+
+    // Second T is dummy
+    return this->cv( T, T, Y );
   }
 
 } // end namespace GRINS

--- a/src/properties/include/grins/antioch_evaluator.h
+++ b/src/properties/include/grins/antioch_evaluator.h
@@ -204,6 +204,14 @@ namespace GRINS
     return _chem.species_name(species_index);
   }
 
+  template<typename Thermo>
+  inline
+  void AntiochEvaluator<Thermo>::check_and_reset_temp_cache( const libMesh::Real& T )
+  {
+    if( _temp_cache->T != T )
+      _temp_cache.reset( new Antioch::TempCache<libMesh::Real>(T) );
+  }
+
 } // end namespace GRINS
 
 #endif // GRINS_HAVE_ANTIOCH

--- a/src/properties/include/grins/antioch_kinetics.h
+++ b/src/properties/include/grins/antioch_kinetics.h
@@ -59,7 +59,8 @@ namespace GRINS
   public:
 
     AntiochKinetics( const AntiochMixture& mixture );
-    ~AntiochKinetics();
+
+    ~AntiochKinetics(){};
 
     void omega_dot( const Antioch::TempCache<libMesh::Real>& temp_cache,
                     const libMesh::Real rho,

--- a/src/properties/include/grins/antioch_kinetics.h
+++ b/src/properties/include/grins/antioch_kinetics.h
@@ -62,6 +62,11 @@ namespace GRINS
 
     ~AntiochKinetics(){};
 
+    void omega_dot( const libMesh::Real& T,
+                    const libMesh::Real rho,
+                    const std::vector<libMesh::Real>& mass_fractions,
+                    std::vector<libMesh::Real>& omega_dot );
+
     void omega_dot( const Antioch::TempCache<libMesh::Real>& temp_cache,
                     const libMesh::Real rho,
                     const std::vector<libMesh::Real>& mass_fractions,

--- a/src/properties/include/grins/antioch_mixture.h
+++ b/src/properties/include/grins/antioch_mixture.h
@@ -63,7 +63,7 @@ namespace GRINS
 
     AntiochMixture( const GetPot& input, const std::string& material );
 
-    virtual ~AntiochMixture();
+    virtual ~AntiochMixture(){};
 
     const Antioch::ReactionSet<libMesh::Real>& reaction_set() const;
 
@@ -105,7 +105,7 @@ namespace GRINS
   {
     return _h_stat_mech_ref_correction[species];
   }
-  
+
 } // end namespace GRINS
 
 #endif // GRINS_HAVE_ANTIOCH

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
@@ -67,9 +67,11 @@ namespace GRINS
                    libMesh::Real& mu, libMesh::Real& k );
 
     libMesh::Real mu( const libMesh::Real T,
+                      const libMesh::Real P,
                       const std::vector<libMesh::Real>& Y );
 
     libMesh::Real k( const libMesh::Real T,
+                     const libMesh::Real P,
                      const std::vector<libMesh::Real>& Y );
 
     void D( const libMesh::Real T,

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
@@ -74,12 +74,6 @@ namespace GRINS
                      const libMesh::Real P,
                      const std::vector<libMesh::Real>& Y );
 
-    void D( const libMesh::Real T,
-            const libMesh::Real rho,
-            const libMesh::Real cp,
-            const std::vector<libMesh::Real>& Y,
-            std::vector<libMesh::Real>& D );
-
     void mu_and_k_and_D( const libMesh::Real T,
                          const libMesh::Real rho,
                          const libMesh::Real cp,

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
@@ -57,7 +57,7 @@ namespace GRINS
 
     AntiochMixtureAveragedTransportEvaluator( const AntiochMixtureAveragedTransportMixture<Thermo,Viscosity,Conductivity,Diffusivity>& mixture );
 
-    virtual ~AntiochMixtureAveragedTransportEvaluator();
+    virtual ~AntiochMixtureAveragedTransportEvaluator(){};
 
     libMesh::Real mu( const CachedValues& cache, unsigned int qp );
 

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
@@ -59,13 +59,6 @@ namespace GRINS
 
     virtual ~AntiochMixtureAveragedTransportEvaluator(){};
 
-    libMesh::Real mu( const CachedValues& cache, unsigned int qp );
-
-    libMesh::Real k( const CachedValues& cache, unsigned int qp );
-
-    void mu_and_k( const CachedValues& cache, unsigned int qp,
-                   libMesh::Real& mu, libMesh::Real& k );
-
     libMesh::Real mu( const libMesh::Real T,
                       const libMesh::Real P,
                       const std::vector<libMesh::Real>& Y );

--- a/src/properties/include/grins/cantera_evaluator.h
+++ b/src/properties/include/grins/cantera_evaluator.h
@@ -330,17 +330,12 @@ namespace GRINS
   inline
   void CanteraEvaluator::mu_and_k_and_D( const libMesh::Real T,
                                          const libMesh::Real rho,
-                                         const libMesh::Real /*cp*/,
+                                         const libMesh::Real cp,
                                          const std::vector<libMesh::Real>& Y,
                                          libMesh::Real& mu, libMesh::Real& k,
                                          std::vector<libMesh::Real>& D )
   {
-    /*! \todo We're assuming an ideal gas here. Fix this when the API becomes stable, i.e
-              when we only need to pass a GRINS::AssemblyContext. */
-    libMesh::Real R_mix = this->R_mix(Y);
-    libMesh::Real P = rho*R_mix*T;
-
-    _transport.mu_and_k_and_D( T, P, Y, mu, k, D );
+    _transport.mu_and_k_and_D( T, rho, cp, Y, mu, k, D );
   }
 
   inline

--- a/src/properties/include/grins/cantera_evaluator.h
+++ b/src/properties/include/grins/cantera_evaluator.h
@@ -71,31 +71,16 @@ namespace GRINS
     std::string species_name( unsigned int species_index ) const;
 
     // Thermo
-    libMesh::Real cp( const CachedValues& cache, unsigned int qp );
-
     libMesh::Real cp( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
-    libMesh::Real cv( const CachedValues& cache, unsigned int qp );
-
     libMesh::Real cv( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
-
-    libMesh::Real h_s(const CachedValues& cache, unsigned int qp, unsigned int species);
-
-    void h_s(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h);
 
     libMesh::Real h_s( const libMesh::Real& T, unsigned int species );
 
     // Transport
-    libMesh::Real mu( const CachedValues& cache, unsigned int qp );
-
     libMesh::Real mu( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
-    libMesh::Real k( const CachedValues& cache, unsigned int qp );
-
     libMesh::Real k( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
-
-    void mu_and_k( const CachedValues& cache, unsigned int qp,
-                   libMesh::Real& mu, libMesh::Real& k );
 
     void mu_and_k( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y,
                    libMesh::Real& mu, libMesh::Real& k );
@@ -108,42 +93,9 @@ namespace GRINS
                          std::vector<libMesh::Real>& D );
 
     // Kinetics
-    void omega_dot( const CachedValues& cache, unsigned int qp,
-		    std::vector<libMesh::Real>& omega_dot );
-
     void omega_dot( const libMesh::Real& T, libMesh::Real rho,
                     const std::vector<libMesh::Real> mass_fractions,
                     std::vector<libMesh::Real>& omega_dot );
-
-    libMesh::Real cp( const libMesh::Real& /*T*/,
-                      const std::vector<libMesh::Real>& /*Y*/ )
-    {
-      libmesh_not_implemented();
-      return 0.0;
-    }
-
-    libMesh::Real mu( const libMesh::Real& /*T*/,
-                      const std::vector<libMesh::Real>& /*Y*/ )
-    {
-      libmesh_not_implemented();
-      return 0.0;
-    }
-
-    libMesh::Real k( const libMesh::Real& /*T*/,
-                     const std::vector<libMesh::Real>& /*Y*/ )
-    {
-      libmesh_not_implemented();
-      return 0.0;
-    }
-
-    void D( const libMesh::Real /*rho*/,
-            const libMesh::Real /*cp*/,
-            const libMesh::Real /*k*/,
-	    std::vector<libMesh::Real>& /*D*/ )
-    {
-      libmesh_not_implemented();
-      return;
-    }
 
   protected:
 
@@ -213,23 +165,11 @@ namespace GRINS
   }
 
   inline
-  libMesh::Real CanteraEvaluator::cp( const CachedValues& cache, unsigned int qp )
-  {
-    return _thermo.cp(cache,qp);
-  }
-
-  inline
   libMesh::Real CanteraEvaluator::cp( const libMesh::Real& T,
                                       const libMesh::Real P,
                                       const std::vector<libMesh::Real>& Y )
   {
     return _thermo.cp(T,P,Y);
-  }
-
-  inline
-  libMesh::Real CanteraEvaluator::cv( const CachedValues& cache, unsigned int qp )
-  {
-    return _thermo.cv(cache,qp);
   }
 
   inline
@@ -241,28 +181,9 @@ namespace GRINS
   }
 
   inline
-  libMesh::Real CanteraEvaluator::h_s(const CachedValues& cache, unsigned int qp, unsigned int species)
-  {
-    return _thermo.h(cache,qp,species);
-  }
-
-  inline
-  void CanteraEvaluator::h_s(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h)
-  {
-    _thermo.h(cache,qp,h);
-    return;
-  }
-
-  inline
   libMesh::Real CanteraEvaluator::h_s( const libMesh::Real& T, unsigned int species )
   {
     return _thermo.h(T,species);
-  }
-
-  inline
-  libMesh::Real CanteraEvaluator::mu( const CachedValues& cache, unsigned int qp )
-  {
-    return _transport.mu(cache,qp);
   }
 
   inline
@@ -274,25 +195,11 @@ namespace GRINS
   }
 
   inline
-  libMesh::Real CanteraEvaluator::k( const CachedValues& cache, unsigned int qp )
-  {
-    return _transport.k(cache,qp);
-  }
-
-  inline
   libMesh::Real CanteraEvaluator::k( const libMesh::Real& T,
                                       const libMesh::Real P,
                                       const std::vector<libMesh::Real>& Y )
   {
     return _transport.k(T,P,Y);
-  }
-
-  inline
-  void CanteraEvaluator::mu_and_k( const CachedValues& cache, unsigned int qp,
-                                   libMesh::Real& mu, libMesh::Real& k )
-  {
-    mu = _transport.mu(cache,qp);
-    k = _transport.k(cache,qp);
   }
 
   inline
@@ -317,18 +224,11 @@ namespace GRINS
   }
 
   inline
-  void CanteraEvaluator::omega_dot( const CachedValues& cache, unsigned int qp,
-                                    std::vector<libMesh::Real>& omega_dot )
-  {
-    return _kinetics.omega_dot(cache,qp,omega_dot);
-  }
-
-  inline
   void CanteraEvaluator::omega_dot( const libMesh::Real& T, libMesh::Real rho,
                                     const std::vector<libMesh::Real> mass_fractions,
                                     std::vector<libMesh::Real>& omega_dot )
   {
-    return _kinetics.omega_dot_TRY(T,rho,mass_fractions,omega_dot);
+    _kinetics.omega_dot(T,rho,mass_fractions,omega_dot);
   }
 
 } // end namespace GRINS

--- a/src/properties/include/grins/cantera_evaluator.h
+++ b/src/properties/include/grins/cantera_evaluator.h
@@ -50,7 +50,7 @@ namespace GRINS
   public:
 
     CanteraEvaluator( CanteraMixture& mixture );
-    ~CanteraEvaluator();
+    ~CanteraEvaluator(){};
 
     // Chemistry
     libMesh::Real M( unsigned int species ) const;

--- a/src/properties/include/grins/cantera_evaluator.h
+++ b/src/properties/include/grins/cantera_evaluator.h
@@ -71,26 +71,28 @@ namespace GRINS
     std::string species_name( unsigned int species_index ) const;
 
     // Thermo
-    libMesh::Real cp( const CachedValues& cache, unsigned int qp ) const;
+    libMesh::Real cp( const CachedValues& cache, unsigned int qp );
 
-    libMesh::Real cv( const CachedValues& cache, unsigned int qp ) const;
 
-    libMesh::Real h_s(const CachedValues& cache, unsigned int qp, unsigned int species) const;
+    libMesh::Real cv( const CachedValues& cache, unsigned int qp );
 
-    void h_s(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h) const;
+
+    libMesh::Real h_s(const CachedValues& cache, unsigned int qp, unsigned int species);
+
+    void h_s(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h);
 
     libMesh::Real h_s( const libMesh::Real& T, unsigned int species );
 
     // Transport
-    libMesh::Real mu( const CachedValues& cache, unsigned int qp ) const;
+    libMesh::Real mu( const CachedValues& cache, unsigned int qp );
 
-    libMesh::Real k( const CachedValues& cache, unsigned int qp ) const;
+    libMesh::Real k( const CachedValues& cache, unsigned int qp );
 
     void mu_and_k( const CachedValues& cache, unsigned int qp,
                    libMesh::Real& mu, libMesh::Real& k );
 
     void D( const CachedValues& cache, unsigned int qp,
-	    std::vector<libMesh::Real>& D ) const;
+	    std::vector<libMesh::Real>& D );
 
     void mu_and_k_and_D( const libMesh::Real T,
                          const libMesh::Real rho,
@@ -101,7 +103,7 @@ namespace GRINS
 
     // Kinetics
     void omega_dot( const CachedValues& cache, unsigned int qp,
-		    std::vector<libMesh::Real>& omega_dot ) const;
+		    std::vector<libMesh::Real>& omega_dot );
 
     void omega_dot( const libMesh::Real& T, libMesh::Real rho,
                     const std::vector<libMesh::Real> mass_fractions,
@@ -205,25 +207,25 @@ namespace GRINS
   }
 
   inline
-  libMesh::Real CanteraEvaluator::cp( const CachedValues& cache, unsigned int qp ) const
+  libMesh::Real CanteraEvaluator::cp( const CachedValues& cache, unsigned int qp )
   {
     return _thermo.cp(cache,qp);
   }
 
   inline
-  libMesh::Real CanteraEvaluator::cv( const CachedValues& cache, unsigned int qp ) const
+  libMesh::Real CanteraEvaluator::cv( const CachedValues& cache, unsigned int qp )
   {
     return _thermo.cv(cache,qp);
   }
   
   inline
-  libMesh::Real CanteraEvaluator::h_s(const CachedValues& cache, unsigned int qp, unsigned int species) const
+  libMesh::Real CanteraEvaluator::h_s(const CachedValues& cache, unsigned int qp, unsigned int species)
   {
     return _thermo.h(cache,qp,species);
   }
   
   inline
-  void CanteraEvaluator::h_s(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h) const
+  void CanteraEvaluator::h_s(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h)
   {
     _thermo.h(cache,qp,h);
     return;
@@ -236,13 +238,13 @@ namespace GRINS
   }
 
   inline
-  libMesh::Real CanteraEvaluator::mu( const CachedValues& cache, unsigned int qp ) const
+  libMesh::Real CanteraEvaluator::mu( const CachedValues& cache, unsigned int qp )
   {
     return _transport.mu(cache,qp);
   }
 
   inline
-  libMesh::Real CanteraEvaluator::k( const CachedValues& cache, unsigned int qp ) const
+  libMesh::Real CanteraEvaluator::k( const CachedValues& cache, unsigned int qp )
   {
     return _transport.k(cache,qp);
   }
@@ -257,7 +259,7 @@ namespace GRINS
 
   inline
   void CanteraEvaluator::D( const CachedValues& cache, unsigned int qp,
-                            std::vector<libMesh::Real>& D ) const
+                            std::vector<libMesh::Real>& D )
   {
     return _transport.D(cache,qp,D);
   }
@@ -280,7 +282,7 @@ namespace GRINS
 
   inline
   void CanteraEvaluator::omega_dot( const CachedValues& cache, unsigned int qp,
-                                    std::vector<libMesh::Real>& omega_dot ) const
+                                    std::vector<libMesh::Real>& omega_dot )
   {
     return _kinetics.omega_dot(cache,qp,omega_dot);
   }

--- a/src/properties/include/grins/cantera_evaluator.h
+++ b/src/properties/include/grins/cantera_evaluator.h
@@ -73,9 +73,11 @@ namespace GRINS
     // Thermo
     libMesh::Real cp( const CachedValues& cache, unsigned int qp );
 
+    libMesh::Real cp( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
     libMesh::Real cv( const CachedValues& cache, unsigned int qp );
 
+    libMesh::Real cv( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
     libMesh::Real h_s(const CachedValues& cache, unsigned int qp, unsigned int species);
 
@@ -213,17 +215,33 @@ namespace GRINS
   }
 
   inline
+  libMesh::Real CanteraEvaluator::cp( const libMesh::Real& T,
+                                      const libMesh::Real P,
+                                      const std::vector<libMesh::Real>& Y )
+  {
+    return _thermo.cp(T,P,Y);
+  }
+
+  inline
   libMesh::Real CanteraEvaluator::cv( const CachedValues& cache, unsigned int qp )
   {
     return _thermo.cv(cache,qp);
   }
-  
+
+  inline
+  libMesh::Real CanteraEvaluator::cv( const libMesh::Real& T,
+                                      const libMesh::Real P,
+                                      const std::vector<libMesh::Real>& Y )
+  {
+    return _thermo.cv(T,P,Y);
+  }
+
   inline
   libMesh::Real CanteraEvaluator::h_s(const CachedValues& cache, unsigned int qp, unsigned int species)
   {
     return _thermo.h(cache,qp,species);
   }
-  
+
   inline
   void CanteraEvaluator::h_s(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h)
   {

--- a/src/properties/include/grins/cantera_evaluator.h
+++ b/src/properties/include/grins/cantera_evaluator.h
@@ -100,12 +100,6 @@ namespace GRINS
     void mu_and_k( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y,
                    libMesh::Real& mu, libMesh::Real& k );
 
-    void D( const CachedValues& cache, unsigned int qp,
-	    std::vector<libMesh::Real>& D );
-
-    void D( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y,
-	    std::vector<libMesh::Real>& D );
-
     void mu_and_k_and_D( const libMesh::Real T,
                          const libMesh::Real rho,
                          const libMesh::Real cp,
@@ -309,22 +303,6 @@ namespace GRINS
   {
     mu = _transport.mu(T,P,Y);
     k = _transport.k(T,P,Y);
-  }
-
-  inline
-  void CanteraEvaluator::D( const CachedValues& cache, unsigned int qp,
-                            std::vector<libMesh::Real>& D )
-  {
-    _transport.D(cache,qp,D);
-  }
-
-  inline
-  void CanteraEvaluator::D( const libMesh::Real& T,
-                            const libMesh::Real P,
-                            const std::vector<libMesh::Real>& Y,
-                            std::vector<libMesh::Real>& D )
-  {
-    _transport.D(T,P,Y,D);
   }
 
   inline

--- a/src/properties/include/grins/cantera_evaluator.h
+++ b/src/properties/include/grins/cantera_evaluator.h
@@ -88,12 +88,22 @@ namespace GRINS
     // Transport
     libMesh::Real mu( const CachedValues& cache, unsigned int qp );
 
+    libMesh::Real mu( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
+
     libMesh::Real k( const CachedValues& cache, unsigned int qp );
+
+    libMesh::Real k( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
     void mu_and_k( const CachedValues& cache, unsigned int qp,
                    libMesh::Real& mu, libMesh::Real& k );
 
+    void mu_and_k( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y,
+                   libMesh::Real& mu, libMesh::Real& k );
+
     void D( const CachedValues& cache, unsigned int qp,
+	    std::vector<libMesh::Real>& D );
+
+    void D( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y,
 	    std::vector<libMesh::Real>& D );
 
     void mu_and_k_and_D( const libMesh::Real T,
@@ -262,9 +272,25 @@ namespace GRINS
   }
 
   inline
+  libMesh::Real CanteraEvaluator::mu( const libMesh::Real& T,
+                                      const libMesh::Real P,
+                                      const std::vector<libMesh::Real>& Y )
+  {
+    return _transport.mu(T,P,Y);
+  }
+
+  inline
   libMesh::Real CanteraEvaluator::k( const CachedValues& cache, unsigned int qp )
   {
     return _transport.k(cache,qp);
+  }
+
+  inline
+  libMesh::Real CanteraEvaluator::k( const libMesh::Real& T,
+                                      const libMesh::Real P,
+                                      const std::vector<libMesh::Real>& Y )
+  {
+    return _transport.k(T,P,Y);
   }
 
   inline
@@ -276,10 +302,29 @@ namespace GRINS
   }
 
   inline
+  void CanteraEvaluator::mu_and_k( const libMesh::Real& T,
+                                   const libMesh::Real P,
+                                   const std::vector<libMesh::Real>& Y,
+                                   libMesh::Real& mu, libMesh::Real& k )
+  {
+    mu = _transport.mu(T,P,Y);
+    k = _transport.k(T,P,Y);
+  }
+
+  inline
   void CanteraEvaluator::D( const CachedValues& cache, unsigned int qp,
                             std::vector<libMesh::Real>& D )
   {
-    return _transport.D(cache,qp,D);
+    _transport.D(cache,qp,D);
+  }
+
+  inline
+  void CanteraEvaluator::D( const libMesh::Real& T,
+                            const libMesh::Real P,
+                            const std::vector<libMesh::Real>& Y,
+                            std::vector<libMesh::Real>& D )
+  {
+    _transport.D(T,P,Y,D);
   }
 
   inline

--- a/src/properties/include/grins/cantera_kinetics.h
+++ b/src/properties/include/grins/cantera_kinetics.h
@@ -58,16 +58,9 @@ namespace GRINS
     CanteraKinetics( CanteraMixture& mixture );
     ~CanteraKinetics(){};
 
-    void omega_dot( const CachedValues& cache, unsigned int qp,
-		    std::vector<libMesh::Real>& omega_dot ) const;
-
-    void omega_dot_TPY( const libMesh::Real T, const libMesh::Real P,
-                        const std::vector<libMesh::Real>& mass_fractions,
-                        std::vector<libMesh::Real>& omega_dot ) const;
-
-    void omega_dot_TRY( const libMesh::Real& T, const libMesh::Real rho,
-                        const std::vector<libMesh::Real>& mass_fractions,
-                        std::vector<libMesh::Real>& omega_dot ) const;
+    void omega_dot( const libMesh::Real& T, const libMesh::Real rho,
+                    const std::vector<libMesh::Real>& mass_fractions,
+                    std::vector<libMesh::Real>& omega_dot ) const;
 
   protected:
 

--- a/src/properties/include/grins/cantera_kinetics.h
+++ b/src/properties/include/grins/cantera_kinetics.h
@@ -56,7 +56,7 @@ namespace GRINS
   public:
 
     CanteraKinetics( CanteraMixture& mixture );
-    ~CanteraKinetics();
+    ~CanteraKinetics(){};
 
     void omega_dot( const CachedValues& cache, unsigned int qp,
 		    std::vector<libMesh::Real>& omega_dot ) const;

--- a/src/properties/include/grins/cantera_thermo.h
+++ b/src/properties/include/grins/cantera_thermo.h
@@ -65,17 +65,9 @@ namespace GRINS
     CanteraThermodynamics( CanteraMixture& mixture );
     ~CanteraThermodynamics(){};
 
-    libMesh::Real cp( const CachedValues& cache, unsigned int qp );
-
     libMesh::Real cp( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
-    libMesh::Real cv( const CachedValues& cache, unsigned int qp );
-
     libMesh::Real cv( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
-
-    libMesh::Real h(const CachedValues& cache, unsigned int qp, unsigned int species);
-
-    void h(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h);
 
     libMesh::Real h( const libMesh::Real& T, unsigned int species );
 

--- a/src/properties/include/grins/cantera_thermo.h
+++ b/src/properties/include/grins/cantera_thermo.h
@@ -50,7 +50,7 @@ namespace GRINS
   // GRINS forward declarations
   class CanteraMixture;
   class CachedValues;
-  
+
   //! Wrapper class for evaluating thermo properties using Cantera
   /*!
     This class is expected to be constructed *after* threads have been forked and will only
@@ -67,7 +67,11 @@ namespace GRINS
 
     libMesh::Real cp( const CachedValues& cache, unsigned int qp ) const;
 
+    libMesh::Real cp( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y ) const;
+
     libMesh::Real cv( const CachedValues& cache, unsigned int qp ) const;
+
+    libMesh::Real cv( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y ) const;
 
     libMesh::Real h(const CachedValues& cache, unsigned int qp, unsigned int species) const;
 

--- a/src/properties/include/grins/cantera_thermo.h
+++ b/src/properties/include/grins/cantera_thermo.h
@@ -63,7 +63,7 @@ namespace GRINS
   public:
 
     CanteraThermodynamics( CanteraMixture& mixture );
-    ~CanteraThermodynamics();
+    ~CanteraThermodynamics(){};
 
     libMesh::Real cp( const CachedValues& cache, unsigned int qp ) const;
 

--- a/src/properties/include/grins/cantera_thermo.h
+++ b/src/properties/include/grins/cantera_thermo.h
@@ -65,19 +65,19 @@ namespace GRINS
     CanteraThermodynamics( CanteraMixture& mixture );
     ~CanteraThermodynamics(){};
 
-    libMesh::Real cp( const CachedValues& cache, unsigned int qp ) const;
+    libMesh::Real cp( const CachedValues& cache, unsigned int qp );
 
-    libMesh::Real cp( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y ) const;
+    libMesh::Real cp( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
-    libMesh::Real cv( const CachedValues& cache, unsigned int qp ) const;
+    libMesh::Real cv( const CachedValues& cache, unsigned int qp );
 
-    libMesh::Real cv( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y ) const;
+    libMesh::Real cv( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
-    libMesh::Real h(const CachedValues& cache, unsigned int qp, unsigned int species) const;
+    libMesh::Real h(const CachedValues& cache, unsigned int qp, unsigned int species);
 
-    void h(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h) const;
+    void h(const CachedValues& cache, unsigned int qp, std::vector<libMesh::Real>& h);
 
-    libMesh::Real h( const libMesh::Real& T, unsigned int species ) const;
+    libMesh::Real h( const libMesh::Real& T, unsigned int species );
 
   protected:
 

--- a/src/properties/include/grins/cantera_transport.h
+++ b/src/properties/include/grins/cantera_transport.h
@@ -65,7 +65,8 @@ namespace GRINS
   public:
     
     CanteraTransport( CanteraMixture& mixture );
-    ~CanteraTransport();
+
+    ~CanteraTransport(){};
 
     libMesh::Real mu( const CachedValues& cache, unsigned int qp ) const;
 

--- a/src/properties/include/grins/cantera_transport.h
+++ b/src/properties/include/grins/cantera_transport.h
@@ -68,11 +68,7 @@ namespace GRINS
 
     ~CanteraTransport(){};
 
-    libMesh::Real mu( const CachedValues& cache, unsigned int qp );
-
     libMesh::Real mu( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
-
-    libMesh::Real k( const CachedValues& cache, unsigned int qp );
 
     libMesh::Real k( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 

--- a/src/properties/include/grins/cantera_transport.h
+++ b/src/properties/include/grins/cantera_transport.h
@@ -83,7 +83,8 @@ namespace GRINS
 	    std::vector<libMesh::Real>& D );
 
     void mu_and_k_and_D( const libMesh::Real T,
-                         const libMesh::Real P,
+                         const libMesh::Real rho,
+                         const libMesh::Real cp,
                          const std::vector<libMesh::Real>& Y,
                          libMesh::Real& mu, libMesh::Real& k,
                          std::vector<libMesh::Real>& D );

--- a/src/properties/include/grins/cantera_transport.h
+++ b/src/properties/include/grins/cantera_transport.h
@@ -70,9 +70,16 @@ namespace GRINS
 
     libMesh::Real mu( const CachedValues& cache, unsigned int qp );
 
+    libMesh::Real mu( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
+
     libMesh::Real k( const CachedValues& cache, unsigned int qp );
 
+    libMesh::Real k( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
+
     void D( const CachedValues& cache, unsigned int qp,
+	    std::vector<libMesh::Real>& D );
+
+    void D( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y,
 	    std::vector<libMesh::Real>& D );
 
     void mu_and_k_and_D( const libMesh::Real T,

--- a/src/properties/include/grins/cantera_transport.h
+++ b/src/properties/include/grins/cantera_transport.h
@@ -76,12 +76,6 @@ namespace GRINS
 
     libMesh::Real k( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y );
 
-    void D( const CachedValues& cache, unsigned int qp,
-	    std::vector<libMesh::Real>& D );
-
-    void D( const libMesh::Real& T, const libMesh::Real P, const std::vector<libMesh::Real>& Y,
-	    std::vector<libMesh::Real>& D );
-
     void mu_and_k_and_D( const libMesh::Real T,
                          const libMesh::Real rho,
                          const libMesh::Real cp,

--- a/src/properties/include/grins/cantera_transport.h
+++ b/src/properties/include/grins/cantera_transport.h
@@ -63,17 +63,17 @@ namespace GRINS
   class CanteraTransport
   {
   public:
-    
+
     CanteraTransport( CanteraMixture& mixture );
 
     ~CanteraTransport(){};
 
-    libMesh::Real mu( const CachedValues& cache, unsigned int qp ) const;
+    libMesh::Real mu( const CachedValues& cache, unsigned int qp );
 
-    libMesh::Real k( const CachedValues& cache, unsigned int qp ) const;
+    libMesh::Real k( const CachedValues& cache, unsigned int qp );
 
     void D( const CachedValues& cache, unsigned int qp,
-	    std::vector<libMesh::Real>& D ) const;
+	    std::vector<libMesh::Real>& D );
 
     void mu_and_k_and_D( const libMesh::Real T,
                          const libMesh::Real P,

--- a/src/properties/src/antioch_constant_transport_evaluator.C
+++ b/src/properties/src/antioch_constant_transport_evaluator.C
@@ -100,6 +100,7 @@ namespace GRINS
 
   template<typename Thermo, typename Conductivity>
   libMesh::Real AntiochConstantTransportEvaluator<Thermo,Conductivity>::mu( const libMesh::Real /*T*/,
+                                                                            const libMesh::Real /*P*/,
                                                                             const std::vector<libMesh::Real>& /*Y*/ )
   {
     return _mu;
@@ -107,6 +108,7 @@ namespace GRINS
   
   template<typename Thermo, typename Conductivity>
   libMesh::Real AntiochConstantTransportEvaluator<Thermo,Conductivity>::k( const libMesh::Real T,
+                                                                           const libMesh::Real /*P*/,
                                                                            const std::vector<libMesh::Real>& Y )
   {
     // Second T is dummy

--- a/src/properties/src/antioch_constant_transport_evaluator.C
+++ b/src/properties/src/antioch_constant_transport_evaluator.C
@@ -109,7 +109,8 @@ namespace GRINS
   libMesh::Real AntiochConstantTransportEvaluator<Thermo,Conductivity>::k( const libMesh::Real T,
                                                                            const std::vector<libMesh::Real>& Y )
   {
-    const libMesh::Real cp = this->cp( T, Y );
+    // Second T is dummy
+    const libMesh::Real cp = this->cp( T, T, Y );
 
     return _conductivity( _mu, cp );
   }

--- a/src/properties/src/antioch_constant_transport_evaluator.C
+++ b/src/properties/src/antioch_constant_transport_evaluator.C
@@ -52,36 +52,6 @@ namespace GRINS
   }
 
   template<typename Thermo, typename Conductivity>
-  libMesh::Real AntiochConstantTransportEvaluator<Thermo,Conductivity>::mu( const CachedValues& /*cache*/,
-                                                                            unsigned int /*qp*/ )
-  {
-    return this->_mu;
-  }
-
-  template<typename Thermo, typename Conductivity>
-  libMesh::Real AntiochConstantTransportEvaluator<Thermo,Conductivity>::k( const CachedValues& cache,
-                                                                           unsigned int qp )
-  {
-    libMesh::Real cp = this->cp( cache, qp );
-
-    return _conductivity( _mu, cp );
-  }
-
-  template<typename Thermo, typename Conductivity>
-  void AntiochConstantTransportEvaluator<Thermo,Conductivity>::mu_and_k( const CachedValues& cache,
-                                                                         unsigned int qp,
-                                                                         libMesh::Real& mu,
-                                                                         libMesh::Real& k ) 
-  {
-    mu = _mu;
-
-    libMesh::Real cp = this->cp( cache, qp );
-
-    k = _conductivity( _mu, cp );
-    return;
-  }
-
-  template<typename Thermo, typename Conductivity>
   libMesh::Real AntiochConstantTransportEvaluator<Thermo,Conductivity>::mu( const libMesh::Real /*T*/,
                                                                             const libMesh::Real /*P*/,
                                                                             const std::vector<libMesh::Real>& /*Y*/ )

--- a/src/properties/src/antioch_constant_transport_evaluator.C
+++ b/src/properties/src/antioch_constant_transport_evaluator.C
@@ -82,23 +82,6 @@ namespace GRINS
   }
 
   template<typename Thermo, typename Conductivity>
-  void AntiochConstantTransportEvaluator<Thermo,Conductivity>::D( const CachedValues& cache,
-                                                                  unsigned int qp,
-                                                                  std::vector<libMesh::Real>& D )
-  {
-    const libMesh::Real rho = cache.get_cached_values(Cache::MIXTURE_DENSITY)[qp];
-    
-    /*! \todo Find a way to cache these so we don't have to recompute them */
-    const libMesh::Real cp = this->cp(cache,qp);
-    
-    const libMesh::Real k = _conductivity( _mu, cp );
-
-    this->D(rho,cp,k,D);
-    
-    return;
-  }
-
-  template<typename Thermo, typename Conductivity>
   libMesh::Real AntiochConstantTransportEvaluator<Thermo,Conductivity>::mu( const libMesh::Real /*T*/,
                                                                             const libMesh::Real /*P*/,
                                                                             const std::vector<libMesh::Real>& /*Y*/ )
@@ -115,14 +98,6 @@ namespace GRINS
     const libMesh::Real cp = this->cp( T, T, Y );
 
     return _conductivity( _mu, cp );
-  }
-
-  template<typename Thermo, typename Conductivity>
-  void AntiochConstantTransportEvaluator<Thermo,Conductivity>::D( const libMesh::Real rho, const libMesh::Real cp,
-                                                                  const libMesh::Real k,
-                                                                  std::vector<libMesh::Real>& D )
-  {
-    std::fill( D.begin(), D.end(), _diffusivity.D(rho,cp,k) );
   }
 
   template<typename Thermo, typename Conductivity>

--- a/src/properties/src/antioch_evaluator.C
+++ b/src/properties/src/antioch_evaluator.C
@@ -48,16 +48,6 @@ namespace GRINS
   {
     this->build_thermo( mixture );
   }
-  template<typename Thermo>
-  void AntiochEvaluator<Thermo>::omega_dot( const CachedValues& cache, unsigned int qp,
-                                            std::vector<libMesh::Real>& omega_dot )
-  {
-    const libMesh::Real& T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const libMesh::Real rho = cache.get_cached_values(Cache::MIXTURE_DENSITY)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    this->omega_dot( T, rho, Y, omega_dot );
-  }
 
   template<typename Thermo>
   void AntiochEvaluator<Thermo>::omega_dot( const libMesh::Real& T, libMesh::Real rho,
@@ -115,55 +105,6 @@ namespace GRINS
   libMesh::Real AntiochEvaluator<Antioch::StatMechThermodynamics<libMesh::Real> >::h_s( const libMesh::Real& T, unsigned int species )
   {
     return _thermo->h_tot( species, T ) + _chem.h_stat_mech_ref_correction(species);
-  }
-
-
-
-  template<>
-  libMesh::Real AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::h_s( const CachedValues& cache,
-                                                                              unsigned int qp,
-                                                                              unsigned int species )
-  {
-    const libMesh::Real& T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-
-    return this->h_s( T, species );
-  }
-
-  template<>
-  libMesh::Real AntiochEvaluator<Antioch::StatMechThermodynamics<libMesh::Real> >::h_s( const CachedValues& cache,
-                                                                                        unsigned int qp,
-                                                                                        unsigned int species )
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-
-    return this->h_s(T, species);
-  }
-
-  template<>
-  void AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::h_s( const CachedValues& cache,
-                                                                     unsigned int qp,
-                                                                     std::vector<libMesh::Real>& h_s )
-  {
-    const libMesh::Real& T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-
-    this->check_and_reset_temp_cache(T);
-
-    _thermo->h( *(_temp_cache.get()), h_s );
-
-    return;
-  }
-
-  template<>
-  void AntiochEvaluator<Antioch::StatMechThermodynamics<libMesh::Real> >::h_s( const CachedValues& cache,
-                                                                               unsigned int qp,
-                                                                               std::vector<libMesh::Real>& h_s )
-  {
-    for( unsigned int s = 0; s < _chem.n_species(); s++ )
-      {
-        h_s[s] = this->h_s(cache,qp,s);
-      }
-
-    return;
   }
 
 } // end namespace GRINS

--- a/src/properties/src/antioch_evaluator.C
+++ b/src/properties/src/antioch_evaluator.C
@@ -47,15 +47,7 @@ namespace GRINS
       _temp_cache( new Antioch::TempCache<libMesh::Real>(1.0) )
   {
     this->build_thermo( mixture );
-    return;
   }
-
-  template<typename Thermo>
-  AntiochEvaluator<Thermo>::~AntiochEvaluator()
-  {
-    return;
-  }
-
   template<typename Thermo>
   void AntiochEvaluator<Thermo>::omega_dot( const CachedValues& cache, unsigned int qp,
                                             std::vector<libMesh::Real>& omega_dot )

--- a/src/properties/src/antioch_evaluator.C
+++ b/src/properties/src/antioch_evaluator.C
@@ -70,53 +70,37 @@ namespace GRINS
   }
 
   template<>
-  libMesh::Real AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::cp( const CachedValues& cache,
-                                                                             unsigned int qp )
-  {
-    const libMesh::Real& T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    this->check_and_reset_temp_cache(T);
-
-    return _thermo->cp( *(_temp_cache.get()), Y );
-  }
-
-  template<>
-  libMesh::Real AntiochEvaluator<Antioch::StatMechThermodynamics<libMesh::Real> >::cp( const CachedValues& cache,
-                                                                                       unsigned int qp )
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    return _thermo->cp( T, T, Y );
-  }
-
-  template<>
   libMesh::Real AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::cp( const libMesh::Real& T,
+                                                                             const libMesh::Real /*P*/,
                                                                              const std::vector<libMesh::Real>& Y )
   {
     this->check_and_reset_temp_cache(T);
-
     return _thermo->cp( *(_temp_cache.get()), Y );
   }
 
   template<>
   libMesh::Real AntiochEvaluator<Antioch::StatMechThermodynamics<libMesh::Real> >::cp( const libMesh::Real& T,
+                                                                                       const libMesh::Real /*P*/,
                                                                                        const std::vector<libMesh::Real>& Y )
   {
     return _thermo->cp( T, T, Y );
   }
 
   template<>
-  libMesh::Real AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::cv( const CachedValues& cache,
-                                                                             unsigned int qp )
+  libMesh::Real AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::cv( const libMesh::Real& T,
+                                                                             const libMesh::Real /*P*/,
+                                                                             const std::vector<libMesh::Real>& Y )
   {
-    const libMesh::Real& T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
     this->check_and_reset_temp_cache(T);
-
     return _thermo->cv( *(_temp_cache.get()), Y );
+  }
+
+  template<>
+  libMesh::Real AntiochEvaluator<Antioch::StatMechThermodynamics<libMesh::Real> >::cv( const libMesh::Real& T,
+                                                                                       const libMesh::Real /*P*/,
+                                                                                       const std::vector<libMesh::Real>& Y )
+  {
+    return _thermo->cv( T, T, Y );
   }
 
   template<>
@@ -133,16 +117,8 @@ namespace GRINS
     return _thermo->h_tot( species, T ) + _chem.h_stat_mech_ref_correction(species);
   }
 
-  template<>
-  libMesh::Real AntiochEvaluator<Antioch::StatMechThermodynamics<libMesh::Real> >::cv( const CachedValues& cache,
-                                                                                       unsigned int qp )
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
 
-    return _thermo->cv( T, T, Y );
-  }
-     
+
   template<>
   libMesh::Real AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::h_s( const CachedValues& cache,
                                                                               unsigned int qp,

--- a/src/properties/src/antioch_evaluator.C
+++ b/src/properties/src/antioch_evaluator.C
@@ -57,8 +57,6 @@ namespace GRINS
     const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
 
     this->omega_dot( T, rho, Y, omega_dot );
-
-    return;
   }
 
   template<typename Thermo>
@@ -69,19 +67,6 @@ namespace GRINS
     this->check_and_reset_temp_cache(T);
 
     _kinetics->omega_dot( *(_temp_cache.get()), rho, mass_fractions, omega_dot );
-
-    return;
-  }
-
-  template<typename Thermo>
-  void AntiochEvaluator<Thermo>::check_and_reset_temp_cache( const libMesh::Real& T )
-  {
-    if( _temp_cache->T != T )
-      {
-        _temp_cache.reset( new Antioch::TempCache<libMesh::Real>(T) );
-      }
-
-    return;
   }
 
   template<>

--- a/src/properties/src/antioch_kinetics.C
+++ b/src/properties/src/antioch_kinetics.C
@@ -43,14 +43,7 @@ namespace GRINS
     : _antioch_mixture( mixture ),
       _antioch_kinetics( mixture.reaction_set(), 0 ),
       _antioch_cea_thermo( mixture.cea_mixture() )
-  {
-    return;
-  }
-
-  AntiochKinetics::~AntiochKinetics()
-  {
-    return;
-  }
+  {}
 
   void AntiochKinetics::omega_dot( const Antioch::TempCache<libMesh::Real>& temp_cache,
                                    const libMesh::Real rho,
@@ -73,10 +66,8 @@ namespace GRINS
                                             molar_densities,
                                             h_RT_minus_s_R,
                                             omega_dot );
-
-    return;
   }
-  
+
 }// end namespace GRINS
 
 #endif // GRINS_HAVE_ANTIOCH

--- a/src/properties/src/antioch_kinetics.C
+++ b/src/properties/src/antioch_kinetics.C
@@ -45,6 +45,15 @@ namespace GRINS
       _antioch_cea_thermo( mixture.cea_mixture() )
   {}
 
+  void AntiochKinetics::omega_dot( const libMesh::Real& T,
+                                   const libMesh::Real rho,
+                                   const std::vector<libMesh::Real>& mass_fractions,
+                                   std::vector<libMesh::Real>& omega_dot )
+  {
+    Antioch::TempCache<libMesh::Real> temp_cache(T);
+    this->omega_dot(temp_cache,rho,mass_fractions,omega_dot);
+  }
+
   void AntiochKinetics::omega_dot( const Antioch::TempCache<libMesh::Real>& temp_cache,
                                    const libMesh::Real rho,
                                    const std::vector<libMesh::Real>& mass_fractions,

--- a/src/properties/src/antioch_mixture.C
+++ b/src/properties/src/antioch_mixture.C
@@ -62,13 +62,6 @@ namespace GRINS
     Antioch::read_cea_mixture_data_ascii( *_cea_mixture.get(), cea_data_filename );
 
     this->build_stat_mech_ref_correction();
-
-    return;
-  }
-
-  AntiochMixture::~AntiochMixture()
-  {
-    return;
   }
 
   void AntiochMixture::build_stat_mech_ref_correction()
@@ -81,8 +74,6 @@ namespace GRINS
       {
         _h_stat_mech_ref_correction[s] = -thermo.h_tot( s, 298.15 ) + thermo.e_0(s);
       }
-
-    return;
   }
 
 }// end namespace GRINS

--- a/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
@@ -43,38 +43,6 @@ namespace GRINS
   {}
 
   template<typename Th, typename V, typename C, typename D>
-  libMesh::Real AntiochMixtureAveragedTransportEvaluator<Th,V,C,D>::mu( const CachedValues& cache, unsigned int qp )
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    // Second T is dummy
-    return this->mu( T, T, Y );
-  }
-
-  template<typename Th, typename V, typename C, typename D>
-  libMesh::Real AntiochMixtureAveragedTransportEvaluator<Th,V,C,D>::k( const CachedValues& cache, unsigned int qp )
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    // Second T is dummy
-    return this->k( T, T, Y );
-  }
-
-  template<typename Th, typename V, typename C, typename D>
-  void AntiochMixtureAveragedTransportEvaluator<Th,V,C,D>::mu_and_k( const CachedValues& cache, unsigned int qp,
-                                                                     libMesh::Real& mu, libMesh::Real& k )
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    libmesh_error();
-    //_wilke_evaluator->mu_and_k( T, Y, mu, k );
-    return;
-  }
-
-  template<typename Th, typename V, typename C, typename D>
   libMesh::Real AntiochMixtureAveragedTransportEvaluator<Th,V,C,D>::mu( const libMesh::Real T,
                                                                         const libMesh::Real /*P*/,
                                                                         const std::vector<libMesh::Real>& Y )

--- a/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
@@ -92,20 +92,6 @@ namespace GRINS
   }
 
   template<typename Th, typename V, typename C, typename Diff>
-  void AntiochMixtureAveragedTransportEvaluator<Th,V,C,Diff>::D( const libMesh::Real T,
-                                                                 const libMesh::Real rho,
-                                                                 const libMesh::Real cp,
-                                                                 const std::vector<libMesh::Real>& Y,
-                                                                 std::vector<libMesh::Real>& D )
-  {
-    libMesh::Real dummy = 0.0;
-    typename Antioch::MixtureAveragedTransportEvaluator<Diff,V,C,libMesh::Real>::DiffusivityType
-      diff_type = Antioch::MixtureAveragedTransportEvaluator<Diff,V,C,libMesh::Real>::DiffusivityType::MASS_FLUX_MASS_FRACTION;
-
-    _wilke_evaluator->mu_and_k_and_D( T, rho, cp, Y, dummy, dummy, D, diff_type);
-  }
-
-  template<typename Th, typename V, typename C, typename Diff>
   void AntiochMixtureAveragedTransportEvaluator<Th,V,C,Diff>::mu_and_k_and_D( const libMesh::Real T,
                                                                               const libMesh::Real rho,
                                                                               const libMesh::Real cp,

--- a/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
@@ -69,6 +69,7 @@ namespace GRINS
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
 
+    libmesh_error();
     //_wilke_evaluator->mu_and_k( T, Y, mu, k );
     return;
   }
@@ -86,6 +87,7 @@ namespace GRINS
                                                                        const libMesh::Real P,
                                                                        const std::vector<libMesh::Real>& Y )
   {
+    libmesh_error();
     return 0.0;//_wilke_evaluator->k( T, Y );
   }
 

--- a/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
@@ -48,7 +48,8 @@ namespace GRINS
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
 
-    return this->mu( T, Y );
+    // Second T is dummy
+    return this->mu( T, T, Y );
   }
 
   template<typename Th, typename V, typename C, typename D>
@@ -57,7 +58,8 @@ namespace GRINS
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
 
-    return this->k( T, Y );
+    // Second T is dummy
+    return this->k( T, T, Y );
   }
 
   template<typename Th, typename V, typename C, typename D>
@@ -73,6 +75,7 @@ namespace GRINS
 
   template<typename Th, typename V, typename C, typename D>
   libMesh::Real AntiochMixtureAveragedTransportEvaluator<Th,V,C,D>::mu( const libMesh::Real T,
+                                                                        const libMesh::Real /*P*/,
                                                                         const std::vector<libMesh::Real>& Y )
   {
     return _wilke_evaluator->mu( T, Y );
@@ -80,6 +83,7 @@ namespace GRINS
 
   template<typename Th, typename V, typename C, typename D>
   libMesh::Real AntiochMixtureAveragedTransportEvaluator<Th,V,C,D>::k( const libMesh::Real T,
+                                                                       const libMesh::Real P,
                                                                        const std::vector<libMesh::Real>& Y )
   {
     return 0.0;//_wilke_evaluator->k( T, Y );

--- a/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
@@ -40,15 +40,7 @@ namespace GRINS
     : AntiochEvaluator<Thermo>( mixture ),
     _wilke_evaluator( new Antioch::MixtureAveragedTransportEvaluator<Diffusivity,Viscosity,Conductivity,libMesh::Real>( mixture.wilke_mixture(), mixture.diffusivity(), mixture.viscosity(), mixture.conductivity() ) ),
     _diffusivity( mixture.diffusivity() )
-  {
-    return;
-  }
-
-  template<typename T, typename V, typename C, typename D>
-  AntiochMixtureAveragedTransportEvaluator<T,V,C,D>::~AntiochMixtureAveragedTransportEvaluator()
-  {
-    return;
-  }
+  {}
 
   template<typename Th, typename V, typename C, typename D>
   libMesh::Real AntiochMixtureAveragedTransportEvaluator<Th,V,C,D>::mu( const CachedValues& cache, unsigned int qp )

--- a/src/properties/src/cantera_evaluator.C
+++ b/src/properties/src/cantera_evaluator.C
@@ -45,11 +45,6 @@ namespace GRINS
     return;
   }
 
-  CanteraEvaluator::~CanteraEvaluator()
-  {
-    return;
-  }
-
 } // end namespace GRINS
 
 #endif //GRINS_HAVE_CANTERA

--- a/src/properties/src/cantera_kinetics.C
+++ b/src/properties/src/cantera_kinetics.C
@@ -47,15 +47,7 @@ namespace GRINS
 
   CanteraKinetics::CanteraKinetics( CanteraMixture& mixture )
     :  _cantera_gas( mixture.get_chemistry() )
-  {
-    return;
-  }
-
-  CanteraKinetics::~CanteraKinetics()
-  {
-    return;
-  }
-
+  {}
   void CanteraKinetics::omega_dot( const CachedValues& cache,
 				   unsigned int qp,
 				   std::vector<libMesh::Real>& omega_dot ) const

--- a/src/properties/src/cantera_kinetics.C
+++ b/src/properties/src/cantera_kinetics.C
@@ -48,78 +48,10 @@ namespace GRINS
   CanteraKinetics::CanteraKinetics( CanteraMixture& mixture )
     :  _cantera_gas( mixture.get_chemistry() )
   {}
-  void CanteraKinetics::omega_dot( const CachedValues& cache,
-				   unsigned int qp,
-				   std::vector<libMesh::Real>& omega_dot ) const
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
 
-    this->omega_dot_TPY( T, P, Y, omega_dot );
-
-    return;
-  }
-
-  void CanteraKinetics::omega_dot_TPY( const libMesh::Real T, const libMesh::Real P,
-                                       const std::vector<libMesh::Real>& mass_fractions,
-                                       std::vector<libMesh::Real>& omega_dot ) const
-  {
-    libmesh_assert_equal_to( mass_fractions.size(), omega_dot.size() );
-    libmesh_assert_equal_to( mass_fractions.size(), _cantera_gas.nSpecies() );
-    libmesh_assert_greater(T,0.0);
-    libmesh_assert_greater(P,0.0);
-    
-    {
-      /*! \todo Need to make sure this will work in a threaded environment.
-	Not sure if we will get thread lock here or not. */
-      libMesh::Threads::spin_mutex::scoped_lock lock(cantera_mutex);
-      
-      try
-	{
-	  _cantera_gas.setState_TPY(T, P, &mass_fractions[0]);
-	  _cantera_gas.getNetProductionRates(&omega_dot[0]);
-	}
-      catch(Cantera::CanteraError)
-	{
-	  Cantera::showErrors(std::cerr);
-	  libmesh_error();
-	}
-    }
-
-#ifdef DEBUG
-    for( unsigned int s = 0; s < omega_dot.size(); s++ )
-      {
-        if( libMesh::libmesh_isnan(omega_dot[s]) )
-          {
-            std::cout << "T = " << T << std::endl
-                      << "P = " << P << std::endl;
-            for( unsigned int s = 0; s < omega_dot.size(); s++ )
-              {
-                std::cout << "Y[" << s << "] = " << mass_fractions[s] << std::endl;
-              }
-            for( unsigned int s = 0; s < omega_dot.size(); s++ )
-              {
-                std::cout << "omega_dot[" << s << "] = " << omega_dot[s] << std::endl;
-              }
-
-            libmesh_error();
-          }
-      }
-#endif
-
-    for( unsigned int s = 0; s < omega_dot.size(); s++ )
-      {
-        // convert [kmol/m^3-s] to [kg/m^3-s]
-        omega_dot[s] *= this->_cantera_gas.molecularWeight(s);
-      }
-
-    return;
-  }
-
-  void CanteraKinetics::omega_dot_TRY( const libMesh::Real& T, const libMesh::Real rho,
-                                       const std::vector<libMesh::Real>& mass_fractions,
-                                       std::vector<libMesh::Real>& omega_dot ) const
+  void CanteraKinetics::omega_dot( const libMesh::Real& T, const libMesh::Real rho,
+                                   const std::vector<libMesh::Real>& mass_fractions,
+                                   std::vector<libMesh::Real>& omega_dot ) const
   {
     libmesh_assert_equal_to( mass_fractions.size(), omega_dot.size() );
     libmesh_assert_equal_to( mass_fractions.size(), _cantera_gas.nSpecies() );

--- a/src/properties/src/cantera_thermo.C
+++ b/src/properties/src/cantera_thermo.C
@@ -43,14 +43,7 @@ namespace GRINS
   CanteraThermodynamics::CanteraThermodynamics( CanteraMixture& mixture )
     : _cantera_mixture(mixture),
       _cantera_gas(mixture.get_chemistry())
-  {
-    return;
-  }
-
-  CanteraThermodynamics::~CanteraThermodynamics()
-  {
-    return;
-  }
+  {}
 
   libMesh::Real CanteraThermodynamics::cp( const CachedValues& cache, unsigned int qp ) const
   {

--- a/src/properties/src/cantera_thermo.C
+++ b/src/properties/src/cantera_thermo.C
@@ -45,7 +45,7 @@ namespace GRINS
       _cantera_gas(mixture.get_chemistry())
   {}
 
-  libMesh::Real CanteraThermodynamics::cp( const CachedValues& cache, unsigned int qp ) const
+  libMesh::Real CanteraThermodynamics::cp( const CachedValues& cache, unsigned int qp )
   {
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
@@ -56,7 +56,7 @@ namespace GRINS
 
   libMesh::Real CanteraThermodynamics::cp( const libMesh::Real& T,
                                            const libMesh::Real P,
-                                           const std::vector<libMesh::Real>& Y ) const
+                                           const std::vector<libMesh::Real>& Y )
   {
     libmesh_assert_equal_to( Y.size(), _cantera_gas.nSpecies() );
 
@@ -84,7 +84,7 @@ namespace GRINS
     return cp;
   }
 
-  libMesh::Real CanteraThermodynamics::cv( const CachedValues& cache, unsigned int qp ) const
+  libMesh::Real CanteraThermodynamics::cv( const CachedValues& cache, unsigned int qp )
   {
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
@@ -95,7 +95,7 @@ namespace GRINS
 
   libMesh::Real CanteraThermodynamics::cv( const libMesh::Real& T,
                                            const libMesh::Real P,
-                                           const std::vector<libMesh::Real>& Y ) const
+                                           const std::vector<libMesh::Real>& Y )
   {
     libmesh_assert_equal_to( Y.size(), _cantera_gas.nSpecies() );
 
@@ -124,7 +124,7 @@ namespace GRINS
   }
 
   libMesh::Real CanteraThermodynamics::h( const CachedValues& cache, unsigned int qp,
-				 unsigned int species ) const
+				 unsigned int species )
   {
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
@@ -157,7 +157,7 @@ namespace GRINS
   }
 
   void CanteraThermodynamics::h( const CachedValues& cache, unsigned int qp,
-				 std::vector<libMesh::Real>& h) const
+				 std::vector<libMesh::Real>& h)
   {
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
@@ -191,9 +191,10 @@ namespace GRINS
     }
 
     return;
+
   }
 
-  libMesh::Real CanteraThermodynamics::h( const libMesh::Real& T, unsigned int species ) const
+  libMesh::Real CanteraThermodynamics::h( const libMesh::Real& T, unsigned int species )
   {
     std::vector<libMesh::Real> h_RT( _cantera_gas.nSpecies(), 0.0 );
 

--- a/src/properties/src/cantera_thermo.C
+++ b/src/properties/src/cantera_thermo.C
@@ -50,7 +50,14 @@ namespace GRINS
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
     const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-    
+
+    return this->cp(T,P,Y);
+  }
+
+  libMesh::Real CanteraThermodynamics::cp( const libMesh::Real& T,
+                                           const libMesh::Real P,
+                                           const std::vector<libMesh::Real>& Y ) const
+  {
     libmesh_assert_equal_to( Y.size(), _cantera_gas.nSpecies() );
 
     libMesh::Real cp = 0.0;
@@ -82,7 +89,14 @@ namespace GRINS
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
     const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-    
+
+    return this->cv(T,P,Y);
+  }
+
+  libMesh::Real CanteraThermodynamics::cv( const libMesh::Real& T,
+                                           const libMesh::Real P,
+                                           const std::vector<libMesh::Real>& Y ) const
+  {
     libmesh_assert_equal_to( Y.size(), _cantera_gas.nSpecies() );
 
     libMesh::Real cv = 0.0;

--- a/src/properties/src/cantera_transport.C
+++ b/src/properties/src/cantera_transport.C
@@ -127,43 +127,6 @@ namespace GRINS
     return k;
   }
 
-  void CanteraTransport::D( const CachedValues& cache, unsigned int qp,
-			    std::vector<libMesh::Real>& D )
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    this->D(T,P,Y,D);
-  }
-
-  void CanteraTransport::D( const libMesh::Real& T,
-                            const libMesh::Real P,
-                            const std::vector<libMesh::Real>& Y,
-                            std::vector<libMesh::Real>& D )
-  {
-    libmesh_assert_equal_to( Y.size(), D.size() );
-    libmesh_assert_equal_to( Y.size(), _cantera_gas.nSpecies() );
-
-    {
-      libMesh::Threads::spin_mutex::scoped_lock lock(cantera_mutex);
-    
-      /*! \todo Need to make sure this will work in a threaded environment.
-	Not sure if we will get thread lock here or not. */
-      try
-	{
-	  _cantera_gas.setState_TPY(T, P, &Y[0]);
-	  _cantera_transport.getMixDiffCoeffsMass(&D[0]);
-	}
-      catch(Cantera::CanteraError)
-	{
-	  Cantera::showErrors(std::cerr);
-	  libmesh_error();
-	}
-
-    }
-  }
-
   void CanteraTransport::mu_and_k_and_D( const libMesh::Real T,
                                          const libMesh::Real rho,
                                          const libMesh::Real /*cp*/,

--- a/src/properties/src/cantera_transport.C
+++ b/src/properties/src/cantera_transport.C
@@ -51,7 +51,7 @@ namespace GRINS
       _cantera_transport( mixture.get_transport() )
   {}
 
-  libMesh::Real CanteraTransport::mu( const CachedValues& cache, unsigned int qp ) const
+  libMesh::Real CanteraTransport::mu( const CachedValues& cache, unsigned int qp )
   {
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
@@ -82,7 +82,7 @@ namespace GRINS
     return mu;
   }
 
-  libMesh::Real CanteraTransport::k( const CachedValues& cache, unsigned int qp ) const
+  libMesh::Real CanteraTransport::k( const CachedValues& cache, unsigned int qp )
   {
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
@@ -114,7 +114,7 @@ namespace GRINS
   }
 
   void CanteraTransport::D( const CachedValues& cache, unsigned int qp,
-			    std::vector<libMesh::Real>& D ) const
+			    std::vector<libMesh::Real>& D )
   {
     const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];

--- a/src/properties/src/cantera_transport.C
+++ b/src/properties/src/cantera_transport.C
@@ -57,6 +57,13 @@ namespace GRINS
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
     const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
 
+    return this->mu(T,P,Y);
+  }
+
+  libMesh::Real CanteraTransport::mu( const libMesh::Real& T,
+                                      const libMesh::Real P,
+                                      const std::vector<libMesh::Real>& Y )
+  {
     libmesh_assert_equal_to( Y.size(), _cantera_gas.nSpecies() );
 
     libMesh::Real mu = 0.0;
@@ -88,6 +95,13 @@ namespace GRINS
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
     const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
 
+    return this->k(T,P,Y);
+  }
+
+  libMesh::Real CanteraTransport::k( const libMesh::Real& T,
+                                     const libMesh::Real P,
+                                     const std::vector<libMesh::Real>& Y )
+  {
     libmesh_assert_equal_to( Y.size(), _cantera_gas.nSpecies() );
 
     libMesh::Real k = 0.0;
@@ -120,6 +134,14 @@ namespace GRINS
     const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
     const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
 
+    this->D(T,P,Y,D);
+  }
+
+  void CanteraTransport::D( const libMesh::Real& T,
+                            const libMesh::Real P,
+                            const std::vector<libMesh::Real>& Y,
+                            std::vector<libMesh::Real>& D )
+  {
     libmesh_assert_equal_to( Y.size(), D.size() );
     libmesh_assert_equal_to( Y.size(), _cantera_gas.nSpecies() );
 
@@ -140,8 +162,6 @@ namespace GRINS
 	}
 
     }
-
-    return;
   }
 
   void CanteraTransport::mu_and_k_and_D( const libMesh::Real T,

--- a/src/properties/src/cantera_transport.C
+++ b/src/properties/src/cantera_transport.C
@@ -165,7 +165,8 @@ namespace GRINS
   }
 
   void CanteraTransport::mu_and_k_and_D( const libMesh::Real T,
-                                         const libMesh::Real P,
+                                         const libMesh::Real rho,
+                                         const libMesh::Real /*cp*/,
                                          const std::vector<libMesh::Real>& Y,
                                          libMesh::Real& mu, libMesh::Real& k,
                                          std::vector<libMesh::Real>& D )
@@ -176,7 +177,7 @@ namespace GRINS
 	Not sure if we will get thread lock here or not. */
       try
 	{
-	  _cantera_gas.setState_TPY(T, P, &Y[0]);
+	  _cantera_gas.setState_TRY(T, rho, &Y[0]);
 
           mu =  _cantera_transport.viscosity();
           k =  _cantera_transport.thermalConductivity();

--- a/src/properties/src/cantera_transport.C
+++ b/src/properties/src/cantera_transport.C
@@ -51,15 +51,6 @@ namespace GRINS
       _cantera_transport( mixture.get_transport() )
   {}
 
-  libMesh::Real CanteraTransport::mu( const CachedValues& cache, unsigned int qp )
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    return this->mu(T,P,Y);
-  }
-
   libMesh::Real CanteraTransport::mu( const libMesh::Real& T,
                                       const libMesh::Real P,
                                       const std::vector<libMesh::Real>& Y )
@@ -87,15 +78,6 @@ namespace GRINS
     }
 
     return mu;
-  }
-
-  libMesh::Real CanteraTransport::k( const CachedValues& cache, unsigned int qp )
-  {
-    const libMesh::Real T = cache.get_cached_values(Cache::TEMPERATURE)[qp];
-    const libMesh::Real P = cache.get_cached_values(Cache::THERMO_PRESSURE)[qp];
-    const std::vector<libMesh::Real>& Y = cache.get_cached_vector_values(Cache::MASS_FRACTIONS)[qp];
-
-    return this->k(T,P,Y);
   }
 
   libMesh::Real CanteraTransport::k( const libMesh::Real& T,

--- a/src/properties/src/cantera_transport.C
+++ b/src/properties/src/cantera_transport.C
@@ -49,14 +49,7 @@ namespace GRINS
   CanteraTransport::CanteraTransport( CanteraMixture& mixture )
     : _cantera_gas( mixture.get_chemistry() ),
       _cantera_transport( mixture.get_transport() )
-  {
-    return;
-  }
-
-  CanteraTransport::~CanteraTransport()
-  {
-    return;
-  }
+  {}
 
   libMesh::Real CanteraTransport::mu( const CachedValues& cache, unsigned int qp ) const
   {

--- a/test/interface/antioch_evaluator_regression.C
+++ b/test/interface/antioch_evaluator_regression.C
@@ -140,37 +140,21 @@ int test_evaluator( const GRINS::AntiochMixture& antioch_mixture )
 
   libMesh::Real R_mix = antioch_mixture.R_mix(Y);
 
-  GRINS::CachedValues cache;
-
-  cache.add_quantity(GRINS::Cache::TEMPERATURE);
-  std::vector<double> Tqp(1,T);
-  cache.set_values(GRINS::Cache::TEMPERATURE, Tqp);
-
-  cache.add_quantity(GRINS::Cache::MIXTURE_DENSITY);
-  std::vector<double> rhoqp(1,rho);
-  cache.set_values(GRINS::Cache::MIXTURE_DENSITY, rhoqp);
-
-  cache.add_quantity(GRINS::Cache::MIXTURE_GAS_CONSTANT);
-  std::vector<double> Rqp(1,R_mix);
-  cache.set_values(GRINS::Cache::MIXTURE_GAS_CONSTANT, Rqp);
-
-  cache.add_quantity(GRINS::Cache::MASS_FRACTIONS);
-  std::vector<std::vector<double> > Yqp(1,Y);
-  cache.set_vector_values(GRINS::Cache::MASS_FRACTIONS, Yqp);
+  libMesh::Real P = rho*R_mix*T;
 
   std::vector<libMesh::Real> omega_dot(n_species,0.0);
 
-  libMesh::Real cp =  antioch_evaluator.cp( cache, 0 );
+  libMesh::Real cp =  antioch_evaluator.cp( T, P, Y );
 
   std::cout << std::scientific << std::setprecision(16)
             << "cp = " << cp << std::endl;
 
-  libMesh::Real cv =  antioch_evaluator.cv( cache, 0 );
+  libMesh::Real cv =  antioch_evaluator.cv( T, P, Y );
 
   std::cout << std::scientific << std::setprecision(16)
             << "cv = " << cv << std::endl;
 
-  libMesh::Real h_s =  antioch_evaluator.h_s( cache, 0, 0 );
+  libMesh::Real h_s =  antioch_evaluator.h_s( T, 0 );
 
   std::cout << std::scientific << std::setprecision(16)
             << "h_s = " << h_s << std::endl;
@@ -187,7 +171,7 @@ int test_evaluator( const GRINS::AntiochMixture& antioch_mixture )
   return_flag_temp = test_h_s<Thermo>( h_s );
   if( return_flag_temp != 0 ) return_flag = 1;
 
-  antioch_evaluator.omega_dot( cache, 0, omega_dot );
+  antioch_evaluator.omega_dot( T, rho, Y, omega_dot );
 
   for( unsigned int i = 0; i < n_species; i++ )
     {

--- a/test/interface/antioch_mixture_averaged_transport_evaluator_regression.C
+++ b/test/interface/antioch_mixture_averaged_transport_evaluator_regression.C
@@ -128,11 +128,12 @@ int test_evaluator( const GetPot& input )
 
   std::vector<libMesh::Real> Y(n_species,0.2);
 
+  libMesh::Real p0 = rho*T*evaluator.R_mix(Y);
   libMesh::Real mu = 0.0;
   libMesh::Real k = 0.0;
   std::vector<libMesh::Real> D(n_species,0.0);
 
-  evaluator.mu_and_k_and_D( T, rho, evaluator.cp(T,Y), Y, mu, k, D );
+  evaluator.mu_and_k_and_D( T, rho, evaluator.cp(T,p0,Y), Y, mu, k, D );
 
   std::cout << std::scientific << std::setprecision(16)
             << "mu = " << mu << std::endl;

--- a/test/interface/cantera_chem_thermo_test.C
+++ b/test/interface/cantera_chem_thermo_test.C
@@ -71,30 +71,18 @@ int main(int argc, char* argv[])
 
   std::vector<double> Y(5,0.2);
 
-  GRINS::CachedValues cache;
-
-  cache.add_quantity(GRINS::Cache::TEMPERATURE);
-  cache.add_quantity(GRINS::Cache::THERMO_PRESSURE);
-  cache.add_quantity(GRINS::Cache::MASS_FRACTIONS);
-
-  std::vector<double> Tqp(1,T);
-  std::vector<double> Pqp(1,P);
-  std::vector<std::vector<double> > Yqp(1,Y);
-
-  cache.set_values(GRINS::Cache::TEMPERATURE, Tqp);
-  cache.set_values(GRINS::Cache::THERMO_PRESSURE, Pqp);
-  cache.set_vector_values(GRINS::Cache::MASS_FRACTIONS, Yqp);
+  double rho = P/T/cantera_mixture.R_mix(Y);
 
   std::vector<double> omega_dot(5,0.0);
-  
-  cantera_kinetics.omega_dot(cache,0,omega_dot);
-  
-  const double cv = cantera_thermo.cv( cache, 0 );
-  const double cp = cantera_thermo.cp( cache, 0 );
+
+  cantera_kinetics.omega_dot(T, rho, Y, omega_dot);
+
+  const double cv = cantera_thermo.cv( T, P, Y );
+  const double cp = cantera_thermo.cp( T, P, Y );
 
   std::vector<double> h(5,0.0);
-
-  cantera_thermo.h(cache,0,h);
+  for( unsigned int s = 0; s < 5; s++ )
+    h[s] = cantera_thermo.h( T, s );
 
   cantera.setState_TPY(T,P,&Y[0]);
   const double e = cantera.intEnergy_mass();

--- a/test/interface/cantera_evaluator_regression.C
+++ b/test/interface/cantera_evaluator_regression.C
@@ -59,6 +59,8 @@ int main(int argc, char* argv[])
 
   std::vector<double> Y(5,0.2);
 
+  double rho = P/T/gas.R_mix(Y);
+
   GRINS::CachedValues cache;
 
   cache.add_quantity(GRINS::Cache::TEMPERATURE);
@@ -80,12 +82,10 @@ int main(int argc, char* argv[])
   const double cv = gas.cv( cache, 0 );
   const double cp = gas.cp( cache, 0 );
 
-  const double mu = gas.mu( cache, 0 );
-  const double k = gas.k( cache, 0 );
-  
+  double mu, k;
   std::vector<libMesh::Real> D(5,0.0);
 
-  gas.D( cache, 0, D );
+  gas.mu_and_k_and_D( T, rho, cp, Y, mu, k, D );
 
   std::vector<double> h(5,0.0);
   gas.h_s( cache, 0, h );

--- a/test/interface/cantera_evaluator_regression.C
+++ b/test/interface/cantera_evaluator_regression.C
@@ -61,26 +61,12 @@ int main(int argc, char* argv[])
 
   double rho = P/T/gas.R_mix(Y);
 
-  GRINS::CachedValues cache;
-
-  cache.add_quantity(GRINS::Cache::TEMPERATURE);
-  cache.add_quantity(GRINS::Cache::THERMO_PRESSURE);
-  cache.add_quantity(GRINS::Cache::MASS_FRACTIONS);
-
-  std::vector<double> Tqp(1,T);
-  std::vector<double> Pqp(1,P);
-  std::vector<std::vector<double> > Yqp(1,Y);
-
-  cache.set_values(GRINS::Cache::TEMPERATURE, Tqp);
-  cache.set_values(GRINS::Cache::THERMO_PRESSURE, Pqp);
-  cache.set_vector_values(GRINS::Cache::MASS_FRACTIONS, Yqp);
-
   std::vector<double> omega_dot(5,0.0);
 
-  gas.omega_dot( cache, 0, omega_dot );
+  gas.omega_dot( T, rho, Y, omega_dot );
 
-  const double cv = gas.cv( cache, 0 );
-  const double cp = gas.cp( cache, 0 );
+  const double cv = gas.cv( T, P, Y );
+  const double cp = gas.cp( T, P, Y );
 
   double mu, k;
   std::vector<libMesh::Real> D(5,0.0);
@@ -88,7 +74,8 @@ int main(int argc, char* argv[])
   gas.mu_and_k_and_D( T, rho, cp, Y, mu, k, D );
 
   std::vector<double> h(5,0.0);
-  gas.h_s( cache, 0, h );
+  for( unsigned int s = 0; s < 5; s++ )
+    h[s] = gas.h_s( T, s );
 
   int return_flag = 0;
   

--- a/test/interface/cantera_transport_regression.C
+++ b/test/interface/cantera_transport_regression.C
@@ -67,6 +67,8 @@ int main(int argc, char* argv[])
 
   std::vector<double> Y(5,0.2);
 
+  double rho = P/T/cantera_mixture.R_mix(Y);
+
   GRINS::CachedValues cache;
 
   cache.add_quantity(GRINS::Cache::TEMPERATURE);
@@ -81,12 +83,12 @@ int main(int argc, char* argv[])
   cache.set_values(GRINS::Cache::THERMO_PRESSURE, Pqp);
   cache.set_vector_values(GRINS::Cache::MASS_FRACTIONS, Yqp);
 
-  const double mu = cantera_trans.mu(cache,0);
-  const double k = cantera_trans.k(cache,0);
-  
+  double mu, k;
   std::vector<libMesh::Real> D(5,0.0);
 
-  cantera_trans.D(cache, 0, D);
+  double dummy = 0.0;
+
+  cantera_trans.mu_and_k_and_D( T, rho, dummy, Y, mu, k, D );
 
   int return_flag = 0;
 


### PR DESCRIPTION
Completely reworked the Mixture/Evaluator interface for Antioch and Cantera that's mainly by the reacting low Mach `Physics`. Got rid of the (stupid) `CachedValues` interface there. I'm still not very happy with this, but it's a step in a better direction.