### PR TITLE
Variable Init Refactor

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -215,6 +215,7 @@ libgrins_la_SOURCES += variables/src/velocity_variables.C
 libgrins_la_SOURCES += variables/src/velocity_fe_variables.C
 libgrins_la_SOURCES += variables/src/displacement_variables.C
 libgrins_la_SOURCES += variables/src/displacement_fe_variables.C
+libgrins_la_SOURCES += variables/src/species_mass_fracs_variables.C
 
 # src/utilities files
 libgrins_la_SOURCES += utilities/src/grins_version.C

--- a/src/bc_handling/src/axisym_heat_transfer_bc_handling.C
+++ b/src/bc_handling/src/axisym_heat_transfer_bc_handling.C
@@ -90,7 +90,7 @@ namespace GRINS
 
   void AxisymmetricHeatTransferBCHandling::init_bc_data( const libMesh::FEMSystem& system )
   {
-    _temp_vars.init(const_cast<libMesh::FEMSystem*>(&system));
+    _temp_vars.init_vars(const_cast<libMesh::FEMSystem*>(&system));
   }
 
   void AxisymmetricHeatTransferBCHandling::init_bc_types( const BoundaryID bc_id, 

--- a/src/bc_handling/src/heat_transfer_bc_handling.C
+++ b/src/bc_handling/src/heat_transfer_bc_handling.C
@@ -82,9 +82,7 @@ namespace GRINS
 
   void HeatTransferBCHandling::init_bc_data( const libMesh::FEMSystem& system )
   {
-    _temp_vars.init(const_cast<libMesh::FEMSystem*>(&system));
-
-    return;
+    _temp_vars.init_vars(const_cast<libMesh::FEMSystem*>(&system));
   }
   
   void HeatTransferBCHandling::init_bc_types( const BoundaryID bc_id, 

--- a/src/bc_handling/src/inc_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/inc_navier_stokes_bc_handling.C
@@ -85,9 +85,7 @@ namespace GRINS
 
   void IncompressibleNavierStokesBCHandling::init_bc_data( const libMesh::FEMSystem& system )
   {
-    _flow_vars.init(const_cast<libMesh::FEMSystem*>(&system));
-
-    return;
+    _flow_vars.init_vars(const_cast<libMesh::FEMSystem*>(&system));
   }
 
   void IncompressibleNavierStokesBCHandling::init_bc_types( const BoundaryID bc_id, 

--- a/src/bc_handling/src/low_mach_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/low_mach_navier_stokes_bc_handling.C
@@ -111,9 +111,9 @@ namespace GRINS
 
   void LowMachNavierStokesBCHandling::init_bc_data( const libMesh::FEMSystem& system )
   {
-    _flow_vars.init(const_cast<libMesh::FEMSystem*>(&system));
+    _flow_vars.init_vars(const_cast<libMesh::FEMSystem*>(&system));
 
-    _temp_vars.init(const_cast<libMesh::FEMSystem*>(&system));
+    _temp_vars.init_vars(const_cast<libMesh::FEMSystem*>(&system));
 
     return;
   }

--- a/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
@@ -390,7 +390,7 @@ namespace GRINS
     // Call base class
     LowMachNavierStokesBCHandling::init_bc_data(system);
 
-    _species_vars.init( const_cast<libMesh::FEMSystem*>(&system) );
+    _species_vars.init_vars( const_cast<libMesh::FEMSystem*>(&system) );
 
     // See if we have a catalytic wall and initialize them if we do
     for( std::map< GRINS::BoundaryID, GRINS::BCType>::const_iterator bc_map = _neumann_bc_map.begin();

--- a/src/bc_handling/src/solid_mechanics_bc_handling.C
+++ b/src/bc_handling/src/solid_mechanics_bc_handling.C
@@ -96,9 +96,7 @@ namespace GRINS
 
   void SolidMechanicsBCHandling::init_bc_data( const libMesh::FEMSystem& system )
   {
-    _disp_vars.init(const_cast<libMesh::FEMSystem*>(&system));
-
-    return;
+    _disp_vars.init_vars(const_cast<libMesh::FEMSystem*>(&system));
   }
 
   void SolidMechanicsBCHandling::init_bc_types( const BoundaryID bc_id,

--- a/src/bc_handling/src/spalart_allmaras_bc_handling.C
+++ b/src/bc_handling/src/spalart_allmaras_bc_handling.C
@@ -74,9 +74,7 @@ namespace GRINS
 
   void SpalartAllmarasBCHandling::init_bc_data( const libMesh::FEMSystem& system )
   {
-    _turb_vars.init(const_cast<libMesh::FEMSystem*>(&system));
-
-    return;
+    _turb_vars.init_vars(const_cast<libMesh::FEMSystem*>(&system));
   }
 
   void SpalartAllmarasBCHandling::init_bc_types( const BoundaryID bc_id,

--- a/src/physics/src/heat_transfer_stab_helper.C
+++ b/src/physics/src/heat_transfer_stab_helper.C
@@ -66,11 +66,9 @@ namespace GRINS
 
   void HeatTransferStabilizationHelper::init( libMesh::FEMSystem& system )
   {
-    _temp_vars.init(&system);
-    _flow_vars.init(&system);
-    _press_var.init(&system);
-
-    return;
+    _temp_vars.init_vars(&system);
+    _flow_vars.init_vars(&system);
+    _press_var.init_vars(&system);
   }
 
   libMesh::Real HeatTransferStabilizationHelper::compute_res_energy_steady( AssemblyContext& context,

--- a/src/physics/src/inc_navier_stokes_stab_helper.C
+++ b/src/physics/src/inc_navier_stokes_stab_helper.C
@@ -67,10 +67,8 @@ namespace GRINS
 
   void IncompressibleNavierStokesStabilizationHelper::init( libMesh::FEMSystem& system )
   {
-    _flow_vars.init(&system);
-    _press_var.init(&system);
-
-    return;
+    _flow_vars.init_vars(&system);
+    _press_var.init_vars(&system);
   }
 
   libMesh::RealGradient IncompressibleNavierStokesStabilizationHelper::UdotGradU( libMesh::Gradient& U, 

--- a/src/physics/src/solid_mechanics_abstract.C
+++ b/src/physics/src/solid_mechanics_abstract.C
@@ -37,13 +37,12 @@ namespace GRINS
   SolidMechanicsAbstract::SolidMechanicsAbstract(const PhysicsName& physics_name,
                                                  const GetPot& input )
     : Physics(physics_name,input),
-      _disp_vars(input,physics_name)
+      _disp_vars(input,physics_name,false,true)// is_2D = false, is_3D = true
   {}
 
   void SolidMechanicsAbstract::init_variables( libMesh::FEMSystem* system )
   {
-    // is_2D = false, is_3D = true
-    _disp_vars.init(system,false,true);
+    _disp_vars.init(system);
   }
 
   void SolidMechanicsAbstract::set_time_evolving_vars( libMesh::FEMSystem* system )

--- a/src/physics/src/spalart_allmaras_helper.C
+++ b/src/physics/src/spalart_allmaras_helper.C
@@ -50,10 +50,8 @@ namespace GRINS
   {
     this->_dim = system->get_mesh().mesh_dimension();
 
-    this->_flow_vars.init(system);
-    this->_press_var.init(system);
-
-    return;
+    this->_flow_vars.init_vars(system);
+    this->_press_var.init_vars(system);
   }
 
   libMesh::Real SpalartAllmarasHelper::vorticity(AssemblyContext& context, unsigned int qp) const

--- a/src/physics/src/spalart_allmaras_stab_helper.C
+++ b/src/physics/src/spalart_allmaras_stab_helper.C
@@ -64,17 +64,15 @@ namespace GRINS
 
   void SpalartAllmarasStabilizationHelper::init( libMesh::FEMSystem& system )
   {
-    this->_flow_vars.init(&system);
-    this->_press_var.init(&system);
+    this->_flow_vars.init_vars(&system);
+    this->_press_var.init_vars(&system);
 
-    this->_turbulence_vars.init(&system);
+    this->_turbulence_vars.init_vars(&system);
 
     // Init the variables belonging to SA helper
     _spalart_allmaras_helper.init_variables(&system);
 
     this->_dim = system.get_mesh().mesh_dimension();
-
-    return;
   }
 
   libMesh::Real SpalartAllmarasStabilizationHelper::compute_res_spalart_steady( AssemblyContext& context,

--- a/src/variables/include/grins/displacement_fe_variables.h
+++ b/src/variables/include/grins/displacement_fe_variables.h
@@ -37,20 +37,28 @@ namespace GRINS
   {
   public:
 
-    DisplacementFEVariables( const GetPot& input, const std::string& physics_name );
+    //! Constructor
+    /*! The arguments specify whether the spatial mesh is really 2D or 3D.
+     *  This is needed for cases such as a 1D beam in 2D (is_2D = true)
+     *  or 3D (is_3D = true) space or 2D shell manifolds in 3D (is_3D = true). */
+    DisplacementFEVariables( const GetPot& input,
+                             const std::string& physics_name,
+                             bool is_2D, bool is_3D );
+
     virtual ~DisplacementFEVariables(){};
 
     //! Initialize System variables
-    /*!
-     *  Additional arguments specify whether the spatial mesh is really 2D or 3D.
-     * This is needed for cases such as a 1D beam in 2D (is_2D = true) or 3D (is_3D = true)
-     * space or 2D shell manifolds in 3D (is_3D = true).
-     */
-    void init( libMesh::FEMSystem* system, bool is_2D, bool is_3D );
+    virtual void init( libMesh::FEMSystem* system );
 
   private:
 
     DisplacementFEVariables();
+
+    //! Tracks whether this is a 2D problem
+    bool _is_2D;
+
+    //! Tracks whether this is a 3D problem
+    bool _is_3D;
 
   };
 

--- a/src/variables/include/grins/displacement_variables.h
+++ b/src/variables/include/grins/displacement_variables.h
@@ -46,7 +46,7 @@ namespace GRINS
      * This is needed for cases such as a 1D beam in 2D (is_2D = true) or 3D (is_3D = true)
      * space or 2D shell manifolds in 3D (is_3D = true).
      */
-    virtual void init( libMesh::FEMSystem* system );
+    virtual void init_vars( libMesh::FEMSystem* system );
 
     bool have_v() const;
     bool have_w() const;

--- a/src/variables/include/grins/displacement_variables.h
+++ b/src/variables/include/grins/displacement_variables.h
@@ -30,6 +30,7 @@
 
 // GRINS
 #include "grins/variables_base.h"
+#include "grins/variables_parsing.h"
 
 namespace GRINS
 {
@@ -62,7 +63,7 @@ namespace GRINS
   protected:
 
     std::string subsection() const
-    { return "Displacement"; }
+    { return VariablesParsing::displacement_section(); }
 
     bool _have_v;
     bool _have_w;

--- a/src/variables/include/grins/displacement_variables.h
+++ b/src/variables/include/grins/displacement_variables.h
@@ -46,7 +46,7 @@ namespace GRINS
      * This is needed for cases such as a 1D beam in 2D (is_2D = true) or 3D (is_3D = true)
      * space or 2D shell manifolds in 3D (is_3D = true).
      */
-    void init( libMesh::FEMSystem* system );
+    virtual void init( libMesh::FEMSystem* system );
 
     bool have_v() const;
     bool have_w() const;

--- a/src/variables/include/grins/fe_variables_base.h
+++ b/src/variables/include/grins/fe_variables_base.h
@@ -55,6 +55,12 @@ namespace GRINS
 
     ~FEVariablesBase(){};
 
+    //! Add variables to the system
+    /*! This expects that _var_names has been setup during construction
+        time. Most subclasses should be able to use default_fe_init, once
+        they subclass this and VariablesBase. */
+    virtual void init( libMesh::FEMSystem* system ) =0;
+
   protected:
 
     //! Default method for init'ing variables

--- a/src/variables/include/grins/generic_fe_type_variable.h
+++ b/src/variables/include/grins/generic_fe_type_variable.h
@@ -36,7 +36,7 @@ namespace GRINS
 {
   //! Generic FE variable for generic physics
   /*! The variable inputs, e.g. fe_family, will be tied to the input physics_name.
-      Thus, the input specification will be [Variables/<physics_name>/fe_family],
+      Thus, the input specification will be [Variables/GenericVariable:<physics_name>/fe_family],
       etc.*/
   class GenericFETypeVariable : public SingleFETypeVariable,
                                 public GenericVariable
@@ -45,7 +45,7 @@ namespace GRINS
 
     GenericFETypeVariable( const GetPot& input,
                            const std::string& physics_name )
-      : SingleFETypeVariable(input,physics_name),
+      : SingleFETypeVariable(input,this->section_name(physics_name)),
         GenericVariable(input,physics_name)
     {}
 

--- a/src/variables/include/grins/generic_variable.h
+++ b/src/variables/include/grins/generic_variable.h
@@ -30,12 +30,13 @@ class GetPot;
 
 // GRINS
 #include "grins/single_variable.h"
+#include "grins/variables_parsing.h"
 
 namespace GRINS
 {
   //! Generic variable for generic physics
   /*! The variable inputs, e.g. name, will be tied to the input physics_name.
-      Thus, the input specification will be [Variables/<physics_name>/name],
+      Thus, the input specification will be [Variables/GenericVariable:<physics_name>/name],
       etc.*/
   class GenericVariable : public SingleVariable
   {
@@ -44,7 +45,7 @@ namespace GRINS
     GenericVariable( const GetPot& input,
                      const std::string& physics_name )
       : SingleVariable(input,
-                       physics_name,
+                       this->section_name(physics_name),
                        this->default_name())
     {}
 
@@ -53,6 +54,9 @@ namespace GRINS
     VariableIndex var() const;
 
   protected:
+
+    std::string section_name(const std::string& physics_name) const
+    { return VariablesParsing::generic_section()+":"+physics_name; }
 
     std::string default_name() const
     { return "u"; }

--- a/src/variables/include/grins/pressure_variable.h
+++ b/src/variables/include/grins/pressure_variable.h
@@ -30,6 +30,7 @@ class GetPot;
 
 // GRINS
 #include "grins/single_variable.h"
+#include "grins/variables_parsing.h"
 
 namespace GRINS
 {
@@ -54,7 +55,7 @@ namespace GRINS
     { return "pressure"; }
 
     std::string subsection() const
-    { return "Pressure"; }
+    { return VariablesParsing::pressure_section(); }
 
     std::string default_name() const
     { return "p"; }

--- a/src/variables/include/grins/primitive_temp_variables.h
+++ b/src/variables/include/grins/primitive_temp_variables.h
@@ -30,6 +30,7 @@ class GetPot;
 
 // GRINS
 #include "grins/single_variable.h"
+#include "grins/variables_parsing.h"
 
 namespace GRINS
 {
@@ -51,10 +52,10 @@ namespace GRINS
   protected:
 
     std::string old_var_name() const
-    { return "Temperature"; }
+    { return VariablesParsing::temperature_section(); }
 
     std::string subsection() const
-    { return "Temperature"; }
+    { return VariablesParsing::temperature_section(); }
 
     std::string default_name() const
     { return "T"; }

--- a/src/variables/include/grins/single_variable.h
+++ b/src/variables/include/grins/single_variable.h
@@ -55,9 +55,6 @@ namespace GRINS
 
     ~SingleVariable(){};
 
-    virtual void init( libMesh::FEMSystem* system )
-    { this->default_var_init(system); }
-
   private:
 
     SingleVariable();

--- a/src/variables/include/grins/species_mass_fracs_variables.h
+++ b/src/variables/include/grins/species_mass_fracs_variables.h
@@ -44,13 +44,20 @@ namespace GRINS
   public:
 
     SpeciesMassFractionsVariables( const GetPot& input, const std::string& material_name )
-      : VariablesBase()
+      : VariablesBase(),
+        _prefix( input("Variables/"+this->subsection()+"/names", "w_" ) )
     {
-      std::string prefix = input("Variables/"+this->subsection()+"/names", "w_" );
-      MaterialsParsing::parse_species_varnames(input, material_name, prefix, _var_names);
+      MaterialsParsing::parse_species_varnames(input, material_name, _prefix, _var_names);
     }
 
+    SpeciesMassFractionsVariables( const GetPot& input )
+      : VariablesBase(),
+        _prefix( input("Variables/"+this->subsection()+"/names", "w_" ) )
+    {}
+
     ~SpeciesMassFractionsVariables(){};
+
+    virtual void init_vars( libMesh::FEMSystem* system );
 
     unsigned int n_species() const;
 
@@ -60,6 +67,10 @@ namespace GRINS
 
     std::string subsection() const
     { return VariablesParsing::species_mass_fractions_section(); }
+
+    void vars_from_species_prefix( libMesh::FEMSystem* system );
+
+    std::string _prefix;
 
   private:
 

--- a/src/variables/include/grins/species_mass_fracs_variables.h
+++ b/src/variables/include/grins/species_mass_fracs_variables.h
@@ -51,9 +51,6 @@ namespace GRINS
 
     ~SpeciesMassFractionsVariables(){};
 
-    virtual void init( libMesh::FEMSystem* system )
-    { this->default_var_init(system); }
-
     unsigned int n_species() const;
 
     VariableIndex species( unsigned int species ) const;

--- a/src/variables/include/grins/species_mass_fracs_variables.h
+++ b/src/variables/include/grins/species_mass_fracs_variables.h
@@ -32,6 +32,7 @@
 // GRINS
 #include "grins/variables_base.h"
 #include "grins/materials_parsing.h"
+#include "grins/variables_parsing.h"
 
 // libMesh forward declarations
 class GetPot;
@@ -58,7 +59,7 @@ namespace GRINS
   protected:
 
     std::string subsection() const
-    { return "SpeciesMassFractions"; }
+    { return VariablesParsing::species_mass_fractions_section(); }
 
   private:
 

--- a/src/variables/include/grins/thermo_pressure_variable.h
+++ b/src/variables/include/grins/thermo_pressure_variable.h
@@ -28,6 +28,7 @@
 
 // GRINS
 #include "grins/single_variable.h"
+#include "grins/variables_parsing.h"
 
 namespace GRINS
 {
@@ -52,7 +53,7 @@ namespace GRINS
     { return "thermo_presure"; }
 
     std::string subsection() const
-    { return "ThermoPressure"; }
+    { return VariablesParsing::thermo_pressure_section(); }
 
     std::string default_name() const
     { return "p0"; }

--- a/src/variables/include/grins/turbulence_variables.h
+++ b/src/variables/include/grins/turbulence_variables.h
@@ -30,6 +30,7 @@ class GetPot;
 
 // GRINS
 #include "grins/single_variable.h"
+#include "grins/variables_parsing.h"
 
 namespace GRINS
 {
@@ -54,7 +55,7 @@ namespace GRINS
     { return "turbulent_viscosity"; }
 
     std::string subsection() const
-    { return "TurbulentViscosity"; }
+    { return VariablesParsing::turbulence_section(); }
 
     std::string default_name() const
     { return "nu"; }

--- a/src/variables/include/grins/variables_base.h
+++ b/src/variables/include/grins/variables_base.h
@@ -50,7 +50,12 @@ namespace GRINS
 
     ~VariablesBase(){};
 
-
+    //! Subclasses implement this to add variables to the system
+    /*! This method assumes that the variable names were setup
+        during construction. Then, we'll just grab the variable
+        number based on the variable name. */
+    virtual void init( libMesh::FEMSystem* system )
+    { this->default_var_init(system); }
 
   protected:
 

--- a/src/variables/include/grins/variables_base.h
+++ b/src/variables/include/grins/variables_base.h
@@ -57,6 +57,11 @@ namespace GRINS
     virtual void init_vars( libMesh::FEMSystem* system )
     { this->default_var_init(system); }
 
+    //! Return the var names that are active from this class
+    /*! This must not be called until init_vars has been called. */
+    const std::vector<std::string>& active_var_names() const
+    { return _var_names; }
+
   protected:
 
     //! Default method for init'ing variables

--- a/src/variables/include/grins/variables_base.h
+++ b/src/variables/include/grins/variables_base.h
@@ -50,11 +50,11 @@ namespace GRINS
 
     virtual ~VariablesBase(){};
 
-    //! Subclasses implement this to add variables to the system
+    //! Read, not add, variable numbers from the system
     /*! This method assumes that the variable names were setup
         during construction. Then, we'll just grab the variable
         number based on the variable name. */
-    virtual void init( libMesh::FEMSystem* system )
+    virtual void init_vars( libMesh::FEMSystem* system )
     { this->default_var_init(system); }
 
   protected:

--- a/src/variables/include/grins/variables_base.h
+++ b/src/variables/include/grins/variables_base.h
@@ -48,7 +48,7 @@ namespace GRINS
 
     VariablesBase(){};
 
-    ~VariablesBase(){};
+    virtual ~VariablesBase(){};
 
     //! Subclasses implement this to add variables to the system
     /*! This method assumes that the variable names were setup

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -31,6 +31,27 @@ namespace GRINS
   {
   public:
 
+    static std::string displacement_section()
+    { return "Displacement"; }
+
+    static std::string pressure_section()
+    { return "Pressure"; }
+
+    static std::string temperature_section()
+    { return "Temperature"; }
+
+    static std::string thermo_pressure_section()
+    { return "ThermoPressure"; }
+
+    static std::string turbulence_section()
+    { return "TurbulentViscosity"; }
+
+    static std::string species_mass_fractions_section()
+    { return "SpeciesMassFractions"; }
+
+    static std::string velocity_section()
+    { return "Velocity"; }
+
     //! Helper function to encapsualte the overall [Variables] section name.
     static std::string variables_section()
     { return "Variables"; }

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -52,6 +52,9 @@ namespace GRINS
     static std::string velocity_section()
     { return "Velocity"; }
 
+    static std::string generic_section()
+    { return "GenericVariable"; }
+
     //! Helper function to encapsualte the overall [Variables] section name.
     static std::string variables_section()
     { return "Variables"; }

--- a/src/variables/include/grins/velocity_variables.h
+++ b/src/variables/include/grins/velocity_variables.h
@@ -46,7 +46,7 @@ namespace GRINS
     VelocityVariables( const GetPot& input );
     ~VelocityVariables(){};
 
-    virtual void init( libMesh::FEMSystem* system );
+    virtual void init_vars( libMesh::FEMSystem* system );
 
     VariableIndex u() const;
     VariableIndex v() const;

--- a/src/variables/include/grins/velocity_variables.h
+++ b/src/variables/include/grins/velocity_variables.h
@@ -35,6 +35,7 @@ namespace libMesh
 
 // GRINS
 #include "grins/variables_base.h"
+#include "grins/variables_parsing.h"
 
 namespace GRINS
 {
@@ -55,7 +56,7 @@ namespace GRINS
   protected:
 
     std::string subsection() const
-    { return "Velocity"; }
+    { return VariablesParsing::velocity_section(); }
 
     unsigned int _u_idx, _v_idx, _w_idx;
 

--- a/src/variables/src/displacement_fe_variables.C
+++ b/src/variables/src/displacement_fe_variables.C
@@ -35,22 +35,26 @@
 namespace GRINS
 {
 
-  DisplacementFEVariables::DisplacementFEVariables( const GetPot& input, const std::string& physics_name )
+  DisplacementFEVariables::DisplacementFEVariables( const GetPot& input,
+                                                    const std::string& physics_name,
+                                                    bool is_2D, bool is_3D )
     :  SingleFETypeVariable(input,physics_name,"",this->subsection(),"LAGRANGE","FIRST"),
-       DisplacementVariables(input)
+       DisplacementVariables(input),
+       _is_2D(is_2D),
+       _is_3D(is_3D)
   {}
 
-  void DisplacementFEVariables::init( libMesh::FEMSystem* system, bool is_2D, bool is_3D )
+  void DisplacementFEVariables::init( libMesh::FEMSystem* system )
   {
     unsigned int mesh_dim = system->get_mesh().mesh_dimension();
 
     // The order matters here. We *must* do w first since we use pop_back().
-    if ( mesh_dim == 3 || is_3D )
+    if ( mesh_dim == 3 || _is_3D )
       _have_w = true;
     else
       _var_names.pop_back();
 
-    if ( mesh_dim >= 2 || is_2D || is_3D)
+    if ( mesh_dim >= 2 || _is_2D || _is_3D)
         _have_v = true;
     else
         _var_names.pop_back();

--- a/src/variables/src/displacement_variables.C
+++ b/src/variables/src/displacement_variables.C
@@ -60,7 +60,7 @@ namespace GRINS
       this->parse_names_from_input(input,this->subsection(),_var_names,default_names);
   }
 
-  void DisplacementVariables::init( libMesh::FEMSystem* system )
+  void DisplacementVariables::init_vars( libMesh::FEMSystem* system )
   {
     // The order matters here. We *must* do w first since we use pop_back().
     if ( system->has_variable( _var_names[_w_idx] ) )

--- a/src/variables/src/species_mass_fracs_variables.C
+++ b/src/variables/src/species_mass_fracs_variables.C
@@ -1,0 +1,59 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/species_mass_fracs_variables.h"
+
+// libMesh
+#include "libmesh/fem_system.h"
+
+namespace GRINS
+{
+  void SpeciesMassFractionsVariables::init_vars( libMesh::FEMSystem* system )
+  {
+    if( !_var_names.empty() )
+      VariablesBase::init_vars(system);
+    else
+      this->vars_from_species_prefix(system);
+  }
+
+  void SpeciesMassFractionsVariables::vars_from_species_prefix( libMesh::FEMSystem* system )
+  {
+    std::vector<unsigned int> all_var_nums;
+    system->get_all_variable_numbers(all_var_nums);
+
+    for( std::vector<unsigned int>::const_iterator it = all_var_nums.begin();
+         it < all_var_nums.end(); ++it )
+      {
+        const std::string& var_name = system->variable_name(*it);
+
+        if( var_name.find(_prefix) != std::string::npos )
+          {
+            _var_names.push_back(var_name);
+            _vars.push_back(*it);
+          }
+      }
+  }
+
+} // end namespace GRINS

--- a/src/variables/src/velocity_variables.C
+++ b/src/variables/src/velocity_variables.C
@@ -58,7 +58,7 @@ namespace GRINS
       this->parse_names_from_input(input,this->subsection(),_var_names,default_names);
   }
 
-  void VelocityVariables::init( libMesh::FEMSystem* system )
+  void VelocityVariables::init_vars( libMesh::FEMSystem* system )
   {
     libmesh_assert_greater_equal(system->get_mesh().mesh_dimension(), 2);
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -111,7 +111,8 @@ check_PROGRAMS += generic_amr_testing_app
 # Unit test source files
 unit_driver_SOURCES = unit/unit_driver.C \
                       unit/string_utils.C \
-                      unit/mesh_builder.C
+                      unit/mesh_builder.C \
+                      unit/variables.C
 antioch_mixture_SOURCES = unit/antioch_mixture.C
 arrhenius_catalycity_SOURCES = unit/arrhenius_catalycity.C
 cantera_mixture_SOURCES = unit/cantera_mixture.C

--- a/test/amr/input_files/convection_diffusion_unsteady_2d_amr.in
+++ b/test/amr/input_files/convection_diffusion_unsteady_2d_amr.in
@@ -44,7 +44,7 @@
 []
 
 [Variables]
-   [./ConvectionDiffusion]
+   [./GenericVariable:ConvectionDiffusion]
       names = 'u'
       fe_family = 'LAGRANGE'
       order = 'FIRST'

--- a/test/common/system_helper.h
+++ b/test/common/system_helper.h
@@ -1,0 +1,66 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// GRINS
+#include "grins/shared_ptr.h"
+#include "grins/multiphysics_sys.h"
+#include "grins/mesh_builder.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+#include "libmesh/unstructured_mesh.h"
+#include "libmesh/equation_systems.h"
+
+namespace GRINSTesting
+{
+  //! Helper class for setting up basic GRINS::MultiphysicsSystem for unit testing
+  class SystemHelper
+  {
+  protected:
+
+    void setup_multiphysics_system(const std::string& filename)
+    {
+      _input.reset( new GetPot(filename) );
+      GRINS::MeshBuilder mesh_builder;
+      _mesh = mesh_builder.build( *_input, *TestCommWorld );
+      _es.reset( new libMesh::EquationSystems(*_mesh) );
+      _system = &_es->add_system<GRINS::MultiphysicsSystem>( "GRINS-TEST" );
+    }
+
+    void reset_all()
+    {
+      _input.reset();
+      _es.reset(); // This will delete the system
+      _mesh.reset();
+    }
+
+    libMesh::UniquePtr<GetPot> _input;
+    GRINS::SharedPtr<libMesh::UnstructuredMesh> _mesh;
+    libMesh::UniquePtr<libMesh::EquationSystems> _es;
+
+    // Needs to be an ordinar pointer since EquationSystems owns this
+    GRINS::MultiphysicsSystem* _system;
+  };
+
+} // end namespace GRINSTesting

--- a/test/input_files/convection_diffusion_steady_1d.in
+++ b/test/input_files/convection_diffusion_steady_1d.in
@@ -32,7 +32,7 @@
 []
 
 [Variables]
-   [./ConvectionDiffusion]
+   [./GenericVariable:ConvectionDiffusion]
       names = 'u'
       fe_family = 'LAGRANGE'
       order = 'FIRST'

--- a/test/input_files/convection_diffusion_unsteady_2d.in
+++ b/test/input_files/convection_diffusion_unsteady_2d.in
@@ -44,7 +44,7 @@
 []
 
 [Variables]
-   [./ConvectionDiffusion]
+   [./GenericVariable:ConvectionDiffusion]
       names = 'u'
       fe_family = 'LAGRANGE'
       order = 'FIRST'

--- a/test/unit/input_files/variables_2d.in
+++ b/test/unit/input_files/variables_2d.in
@@ -20,5 +20,19 @@
       names = 'T'
       fe_family = 'LAGRANGE'
       order = 'FIRST'
+   [../SpeciesMassFractions]
+      names = 'Y_'
+      fe_family = 'LAGRANGE'
+      order = 'SECOND'
 []
 
+[Materials]
+  [./2SpeciesNGas]
+     [./GasMixture]
+        species   = 'N2 N'
+[]
+
+[Physics]
+   [./TestSpeciesMassFractionsVariables]
+      material = '2SpeciesNGas'
+[]

--- a/test/unit/input_files/variables_2d.in
+++ b/test/unit/input_files/variables_2d.in
@@ -1,0 +1,27 @@
+# Mesh related options
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD4'
+      n_elems_x = '10'
+      n_elems_y = '10'
+[]
+
+[Variables]
+   [./Velocity]
+      names = 'Ux Uy'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+   [../Pressure]
+      names = 'p'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+   [../Temperature]
+      names = 'T'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+[]
+
+[Physics]
+   enabled_physics = 'IncompressibleNavierStokes HeatTransfer'
+[]

--- a/test/unit/input_files/variables_2d.in
+++ b/test/unit/input_files/variables_2d.in
@@ -22,6 +22,3 @@
       order = 'FIRST'
 []
 
-[Physics]
-   enabled_physics = 'IncompressibleNavierStokes HeatTransfer'
-[]

--- a/test/unit/input_files/variables_3d.in
+++ b/test/unit/input_files/variables_3d.in
@@ -23,6 +23,3 @@
       order = 'FIRST'
 []
 
-[Physics]
-   enabled_physics = 'IncompressibleNavierStokes HeatTransfer'
-[]

--- a/test/unit/input_files/variables_3d.in
+++ b/test/unit/input_files/variables_3d.in
@@ -1,0 +1,28 @@
+# Mesh related options
+[Mesh]
+   [./Generation]
+      dimension = '3'
+      element_type = 'HEX8'
+      n_elems_x = '10'
+      n_elems_y = '10'
+      n_elems_z = '2'
+[]
+
+[Variables]
+   [./Velocity]
+      names = 'Ux Uy Uz'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+   [../Pressure]
+      names = 'p'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+   [../Temperature]
+      names = 'T'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+[]
+
+[Physics]
+   enabled_physics = 'IncompressibleNavierStokes HeatTransfer'
+[]

--- a/test/unit/variables.C
+++ b/test/unit/variables.C
@@ -49,7 +49,7 @@ namespace GRINSTesting
     CPPUNIT_TEST_SUITE( VariablesTest );
 
     CPPUNIT_TEST( test_velocity_2d );
-    //CPPUNIT_TEST( test_velocity_3d );
+    CPPUNIT_TEST( test_velocity_3d );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -90,6 +90,36 @@ namespace GRINSTesting
       }
     }
 
+    void test_velocity_3d()
+    {
+      std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/variables_3d.in";
+      this->setup_multiphysics_system(filename);
+
+      // This will add the variables to the system
+      {
+        GRINS::VelocityFEVariables vel_vars(*_input,GRINS::PhysicsNaming::incompressible_navier_stokes());
+        vel_vars.init(_system);
+        CPPUNIT_ASSERT_EQUAL((unsigned int)3,_system->n_vars());
+
+        const std::vector<std::string>& var_names = vel_vars.active_var_names();
+        this->test_vel_var_names_3d(var_names);
+
+        // Verify the FE part
+        this->test_vel_fe_3d(*_system);
+      }
+
+      // Now we should be able to also use a basic VelocityVariables class
+      // and get the right var names out once the variables are added to the
+      // system
+      {
+        GRINS::VelocityVariables vel_vars(*_input);
+        vel_vars.init_vars(_system);
+
+        const std::vector<std::string>& var_names = vel_vars.active_var_names();
+        this->test_vel_var_names_3d(var_names);
+      }
+    }
+
   private:
 
     void test_vel_var_names_2d( const std::vector<std::string>& var_names )
@@ -100,6 +130,15 @@ namespace GRINSTesting
       CPPUNIT_ASSERT_EQUAL(std::string("Uy"),var_names[1]);
     }
 
+    void test_vel_var_names_3d( const std::vector<std::string>& var_names )
+    {
+      // For 3-D, we should have 3 components
+      CPPUNIT_ASSERT_EQUAL(3,(int)var_names.size());
+      CPPUNIT_ASSERT_EQUAL(std::string("Ux"),var_names[0]);
+      CPPUNIT_ASSERT_EQUAL(std::string("Uy"),var_names[1]);
+      CPPUNIT_ASSERT_EQUAL(std::string("Uz"),var_names[2]);
+    }
+
     void test_vel_fe_2d( const libMesh::System& system )
     {
       libMesh::Order order = system.variable_type("Ux").order;
@@ -108,6 +147,14 @@ namespace GRINSTesting
 
       order = system.variable_type("Uy").order;
       CPPUNIT_ASSERT_EQUAL(GRINSEnums::LAGRANGE,system.variable_type("Uy").family);
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::FIRST,order);
+    }
+
+    void test_vel_fe_3d( const libMesh::System& system )
+    {
+      this->test_vel_fe_2d(system);
+      libMesh::Order order = system.variable_type("Uz").order;
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::LAGRANGE,system.variable_type("Uz").family);
       CPPUNIT_ASSERT_EQUAL(GRINSEnums::FIRST,order);
     }
 

--- a/test/unit/variables.C
+++ b/test/unit/variables.C
@@ -38,6 +38,7 @@
 #include "grins/grins_enums.h"
 #include "grins/velocity_fe_variables.h"
 #include "grins/primitive_temp_fe_variables.h"
+#include "grins/species_mass_fracs_fe_variables.h"
 
 namespace GRINSTesting
 {
@@ -50,6 +51,7 @@ namespace GRINSTesting
     CPPUNIT_TEST( test_velocity_2d );
     CPPUNIT_TEST( test_velocity_3d );
     CPPUNIT_TEST( test_temp );
+    CPPUNIT_TEST( test_species_mass_fracs );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -150,6 +152,44 @@ namespace GRINSTesting
       }
     }
 
+    void test_species_mass_fracs()
+    {
+      std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/variables_2d.in";
+      this->setup_multiphysics_system(filename);
+
+      // This will add the variables to the system
+      {
+        GRINS::SpeciesMassFractionsFEVariables species_vars(*_input,"TestSpeciesMassFractionsVariables");
+        species_vars.init(_system);
+        CPPUNIT_ASSERT_EQUAL((unsigned int)2,_system->n_vars());
+
+        const std::vector<std::string>& var_names = species_vars.active_var_names();
+        this->test_species_var_names(var_names);
+
+        // Verify the FE part
+        this->test_species_fe(*_system);
+      }
+
+      // Now we should be able to also use a basic SpeciesMassFractionsVariables class
+      // and get the right var names out once the variables are added to the
+      // system. Note we're testing the "GetPot" only constructor
+      // exercising the case where the material name is not available.
+      {
+        GRINS::SpeciesMassFractionsVariables species_vars(*_input);
+        species_vars.init_vars(_system);
+
+        const std::vector<std::string>& var_names =
+        species_vars.active_var_names();
+
+        // For this one, we can't guarantee the order, so we check to
+        // make sure both the species are there.
+        CPPUNIT_ASSERT( std::find( var_names.begin(), var_names.end(),"Y_N2")
+                        != var_names.end() );
+        CPPUNIT_ASSERT( std::find( var_names.begin(), var_names.end(),"Y_N")
+                        != var_names.end() );
+      }
+    }
+
   private:
 
     void test_vel_var_names_2d( const std::vector<std::string>& var_names )
@@ -173,6 +213,13 @@ namespace GRINSTesting
     {
       CPPUNIT_ASSERT_EQUAL(1,(int)var_names.size());
       CPPUNIT_ASSERT_EQUAL(std::string("T"),var_names[0]);
+    }
+
+    void test_species_var_names( const std::vector<std::string>& var_names )
+    {
+      CPPUNIT_ASSERT_EQUAL(2,(int)var_names.size());
+      CPPUNIT_ASSERT_EQUAL(std::string("Y_N2"),var_names[0]);
+      CPPUNIT_ASSERT_EQUAL(std::string("Y_N"),var_names[1]);
     }
 
     void test_vel_fe_2d( const libMesh::System& system )
@@ -201,6 +248,17 @@ namespace GRINSTesting
       CPPUNIT_ASSERT_EQUAL(GRINSEnums::FIRST,order);
     }
 
+
+    void test_species_fe( const libMesh::System& system )
+    {
+      libMesh::Order order = system.variable_type("Y_N2").order;
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::LAGRANGE,system.variable_type("Y_N2").family);
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::SECOND,order);
+
+      order = system.variable_type("Y_N").order;
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::LAGRANGE,system.variable_type("Y_N").family);
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::SECOND,order);
+    }
   };
 
   CPPUNIT_TEST_SUITE_REGISTRATION( VariablesTest );

--- a/test/unit/variables.C
+++ b/test/unit/variables.C
@@ -1,0 +1,120 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+// Testing headers
+#include "test_comm.h"
+#include "grins_test_paths.h"
+#include "system_helper.h"
+
+// GRINS
+#include "grins/grins_enums.h"
+#include "grins/physics_naming.h"
+#include "grins/velocity_variables.h"
+#include "grins/velocity_fe_variables.h"
+
+namespace GRINSTesting
+{
+  class VariablesTest : public CppUnit::TestCase,
+                        public SystemHelper
+  {
+  public:
+    CPPUNIT_TEST_SUITE( VariablesTest );
+
+    CPPUNIT_TEST( test_velocity_2d );
+    //CPPUNIT_TEST( test_velocity_3d );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+
+    void tearDown()
+    {
+      this->reset_all();
+    }
+
+    void test_velocity_2d()
+    {
+      std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/variables_2d.in";
+      this->setup_multiphysics_system(filename);
+
+      // This will add the variables to the system
+      {
+        GRINS::VelocityFEVariables vel_vars(*_input,GRINS::PhysicsNaming::incompressible_navier_stokes());
+        vel_vars.init(_system);
+        CPPUNIT_ASSERT_EQUAL((unsigned int)2,_system->n_vars());
+
+        const std::vector<std::string>& var_names = vel_vars.active_var_names();
+        this->test_vel_var_names_2d(var_names);
+
+        // Verify the FE part
+        this->test_vel_fe_2d(*_system);
+      }
+
+      // Now we should be able to also use a basic VelocityVariables class
+      // and get the right var names out once the variables are added to the
+      // system
+      {
+        GRINS::VelocityVariables vel_vars(*_input);
+        vel_vars.init_vars(_system);
+
+        const std::vector<std::string>& var_names = vel_vars.active_var_names();
+        this->test_vel_var_names_2d(var_names);
+      }
+    }
+
+  private:
+
+    void test_vel_var_names_2d( const std::vector<std::string>& var_names )
+    {
+      // For 2-D, we should only have 2 components
+      CPPUNIT_ASSERT_EQUAL(2,(int)var_names.size());
+      CPPUNIT_ASSERT_EQUAL(std::string("Ux"),var_names[0]);
+      CPPUNIT_ASSERT_EQUAL(std::string("Uy"),var_names[1]);
+    }
+
+    void test_vel_fe_2d( const libMesh::System& system )
+    {
+      libMesh::Order order = system.variable_type("Ux").order;
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::LAGRANGE,system.variable_type("Ux").family);
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::FIRST,order);
+
+      order = system.variable_type("Uy").order;
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::LAGRANGE,system.variable_type("Uy").family);
+      CPPUNIT_ASSERT_EQUAL(GRINSEnums::FIRST,order);
+    }
+
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( VariablesTest );
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_CPPUNIT

--- a/test/unit/variables.C
+++ b/test/unit/variables.C
@@ -36,8 +36,6 @@
 
 // GRINS
 #include "grins/grins_enums.h"
-#include "grins/physics_naming.h"
-#include "grins/velocity_variables.h"
 #include "grins/velocity_fe_variables.h"
 
 namespace GRINSTesting
@@ -67,7 +65,7 @@ namespace GRINSTesting
 
       // This will add the variables to the system
       {
-        GRINS::VelocityFEVariables vel_vars(*_input,GRINS::PhysicsNaming::incompressible_navier_stokes());
+        GRINS::VelocityFEVariables vel_vars(*_input,"PhysicsNameIsDUMMYForThisTest");
         vel_vars.init(_system);
         CPPUNIT_ASSERT_EQUAL((unsigned int)2,_system->n_vars());
 
@@ -97,7 +95,7 @@ namespace GRINSTesting
 
       // This will add the variables to the system
       {
-        GRINS::VelocityFEVariables vel_vars(*_input,GRINS::PhysicsNaming::incompressible_navier_stokes());
+        GRINS::VelocityFEVariables vel_vars(*_input,"PhysicsNameIsDUMMYForThisTest");
         vel_vars.init(_system);
         CPPUNIT_ASSERT_EQUAL((unsigned int)3,_system->n_vars());
 


### PR DESCRIPTION
Refactored how we handle init'ing the `VariableBase` vs. the `FEVariablesBase`. What was there before was confusing. Now, we have an `init_vars` (extracting variable numbers from the `System`) for `VariablesBase` and `init` (adding variables to the `System`) for `FEVariablesBase`. 

Added CppUnit-based testing for most of the variable classes. That addition included adding a testing helper class for setting up a basic `MultiphysicsSystem` for these kinds of tests.

This refactoring is to promote the use of `VariableBase` factories downstream, which will then in turn be used in boundary condition registration refactoring.