### PR TITLE
support output_vars = 'base_velocity' to averaged_fan

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 Version 0.7.0 (In progress)
+   * Added support for output of 'base_velocity' in averaged_fan
 
 Version 0.6.1
 https://github.com/grinsfem/grins/releases/tag/v0.6.1

--- a/examples/simple_fan/fan.in
+++ b/examples/simple_fan/fan.in
@@ -43,6 +43,8 @@ chord_length = '.2*sqrt(2)'
 area_swept = '{r:=sqrt(x^2+y^2); 2*pi*r*(.6-.4)/4}' # 4 blade fan
 angle_of_attack = '{pi/4}'
 
+output_vars = 'base_velocity'
+
 []
 
 [Variables]

--- a/src/physics/include/grins/averaged_fan.h
+++ b/src/physics/include/grins/averaged_fan.h
@@ -55,6 +55,12 @@ namespace GRINS
 
     ~AveragedFan();
 
+
+    //! Register postprocessing variables for HeatTransfer
+    virtual void register_postprocessing_vars( const GetPot& input,
+                                               PostProcessedQuantities<libMesh::Real>& postprocessing );
+
+
     virtual void init_context( AssemblyContext& context );
 
     // residual and jacobian calculations
@@ -65,9 +71,26 @@ namespace GRINS
 				          AssemblyContext& context,
 				          CachedValues& cache );
 
+    //! Compute value of postprocessed quantities at libMesh::Point.
+    virtual void compute_postprocessed_quantity( unsigned int quantity_index,
+                                                 const AssemblyContext& context,
+                                                 const libMesh::Point& point,
+                                                 libMesh::Real& value );
+
   private:
 
+    //! Index from registering this postprocessed quantity
+    unsigned int _base_velocity_x_index;
+
+    //! Index from registering this postprocessed quantity
+    unsigned int _base_velocity_y_index;
+
+    //! Index from registering this postprocessed quantity
+    unsigned int _base_velocity_z_index;
+
     AveragedFan();
+
+
   };
 
 } // end namespace block


### PR DESCRIPTION
This pull adds registration as well as output for the base velocity in the averaged fan physics. It also adds a demonstration of this capability to the examples for the averaged fan example. 

Implementation was simple and was heavily based off of a similar existing capability in velocity penalty. Appears to be working for me. Make check is passing locally on my laptop as well as in an ICES environment. 