### PR TITLE
Add CppUnit Optional Testing Dependency, Update Thermo Interface Tests to Use CppUnit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -306,6 +306,17 @@ AM_CONDITIONAL(CANTERA_ENABLED,test x$HAVE_CANTERA = x1)
 
 AX_PATH_ANTIOCH(0.4.0,no)
 
+# -------------------------------------------------------------
+# cppunit C++ unit testing -- enabled by default
+# -------------------------------------------------------------
+AC_ARG_ENABLE(cppunit,
+              AS_HELP_STRING([--disable-cppunit],
+                             [Build without cppunit C++ unit testing support]))
+AS_IF([test "x$enable_cppunit" != "xno"], [
+   AM_PATH_CPPUNIT([1.10.0],[enablecppunit=yes],[enablecppunit=no])
+])
+
+AM_CONDITIONAL(GRINS_ENABLE_CPPUNIT, test x$enablecppunit = xyes)
 
 dnl-------------------
 dnl Check for TRILINOS

--- a/configure.ac
+++ b/configure.ac
@@ -401,6 +401,11 @@ AC_CONFIG_LINKS([test/input_files/air_5sp_test.xml:test/input_files/air_5sp_test
 AC_CONFIG_LINKS([test/input_files/air.xml:test/input_files/air.xml])
 AC_CONFIG_LINKS([test/input_files/elements.xml:test/input_files/elements.xml])
 
+dnl----------------------------------------------
+dnl Generate header with paths for use in testing
+dnl----------------------------------------------
+AC_CONFIG_FILES(test/common/grins_test_paths.h)
+
 dnl-----------------------------------------------
 dnl Generate run scripts for examples
 dnl-----------------------------------------------

--- a/doxygen/grins.dox.in
+++ b/doxygen/grins.dox.in
@@ -1264,7 +1264,8 @@ INCLUDE_FILE_PATTERNS  =
 # instead of the = operator.
 
 PREDEFINED             = GRINS_HAVE_ANTIOCH \
-                         GRINS_HAVE_CANTERA
+                         GRINS_HAVE_CANTERA \
+                         GRINS_HAVE_CPPUNIT
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then 
 # this tag can be used to specify a list of macro names that should be expanded. 

--- a/m4/common/cppunit.m4
+++ b/m4/common/cppunit.m4
@@ -1,0 +1,98 @@
+dnl
+dnl AM_PATH_CPPUNIT(MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]])
+dnl
+AC_DEFUN([AM_PATH_CPPUNIT],
+[
+
+AC_ARG_WITH(cppunit-prefix,[  --with-cppunit-prefix=PFX   Prefix where CppUnit is installed (optional)],
+            cppunit_config_prefix="$withval", cppunit_config_prefix="")
+AC_ARG_WITH(cppunit-exec-prefix,[  --with-cppunit-exec-prefix=PFX  Exec prefix where CppUnit is installed (optional)],
+            cppunit_config_exec_prefix="$withval", cppunit_config_exec_prefix="")
+
+  if test x$cppunit_config_exec_prefix != x ; then
+     cppunit_config_args="$cppunit_config_args --exec-prefix=$cppunit_config_exec_prefix"
+     if test x${CPPUNIT_CONFIG+set} != xset ; then
+        CPPUNIT_CONFIG=$cppunit_config_exec_prefix/bin/cppunit-config
+     fi
+  fi
+  if test x$cppunit_config_prefix != x ; then
+     cppunit_config_args="$cppunit_config_args --prefix=$cppunit_config_prefix"
+     if test x${CPPUNIT_CONFIG+set} != xset ; then
+        CPPUNIT_CONFIG=$cppunit_config_prefix/bin/cppunit-config
+     fi
+  fi
+
+  AC_PATH_PROG(CPPUNIT_CONFIG, cppunit-config, no)
+  cppunit_version_min=$1
+
+  AC_MSG_CHECKING(for Cppunit - version >= $cppunit_version_min)
+  no_cppunit=""
+  if test "$CPPUNIT_CONFIG" = "no" ; then
+    AC_MSG_RESULT(no)
+    no_cppunit=yes
+  else
+    CPPUNIT_CPPFLAGS=`$CPPUNIT_CONFIG --cflags`
+    CPPUNIT_LIBS=`$CPPUNIT_CONFIG --libs`
+    CPPUNIT_VERSION=`$CPPUNIT_CONFIG --version`
+    CPPUNIT_PREFIX=`$CPPUNIT_CONFIG --prefix`
+    cppunit_version=`$CPPUNIT_CONFIG --version`
+
+    cppunit_major_version=`echo $cppunit_version | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
+    cppunit_minor_version=`echo $cppunit_version | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\2/'`
+    cppunit_micro_version=`echo $cppunit_version | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\3/'`
+
+    cppunit_major_min=`echo $cppunit_version_min | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
+    if test "x${cppunit_major_min}" = "x" ; then
+       cppunit_major_min=0
+    fi
+
+    cppunit_minor_min=`echo $cppunit_version_min | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\2/'`
+    if test "x${cppunit_minor_min}" = "x" ; then
+       cppunit_minor_min=0
+    fi
+
+    cppunit_micro_min=`echo $cppunit_version_min | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\3/'`
+    if test "x${cppunit_micro_min}" = "x" ; then
+       cppunit_micro_min=0
+    fi
+
+    cppunit_version_proper=`expr \
+        $cppunit_major_version \> $cppunit_major_min \| \
+        $cppunit_major_version \= $cppunit_major_min \& \
+        $cppunit_minor_version \> $cppunit_minor_min \| \
+        $cppunit_major_version \= $cppunit_major_min \& \
+        $cppunit_minor_version \= $cppunit_minor_min \& \
+        $cppunit_micro_version \>= $cppunit_micro_min `
+
+    if test "$cppunit_version_proper" = "1" ; then
+      AC_MSG_RESULT([$cppunit_major_version.$cppunit_minor_version.$cppunit_micro_version])
+    else
+      AC_MSG_RESULT(no)
+      no_cppunit=yes
+    fi
+  fi
+
+  if test "x$no_cppunit" = x ; then
+     ifelse([$2], , :, [$2])
+     AC_SUBST(HAVE_CPPUNIT,[1])
+     AC_DEFINE([HAVE_CPPUNIT], [1], [Enable CPPUnit Tests])
+  else
+     CPPUNIT_CPPFLAGS=""
+     CPPUNIT_LIBS=""
+     ifelse([$3], , :, [$3])
+  fi
+  
+  AC_SUBST(CPPUNIT_VERSION)
+  AC_SUBST(CPPUNIT_PREFIX)
+  AC_SUBST(CPPUNIT_CPPFLAGS)
+  AC_SUBST(CPPUNIT_LIBS)
+])
+
+
+

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -41,8 +41,16 @@ echo libMesh LIBS.................. : $LIBMESH_LIBS
 #echo HDF5.......................... : $HDF5_PREFIX
 #echo GSL........................... : $GSL_PREFIX
 #echo GLPK.......................... : $GLPK_PREFIX
-
-# masa optional check:
+echo
+echo Testing Options:
+if test "x$HAVE_CPPUNIT" = "x1"; then
+  echo '  'CppUnit..................... : yes
+  echo '    'CPPUNIT_VERSION........... : $CPPUNIT_VERSION
+  echo '    'CPPUNIT_CPPFLAGS.......... : $CPPUNIT_CPPFLAGS
+  echo '    'CPPUNIT_LIBS.............. : $CPPUNIT_LIBS
+else
+  echo '  'CppUnit..................... : no
+fi
 echo
 echo Optional Features:
 if test "x$HAVE_BOOST" = "x1"; then

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -22,6 +22,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/visualization/include
 AM_CPPFLAGS += -I$(top_srcdir)/test/interface
 AM_CPPFLAGS += -I$(top_builddir)/test/common
 AM_CPPFLAGS += -I$(top_srcdir)/test/common
+AM_CPPFLAGS += -I$(top_builddir)/test/common
 
 AM_CPPFLAGS += $(BOOST_CPPFLAGS)
 AM_CPPFLAGS += $(LIBMESH_CPPFLAGS)
@@ -123,7 +124,9 @@ power_law_catalycity_SOURCES = unit/power_law_catalycity.C
 split_string_SOURCES = unit/split_string.C
 
 # Interface test source files
-interface_cppunit_test_SOURCES = interface/interface_cppunit_test.C
+interface_cppunit_test_SOURCES = interface/interface_cppunit_test.C \
+                                 interface/antioch_thermo.C
+
 antioch_evaluator_regression_SOURCES = interface/antioch_evaluator_regression.C
 antioch_kinetics_regression_SOURCES = interface/antioch_kinetics_regression.C
 antioch_mixture_averaged_transport_evaluator_regression_SOURCES = interface/antioch_mixture_averaged_transport_evaluator_regression.C

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,6 +19,10 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/utilities/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/variables/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/visualization/include
 
+AM_CPPFLAGS += -I$(top_srcdir)/test/interface
+AM_CPPFLAGS += -I$(top_builddir)/test/common
+AM_CPPFLAGS += -I$(top_srcdir)/test/common
+
 AM_CPPFLAGS += $(BOOST_CPPFLAGS)
 AM_CPPFLAGS += $(LIBMESH_CPPFLAGS)
 AM_CPPFLAGS += $(GRVY_CFLAGS)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -125,7 +125,8 @@ split_string_SOURCES = unit/split_string.C
 
 # Interface test source files
 interface_cppunit_test_SOURCES = interface/interface_cppunit_test.C \
-                                 interface/antioch_thermo.C
+                                 interface/antioch_thermo.C \
+                                 interface/cantera_thermo.C
 
 antioch_evaluator_regression_SOURCES = interface/antioch_evaluator_regression.C
 antioch_kinetics_regression_SOURCES = interface/antioch_kinetics_regression.C

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -52,6 +52,14 @@ if MASA_ENABLED
   LIBS += $(MASA_LIBS)
 endif
 
+#----------------
+# CppUnit support
+#----------------
+if GRINS_ENABLE_CPPUNIT
+  AM_CPPFLAGS += $(CPPUNIT_CPPFLAGS)
+  LIBS += $(CPPUNIT_LIBS)
+endif
+
 # These are programs that need to be built in order to run
 # the various tests. They will be built with `make check`
 check_PROGRAMS =
@@ -68,6 +76,7 @@ check_PROGRAMS += power_law_catalycity
 check_PROGRAMS += split_string
 
 # Interface Tests
+check_PROGRAMS += interface_cppunit_test
 check_PROGRAMS += antioch_evaluator_regression
 check_PROGRAMS += antioch_kinetics_regression
 check_PROGRAMS += antioch_mixture_averaged_transport_evaluator_regression
@@ -110,6 +119,7 @@ power_law_catalycity_SOURCES = unit/power_law_catalycity.C
 split_string_SOURCES = unit/split_string.C
 
 # Interface test source files
+interface_cppunit_test_SOURCES = interface/interface_cppunit_test.C
 antioch_evaluator_regression_SOURCES = interface/antioch_evaluator_regression.C
 antioch_kinetics_regression_SOURCES = interface/antioch_kinetics_regression.C
 antioch_mixture_averaged_transport_evaluator_regression_SOURCES = interface/antioch_mixture_averaged_transport_evaluator_regression.C
@@ -165,6 +175,7 @@ TESTS += power_law_catalycity
 TESTS += split_string
 
 # Interface TESTS
+TESTS += interface_cppunit_test
 TESTS += interface/antioch_evaluator_regression.sh
 TESTS += interface/antioch_kinetics_regression.sh
 TESTS += interface/antioch_mixture_averaged_transport_evaluator_regression.sh

--- a/test/common/grins_test_paths.h.in
+++ b/test/common/grins_test_paths.h.in
@@ -1,0 +1,31 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_TEST_PATHS_H
+#define GRINS_TEST_PATHS_H
+
+#define GRINS_TEST_SRCDIR "@abs_top_srcdir@/test"
+#define GRINS_TEST_BUILDDIR "@abs_top_buiddir@/test"
+
+#endif // GRINS_TEST_PATHS_H

--- a/test/common/testing_utils.h
+++ b/test/common/testing_utils.h
@@ -1,0 +1,57 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_TESTING_UTILS_H
+#define GRINS_TESTING_UTILS_H
+
+// C++
+#include <limits>
+
+// libMesh
+#include "libmesh/libmesh_common.h"
+
+namespace GRINSTesting
+{
+  class TestingUtils
+  {
+  public:
+
+    //! Get absolute tolerance from input relative tol
+    /*! CppUnit uses absolute tolerance for double tests. This will
+        let the user input a relative tolerance and an exact value
+        to get back the corresponding absolute tolerance. */
+    static libMesh::Real abs_tol_from_rel_tol( libMesh::Real exact, libMesh::Real rel_tol )
+    {
+      return exact*rel_tol;
+    }
+
+    //! Convenience function
+    static libMesh::Real epsilon()
+    {
+      return std::numeric_limits<libMesh::Real>::epsilon();
+    }
+  };
+}
+
+#endif // GRINS_TESTING_UTILS_H

--- a/test/interface/air_nasa_poly_base.h
+++ b/test/interface/air_nasa_poly_base.h
@@ -87,6 +87,48 @@ namespace GRINSTesting
         }
     }
 
+    template<typename ThermoMixture, typename ThermoEvaluator>
+    void test_h_common( ThermoMixture& mixture, AirTestBase& testing_funcs, libMesh::Real rel_tol )
+    {
+      ThermoEvaluator evaluator( mixture );
+
+      libMesh::Real tol;
+
+      libMesh::Real T = 300;
+      while( T <= 1000 )
+        {
+          std::stringstream ss;
+          ss << T;
+          std::string message = "T = "+ss.str();
+
+          tol = TestingUtils::abs_tol_from_rel_tol( testing_funcs.h_exact(_N2_idx, T), rel_tol );
+          CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( message,
+                                                testing_funcs.h_exact(_N2_idx, T), /* exact */
+                                                evaluator.h_s( T, _N2_idx ), /* computed */
+                                                tol );
+
+          tol = TestingUtils::abs_tol_from_rel_tol( testing_funcs.h_exact(_O2_idx, T), rel_tol );
+          CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( message,
+                                                testing_funcs.h_exact(_O2_idx, T), /* exact */
+                                                evaluator.h_s( T, _O2_idx ), /* computed */
+                                                tol );
+
+          tol = TestingUtils::abs_tol_from_rel_tol( testing_funcs.h_exact(_NO_idx, T), rel_tol );
+          CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( message,
+                                                testing_funcs.h_exact(_NO_idx, T), /* exact */
+                                                evaluator.h_s( T, _NO_idx ), /* computed */
+                                                tol );
+
+          tol = TestingUtils::abs_tol_from_rel_tol( testing_funcs.h_exact(_O_idx, T), rel_tol );
+          CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( message,
+                                                testing_funcs.h_exact(_O_idx, T), /* exact */
+                                                evaluator.h_s( T, _O_idx ), /* computed */
+                                                tol );
+
+          T += 100.0;
+        }
+    }
+
   protected:
 
     virtual libMesh::Real cp_exact( unsigned int species_idx, libMesh::Real T ) = 0;

--- a/test/interface/air_nasa_poly_base.h
+++ b/test/interface/air_nasa_poly_base.h
@@ -1,0 +1,310 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_AIR_NASA_POLY_BASE_H
+#define GRINS_AIR_NASA_POLY_BASE_H
+
+// C++
+#include <vector>
+
+// libMesh
+#include "libmesh/libmesh_common.h"
+
+// GRINS
+#include "grins/physical_constants.h"
+
+#include "nasa_poly_test_base.h"
+
+namespace GRINSTesting
+{
+  class AirTestBase
+  {
+  public:
+
+
+
+  protected:
+
+    virtual libMesh::Real cp_exact( unsigned int species_idx, libMesh::Real T ) = 0;
+
+    virtual libMesh::Real h_exact( unsigned int species_idx, libMesh::Real T ) = 0;
+
+    libMesh::Real molar_mass( unsigned int idx )
+    {
+      libMesh::Real value = 0.0;
+
+      if(idx == _N2_idx)
+          value = 28.016;
+
+      else if( idx == _O2_idx)
+        value = 32.0;
+
+      else if( idx == _NO_idx)
+        value = 30.008;
+
+      else if(idx == _O_idx)
+        value = 16.0;
+
+      else
+        CPPUNIT_FAIL("Invalid idx for molar_mass");
+
+      return value;
+    }
+
+    libMesh::Real R_species( unsigned int idx )
+    {
+      return GRINS::Constants::R_universal/this->molar_mass(idx);
+    }
+
+    const std::vector<libMesh::Real>& nasa_coeffs( unsigned int idx )
+    {
+      if(idx == _N2_idx)
+        return _N2_200_1000_coeffs;
+
+      else if( idx == _O2_idx)
+        return _O2_200_1000_coeffs;
+
+      else if( idx == _NO_idx)
+        return _NO_200_1000_coeffs;
+
+      else if(idx == _O_idx)
+        return _O_200_1000_coeffs;
+
+      else
+        CPPUNIT_FAIL("Invalid idx for nasa_coeffs");
+
+      // dummy to avoid warning
+      return _N2_200_1000_coeffs;
+    }
+
+    // Species indices. Should be set by subclass at init time.
+    unsigned int _N2_idx, _O2_idx, _O_idx, _N_idx, _NO_idx;
+
+    std::vector<libMesh::Real> _N2_200_1000_coeffs;
+    std::vector<libMesh::Real> _O2_200_1000_coeffs;
+    std::vector<libMesh::Real> _O_200_1000_coeffs;
+    std::vector<libMesh::Real> _NO_200_1000_coeffs;
+  };
+
+  class AirNASA7TestBase : public AirTestBase,
+                           public NASA7TestBase
+  {
+  public:
+    AirNASA7TestBase()
+    {
+      this->init_N2_coeffs();
+      this->init_O2_coeffs();
+      this->init_O_coeffs();
+      this->init_NO_coeffs();
+    }
+
+  protected:
+
+    virtual libMesh::Real cp_exact( unsigned int species_idx, libMesh::Real T )
+    {
+      const std::vector<libMesh::Real> coeffs = this->nasa_coeffs(species_idx);
+      return this->cp_R_exact(T,
+                              coeffs[0],
+                              coeffs[1],
+                              coeffs[2],
+                              coeffs[3],
+                              coeffs[4])*this->R_species(species_idx);
+    }
+
+    virtual libMesh::Real h_exact( unsigned int species_idx, libMesh::Real T )
+    {
+      const std::vector<libMesh::Real> coeffs = this->nasa_coeffs(species_idx);
+      return this->h_RT_exact(T,
+                              coeffs[0],
+                              coeffs[1],
+                              coeffs[2],
+                              coeffs[3],
+                              coeffs[4],
+                              coeffs[5])*this->R_species(species_idx)*T;
+    }
+
+  private:
+
+    void init_N2_coeffs()
+    {
+      _N2_200_1000_coeffs.resize(7);
+
+      _N2_200_1000_coeffs[0] =  3.53100528E+00;
+      _N2_200_1000_coeffs[1] = -1.23660987E-04;
+      _N2_200_1000_coeffs[2] = -5.02999437E-07;
+      _N2_200_1000_coeffs[3] =  2.43530612E-09;
+      _N2_200_1000_coeffs[4] = -1.40881235E-12;
+      _N2_200_1000_coeffs[5] = -1.04697628E+03;
+      _N2_200_1000_coeffs[6] =  2.96747468E+00;
+    }
+
+    void init_O2_coeffs()
+    {
+      _O2_200_1000_coeffs.resize(7);
+
+      _O2_200_1000_coeffs[0] =  3.78245636E+00;
+      _O2_200_1000_coeffs[1] = -2.99673415E-03;
+      _O2_200_1000_coeffs[2] =  9.84730200E-06;
+      _O2_200_1000_coeffs[3] = -9.68129508E-09;
+      _O2_200_1000_coeffs[4] =  3.24372836E-12;
+      _O2_200_1000_coeffs[5] = -1.06394356E+03;
+      _O2_200_1000_coeffs[6] =  3.65767573E+00;
+    }
+
+    void init_O_coeffs()
+    {
+      _O_200_1000_coeffs.resize(7);
+
+      _O_200_1000_coeffs[0] =  3.16826710E+00;
+      _O_200_1000_coeffs[1] = -3.27931884E-03;
+      _O_200_1000_coeffs[2] =  6.64306396E-06;
+      _O_200_1000_coeffs[3] = -6.12806624E-09;
+      _O_200_1000_coeffs[4] =  2.11265971E-12;
+      _O_200_1000_coeffs[5] =  2.91222592E+04;
+      _O_200_1000_coeffs[6] =  2.05193346E+00;
+    }
+
+    void init_NO_coeffs()
+    {
+      _NO_200_1000_coeffs.resize(7);
+
+      _NO_200_1000_coeffs[0] =  4.21859896E+00;
+      _NO_200_1000_coeffs[1] = -4.63988124E-03;
+      _NO_200_1000_coeffs[2] =  1.10443049E-05;
+      _NO_200_1000_coeffs[3] = -9.34055507E-09;
+      _NO_200_1000_coeffs[4] =  2.80554874E-12;
+      _NO_200_1000_coeffs[5] =  9.84509964E+03;
+      _NO_200_1000_coeffs[6] =  2.28061001E+00;
+    }
+
+  };
+
+  class AirNASA9TestBase : public AirTestBase,
+                           public NASA9TestBase
+  {
+  public:
+
+    AirNASA9TestBase()
+    {
+      this->init_N2_coeffs();
+      this->init_O2_coeffs();
+      this->init_O_coeffs();
+      this->init_NO_coeffs();
+    }
+
+  protected:
+
+    virtual libMesh::Real cp_exact( unsigned int species_idx, libMesh::Real T )
+    {
+      const std::vector<libMesh::Real> coeffs = this->nasa_coeffs(species_idx);
+      return this->cp_R_exact(T,
+                              coeffs[0],
+                              coeffs[1],
+                              coeffs[2],
+                              coeffs[3],
+                              coeffs[4],
+                              coeffs[5],
+                              coeffs[6])*this->R_species(species_idx);
+    }
+
+    virtual libMesh::Real h_exact( unsigned int species_idx, libMesh::Real T )
+    {
+      const std::vector<libMesh::Real> coeffs = this->nasa_coeffs(species_idx);
+      return this->h_RT_exact(T,
+                              coeffs[0],
+                              coeffs[1],
+                              coeffs[2],
+                              coeffs[3],
+                              coeffs[4],
+                              coeffs[5],
+                              coeffs[6],
+                              coeffs[7])*this->R_species(species_idx)*T;
+    }
+
+  private:
+
+    void init_N2_coeffs()
+    {
+      _N2_200_1000_coeffs.resize(9);
+
+      _N2_200_1000_coeffs[0] =  2.21037122e+04;
+      _N2_200_1000_coeffs[1] = -3.81846145e+02;
+      _N2_200_1000_coeffs[2] =  6.08273815e+00;
+      _N2_200_1000_coeffs[3] = -8.53091381e-03;
+      _N2_200_1000_coeffs[4] =  1.38464610e-05;
+      _N2_200_1000_coeffs[5] = -9.62579293e-09;
+      _N2_200_1000_coeffs[6] =  2.51970560e-12;
+      _N2_200_1000_coeffs[7] =  7.10845911e+02;
+      _N2_200_1000_coeffs[8] = -1.07600320e+01;
+    }
+
+    void init_O2_coeffs()
+    {
+      _O2_200_1000_coeffs.resize(9);
+
+      _O2_200_1000_coeffs[0] = -3.42556269e+04;
+      _O2_200_1000_coeffs[1] =  4.84699986e+02;
+      _O2_200_1000_coeffs[2] =  1.11901159e+00;
+      _O2_200_1000_coeffs[3] =  4.29388743e-03;
+      _O2_200_1000_coeffs[4] = -6.83627313e-07;
+      _O2_200_1000_coeffs[5] = -2.02337478e-09;
+      _O2_200_1000_coeffs[6] =  1.03904064e-12;
+      _O2_200_1000_coeffs[7] = -3.39145434e+03;
+      _O2_200_1000_coeffs[8] =  1.84969912e+01;
+    }
+
+    void init_O_coeffs()
+    {
+      _O_200_1000_coeffs.resize(9);
+
+      _O_200_1000_coeffs[0] = -7.95361130e+03;
+      _O_200_1000_coeffs[1] =  1.60717779e+02;
+      _O_200_1000_coeffs[2] =  1.96622644e+00;
+      _O_200_1000_coeffs[3] =  1.01367031e-03;
+      _O_200_1000_coeffs[4] = -1.11041542e-06;
+      _O_200_1000_coeffs[5] =  6.51750750e-10;
+      _O_200_1000_coeffs[6] = -1.58477925e-13;
+      _O_200_1000_coeffs[7] =  2.84036244e+04;
+      _O_200_1000_coeffs[8] =  8.40424182e+00;
+    }
+
+    void init_NO_coeffs()
+    {
+      _NO_200_1000_coeffs.resize(9);
+
+      _NO_200_1000_coeffs[0] = -1.14391658e+04;
+      _NO_200_1000_coeffs[1] =  1.53646774e+02;
+      _NO_200_1000_coeffs[2] =  3.43146865e+00;
+      _NO_200_1000_coeffs[3] = -2.66859213e-03;
+      _NO_200_1000_coeffs[4] =  8.48139877e-06;
+      _NO_200_1000_coeffs[5] = -7.68511079e-09;
+      _NO_200_1000_coeffs[6] =  2.38679758e-12;
+      _NO_200_1000_coeffs[7] =  9.09794974e+03;
+      _NO_200_1000_coeffs[8] =  6.72872795e+00;
+    }
+
+  };
+}
+
+#endif // GRINS_AIR_NASA_POLY_BASE_H

--- a/test/interface/antioch_test_base.h
+++ b/test/interface/antioch_test_base.h
@@ -1,0 +1,61 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_ANTIOCH_TEST_BASE_H
+#define GRINS_ANTIOCH_TEST_BASE_H
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_ANTIOCH
+
+// GRINS
+#include "grins/antioch_mixture.h"
+
+// libMesh
+#include "libmesh/libmesh_common.h"
+#include "libmesh/getpot.h"
+
+namespace GRINSTesting
+{
+  class AntiochTestBase
+  {
+  public:
+
+    void init_antioch(const std::string& input_file, const std::string& material_name)
+    {
+      GetPot input(input_file);
+
+      _antioch_mixture.reset( new GRINS::AntiochMixture(input,material_name) );
+    }
+
+  protected:
+
+    libMesh::UniquePtr<GRINS::AntiochMixture> _antioch_mixture;
+  };
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_ANTIOCH
+
+#endif // GRINS_ANTIOCH_TEST_BASE_H

--- a/test/interface/antioch_thermo.C
+++ b/test/interface/antioch_thermo.C
@@ -1,0 +1,93 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+#ifdef GRINS_HAVE_ANTIOCH
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include "grins_test_paths.h"
+#include "air_nasa_poly_base.h"
+#include "antioch_test_base.h"
+#include "thermochem_test_common.h"
+#include "testing_utils.h"
+
+// GRINS
+#include "grins/antioch_evaluator.h"
+
+// C++
+#include <sstream>
+
+namespace GRINSTesting
+{
+  class AntiochCEAThermoTest : public CppUnit::TestCase,
+                               public AntiochTestBase,
+                               public AirNASA9TestBase
+  {
+  public:
+    CPPUNIT_TEST_SUITE( AntiochCEAThermoTest );
+
+    CPPUNIT_TEST( test_cp );
+    CPPUNIT_TEST( test_hs );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+
+    void setUp()
+    {
+      std::string input_file = std::string(GRINS_TEST_SRCDIR)+"/input_files/antioch.in";
+      this->init_antioch(input_file, "TestMaterial");
+
+      _N2_idx = _antioch_mixture->species_index("N2");
+      _O2_idx = _antioch_mixture->species_index("O2");
+      _N_idx = _antioch_mixture->species_index("N");
+      _O_idx = _antioch_mixture->species_index("O");
+      _NO_idx = _antioch_mixture->species_index("NO");
+    }
+
+    void test_cp()
+    {
+      this->test_cp_common<GRINS::AntiochMixture,GRINS::AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> > >
+        ( *_antioch_mixture, (*this), TestingUtils::epsilon()*100 );
+    }
+
+    void test_hs()
+    {
+      this->test_h_common<GRINS::AntiochMixture,GRINS::AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> > >
+        ( *_antioch_mixture, (*this), TestingUtils::epsilon()*100 );
+    }
+
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( AntiochCEAThermoTest );
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_ANTIOCH
+#endif // GRINS_HAVE_CPPUNIT

--- a/test/interface/cantera_test_base.h
+++ b/test/interface/cantera_test_base.h
@@ -1,0 +1,61 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_CANTERA_TEST_BASE_H
+#define GRINS_CANTERA_TEST_BASE_H
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CANTERA
+
+// GRINS
+#include "grins/cantera_mixture.h"
+
+// libMesh
+#include "libmesh/libmesh_common.h"
+#include "libmesh/getpot.h"
+
+namespace GRINSTesting
+{
+  class CanteraTestBase
+  {
+  public:
+
+    void init_cantera(const std::string& input_file, const std::string& material_name)
+    {
+      GetPot input(input_file);
+
+      _cantera_mixture.reset( new GRINS::CanteraMixture(input,material_name) );
+    }
+
+  protected:
+
+    libMesh::UniquePtr<GRINS::CanteraMixture> _cantera_mixture;
+  };
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_CANTERA
+
+#endif // GRINS_CANTERA_TEST_BASE_H

--- a/test/interface/cantera_thermo.C
+++ b/test/interface/cantera_thermo.C
@@ -1,0 +1,91 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+#ifdef GRINS_HAVE_CANTERA
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include "grins_test_paths.h"
+#include "air_nasa_poly_base.h"
+#include "cantera_test_base.h"
+#include "thermochem_test_common.h"
+#include "testing_utils.h"
+
+// GRINS
+#include "grins/cantera_evaluator.h"
+
+// C++
+#include <sstream>
+
+namespace GRINSTesting
+{
+  class CanteraNASA9ThermoTest : public CppUnit::TestCase,
+                                 public CanteraTestBase,
+                                 public AirNASA9TestBase
+  {
+  public:
+    CPPUNIT_TEST_SUITE( CanteraNASA9ThermoTest );
+
+    CPPUNIT_TEST( test_cp );
+    CPPUNIT_TEST( test_hs );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+
+    void setUp()
+    {
+      std::string input_file = std::string(GRINS_TEST_SRCDIR)+"/input_files/cantera_chem_thermo.in";
+      this->init_cantera(input_file, "TestMaterial");
+
+      _N2_idx = _cantera_mixture->species_index("N2");
+      _O2_idx = _cantera_mixture->species_index("O2");
+      _N_idx = _cantera_mixture->species_index("N");
+      _O_idx = _cantera_mixture->species_index("O");
+      _NO_idx = _cantera_mixture->species_index("NO");
+    }
+
+    void test_cp()
+    {
+      this->test_cp_common<GRINS::CanteraMixture,GRINS::CanteraEvaluator>
+        ( *_cantera_mixture, (*this), 1.0e-4 /*relative tolerance*/ );
+    }
+
+    void test_hs()
+    {
+      this->test_h_common<GRINS::CanteraMixture,GRINS::CanteraEvaluator>
+        ( *_cantera_mixture, (*this), 1.0e-4 /*relative tolerance*/ );
+    }
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( CanteraNASA9ThermoTest );
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_CANTERA
+#endif // GRINS_HAVE_CPPUNIT

--- a/test/interface/interface_cppunit_test.C
+++ b/test/interface/interface_cppunit_test.C
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/ui/text/TestRunner.h>
+#endif // GRINS_HAVE_CPPUNIT
+
+int main()
+{
+#ifdef GRINS_HAVE_CPPUNIT
+  CppUnit::TextUi::TestRunner runner;
+  CppUnit::TestFactoryRegistry &registry = CppUnit::TestFactoryRegistry::getRegistry();
+  runner.addTest( registry.makeTest() );
+
+  // If the tests all succeed, report success
+  if (runner.run())
+    return 0;
+
+  // If any test fails report failure
+  return 1;
+
+#else
+  // If we don't have CPPUnit, report we skipped
+  // 77 return code tells Automake we skipped this.
+  return 77;
+#endif // GRINS_HAVE_CPPUNIT
+}

--- a/test/interface/nasa_poly_test_base.h
+++ b/test/interface/nasa_poly_test_base.h
@@ -1,0 +1,86 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_NASA_POLY_TEST_BASE_H
+#define GRINS_NASA_POLY_TEST_BASE_H
+
+namespace GRINSTesting
+{
+  class NASA7TestBase
+  {
+  public:
+
+    libMesh::Real cp_R_exact( libMesh::Real T,
+                              libMesh::Real a0, libMesh::Real a1, libMesh::Real a2,
+                              libMesh::Real a3, libMesh::Real a4 )
+    {
+      return a0 + a1*T + a2*T*T + a3*T*T*T + a4*(T*T*T*T);
+    }
+
+    libMesh::Real h_RT_exact( libMesh::Real T,
+                              libMesh::Real a0, libMesh::Real a1, libMesh::Real a2,
+                              libMesh::Real a3, libMesh::Real a4, libMesh::Real a5 )
+    {
+      return a0 + a1/2.0*T + a2/3.0*T*T + a3/4.0*T*T*T + a4/5.0*(T*T*T*T) + a5/T;
+    }
+
+    libMesh::Real s_R_exact( libMesh::Real T,
+                             libMesh::Real a0, libMesh::Real a1, libMesh::Real a2,
+                             libMesh::Real a3, libMesh::Real a4, libMesh::Real a6 )
+    {
+      return a0*std::log(T) + a1*T + a2/2.0*T*T + a3/3.0*T*T*T + a4/4.0*(T*T*T*T) + a6;
+    }
+  };
+
+  class NASA9TestBase
+  {
+  public:
+
+    libMesh::Real cp_R_exact( libMesh::Real T,
+                              libMesh::Real a0, libMesh::Real a1, libMesh::Real a2,
+                              libMesh::Real a3, libMesh::Real a4, libMesh::Real a5, libMesh::Real a6 )
+    {
+      return a0/(T*T) + a1/T + a2 + a3*T + a4*(T*T) + a5*(T*T*T) + a6*(T*T*T*T);
+    }
+
+    libMesh::Real h_RT_exact( libMesh::Real T,
+                              libMesh::Real a0, libMesh::Real a1, libMesh::Real a2, libMesh::Real a3,
+                              libMesh::Real a4, libMesh::Real a5, libMesh::Real a6, libMesh::Real a7 )
+    {
+      return -a0/(T*T) + a1*std::log(T)/T + a2 + a3*T/2.0 + a4*(T*T)/3.0
+        + a5*(T*T*T)/4.0 + a6*(T*T*T*T)/5.0 + a7/T;
+    }
+
+    libMesh::Real s_R_exact( libMesh::Real T,
+                             libMesh::Real a0, libMesh::Real a1, libMesh::Real a2, libMesh::Real a3,
+                             libMesh::Real a4, libMesh::Real a5, libMesh::Real a6, libMesh::Real a8 )
+    {
+      return -a0/(2.*T*T) - a1/T + a2*std::log(T) + a3*T + a4*(T*T)/2.0
+        + a5*(T*T*T)/3.0 + a6*(T*T*T*T)/4.0 + a8;
+    }
+  };
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_NASA_POLY_TEST_BASE_H

--- a/test/interface/thermochem_test_common.h
+++ b/test/interface/thermochem_test_common.h
@@ -1,0 +1,64 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_THERMOCHEM_TEST_COMMON_H
+#define GRINS_THERMOCHEM_TEST_COMMON_H
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <vector>
+
+#include "libmesh/libmesh_common.h"
+
+namespace GRINSTesting
+{
+  class ThermochemTestCommon
+  {
+  public:
+
+    static libMesh::Real compute_mass_frac_mixture_prop( const std::vector<libMesh::Real>& properties,
+                                                         const std::vector<libMesh::Real>& mass_fracs )
+    {
+      CPPUNIT_ASSERT_EQUAL( properties.size(), mass_fracs.size() );
+
+      unsigned int size = properties.size();
+
+      libMesh::Real mixed_value = 0.0;
+      for( unsigned int s = 0; s < size; s++ )
+        mixed_value += mass_fracs[s]*properties[s];
+
+      return mixed_value;
+    }
+
+  };
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_CPPUNIT
+
+#endif // GRINS_THERMOCHEM_TEST_COMMON_H


### PR DESCRIPTION
The first bit of this PR adds a check for CppUnit and adds paths accordingly to the test/Makefile.am. The only catch here is: 1. If your system is GCC 4.x based and you're using GCC 5.y, you need to build your own CppUnit (because of the cxx11 business in the STL headers that started in GCC 5.y)  and 2. If you're on a GCC 5.x based system, you'll need to build your own CppUnit if you want to use Clang (because of current inconsistencies in libstdc++ and libc++). I've already gotten used to having a cppunit module tied to the compiler because of the first exception, so it's not that big of deal. But comments welcome @roystgnr if you see a better way of handling that.

The second part of the PR introduces CppUnit based testing for the thermo interfaces in Cantera and Antioch. Currently only testing NASA9. But gives a good example of how to use this and so I wanted to get this merged. More testing to come (kinetic rates next!).

Note that this builds on #362.