### PR TITLE
Check T^2 in AntiochEvaluator::check_and_reset_temp_cache

### DIFF
--- a/src/properties/include/grins/antioch_evaluator.h
+++ b/src/properties/include/grins/antioch_evaluator.h
@@ -198,7 +198,9 @@ namespace GRINS
   inline
   void AntiochEvaluator<Thermo>::check_and_reset_temp_cache( const libMesh::Real& T )
   {
-    if( _temp_cache->T != T )
+    // We can't compare T because it's a reference, so we may have already
+    // changed it upstream. So, we compare the next cheapest thing.
+    if( _temp_cache->T2 != T*T )
       _temp_cache.reset( new Antioch::TempCache<libMesh::Real>(T) );
   }
 


### PR DESCRIPTION
Before, we were checking just T. However, in both the cache and
the argument coming in, T is a reference. So, if T changed upstream,
then the expression evals to true even though we need to rebuild
the TempCache. So, we'll check the next cheapest thing, which is T^2.
This didn't bite us in the PDE solves because we actually had different
addresses for T when constructing this, but it would produce incorrect
results from the thermo apps. Picked up on this in a separate branch
where I'm adding CppUnit-based tests of the thermochemistry interfaces.

This is really a symptom of a bad design decision, I think. What I think we should do is make a "compute all the things for reacting low Mach Navier-Stokes" method and remove this function entirely. Then, if the user wants to use the single functions themselves, they can worry about constructing the `Antioch::TempCache` themselves. But that's for another day.

Would like to merge this quickly.