### PR TITLE
adding scalar parsed qoi test case

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Version 0.7.0 (In progress)
    * Added support for output of 'base_velocity' in averaged_fan
+   * Added scalar parsed qoi regression test case
 
 Version 0.6.1
 https://github.com/grinsfem/grins/releases/tag/v0.6.1

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -248,6 +248,7 @@ TESTS += regression/dirichlet_fem.sh
 TESTS += regression/dirichlet_nan.sh
 TESTS += regression/simple_ode.sh
 TESTS += regression/parsed_qoi.sh
+TESTS += regression/parsed_qoi_scalar.sh
 TESTS += regression/low_mach_cavity_benchmark.sh
 TESTS += regression/backward_facing_step.sh
 TESTS += regression/locally_refine.sh

--- a/test/input_files/parsed_qoi_scalar.in
+++ b/test/input_files/parsed_qoi_scalar.in
@@ -1,0 +1,112 @@
+# Mesh related options
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '32'
+      n_elems_y = '16'
+      x_max = '5.0'
+
+[]
+
+# Options for time solvers
+
+
+
+#Linear and nonlinear solver options
+[linear-nonlinear-solver]
+max_nonlinear_iterations = 10
+max_linear_iterations = 2500
+
+initial_linear_tolerance = 1.0e-12
+
+verify_analytic_jacobians = 1.e-6
+
+# Visualization options
+[vis-options]
+output_vis = 'false'
+output_solution_sensitivities = 'false'
+vis_output_file_prefix = 'parsed_qoi_vis'
+output_format = 'ExodusII'
+
+# Options for print info to the screen
+[screen-options]
+print_equation_system_info = 'false'
+print_mesh_info = 'false'
+print_log_info = 'false'
+solver_verbose = 'false'
+solver_quiet = 'true'
+
+echo_physics = 'true'
+echo_qoi = 'true' # which QoIs activated
+print_qoi = 'true' # print numerical values of QoIs
+
+[Materials]
+   [./TestMaterial]
+      [./Viscosity]
+         model = 'constant'
+         value = '1.0'
+      [../Density]
+         value = '1.0'
+[]
+
+# Options related to all Physics
+[Physics]
+
+enabled_physics = 'Stokes'
+
+# Options for Stokes physics
+[./Stokes]
+
+material = 'TestMaterial'
+
+bc_ids = '1 3 2 0'
+bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+bc_variables = 'u u na na'
+bc_values = '{y-y^2} {y-y^2} na na'
+
+pin_pressure = true
+pin_value = 100.0
+pin_location = '2.5 0' # Must be on boundary!
+
+[]
+
+[Variables]
+   [./Velocity]
+      names = 'u v'
+      fe_family = 'LAGRANGE'
+      order = 'SECOND'
+   [../Pressure]
+      names = 'p'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+[]
+
+# Options for adaptivity
+[QoI]
+enabled_qois = 'parsed_interior parsed_boundary weighted_flux'
+
+# All sensitivities should be zero
+adjoint_sensitivity_parameters = 'Materials/TestMaterial/Viscosity/value Materials/TestMaterial/Density/value QoI/ParsedBoundary/qoi_functional/a QoI/ParsedInterior/qoi_functional/a'
+forward_sensitivity_parameters = 'Materials/TestMaterial/Viscosity/value Materials/TestMaterial/Density/value QoI/ParsedBoundary/qoi_functional/a QoI/ParsedInterior/qoi_functional/a'
+
+[./ParsedBoundary]
+bc_ids = '3'
+qoi_functional = 'a:=1;a+u'
+
+[../ParsedInterior]
+
+# testing parsed interior on a scalar case
+#
+# \int_0^5 \int_0^1 dy dx
+# 
+# I think this integral should be 5
+#
+qoi_functional = 'a:=1;a'
+
+[../WeightedFlux]
+variables = 'u'
+bc_ids = '0' # Note that this spills over to 1+3 in the corners!
+weights = '1' # Only one variable == only one weight to specify
+
+[]

--- a/test/regression/parsed_qoi_scalar.sh
+++ b/test/regression/parsed_qoi_scalar.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+PROG="${GRINS_BUILDSRC_DIR}/grins"
+
+INPUT="${GRINS_TEST_INPUT_DIR}/parsed_qoi.in"
+
+${LIBMESH_RUN:-} $PROG $INPUT
+


### PR DESCRIPTION
Talked with @roystgnr about this briefly, and we both agreed this should be a tested capability. 

This case is almost a complete duplicate of the parsed_qoi.in test, but has been modified to ensure the parsed_qoi parsing appropriately handles scalars over the interior of the domain. This integral is analytically 5.0, and my machine is reporting,
<pre>
==========================================================
parsed_interior = 5.0000000000000648e+00
==========================================================
</pre>

e.g. 6.48e-14 error. Appears quite sane. However, any easy way to add this fact to the regression shell script? Right now it is just running, not testing this equality. 