### PR TITLE
Factory Restructure

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -290,6 +290,7 @@ include_HEADERS += boundary_conditions/include/grins/power_law_catalycity.h
 # src/common headers
 include_HEADERS += common/include/grins/common.h
 include_HEADERS += common/include/grins/factory_with_getpot.h
+include_HEADERS += common/include/grins/factory_with_getpot_physics_name.h
 
 # src/error_estimation headers
 include_HEADERS += error_estimation/include/grins/error_estimation_factory.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -289,6 +289,7 @@ include_HEADERS += boundary_conditions/include/grins/power_law_catalycity.h
 
 # src/common headers
 include_HEADERS += common/include/grins/common.h
+include_HEADERS += common/include/grins/factory_with_getpot.h
 
 # src/error_estimation headers
 include_HEADERS += error_estimation/include/grins/error_estimation_factory.h

--- a/src/common/include/grins/factory_with_getpot.h
+++ b/src/common/include/grins/factory_with_getpot.h
@@ -22,26 +22,38 @@
 //
 //-----------------------------------------------------------------------el-
 
-// This class
-#include "grins/physics_factory_base.h"
+#ifndef GRINS_FACTORY_WITH_GETPOT_H
+#define GRINS_FACTORY_WITH_GETPOT_H
 
-// Full specialization for the Factory<Physics>
-namespace libMesh
-{
-  template<>
-  std::map<std::string, libMesh::Factory<GRINS::Physics>*>&
-  libMesh::Factory<GRINS::Physics>::factory_map()
-  {
-    static std::map<std::string, libMesh::Factory<GRINS::Physics>*> _map;
-    return _map;
-  }
-} // end namespace libMesh
+// libMesh
+#include "libmesh/factory.h"
+#include "libmesh/getpot.h"
 
-// Definition of static members
 namespace GRINS
 {
-  std::string PhysicsFactoryBase::_physics_name = std::string("DIE!");
+  //! Abstract factory that provides availability of GetPot
+  template<typename Base>
+  class FactoryWithGetPot : public libMesh::Factory<Base>
+  {
+  public:
+    FactoryWithGetPot( const std::string& name )
+      : libMesh::Factory<Base>(name)
+    {}
 
-  template<>
-  const GetPot* FactoryWithGetPot<Physics>::_input = NULL;
+    ~FactoryWithGetPot(){};
+
+    static void set_getpot( const GetPot& input )
+    { _input = &input; }
+
+  protected:
+
+    /*! We store only a raw pointer here because we *can't* make a copy.
+        Otherwise, the UFO detection will be all screwed. We are not taking
+        ownership of this, so we need to *not* delete this.*/
+    static const GetPot* _input;
+
+  };
+
 } // end namespace GRINS
+
+#endif // GRINS_FACTORY_WITH_GETPOT_H

--- a/src/common/include/grins/factory_with_getpot_physics_name.h
+++ b/src/common/include/grins/factory_with_getpot_physics_name.h
@@ -1,0 +1,62 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_FACTORY_WITH_GETPOT_PHYSICS_NAME_H
+#define GRINS_FACTORY_WITH_GETPOT_PHYSICS_NAME_H
+
+// GRINS
+#include "grins/factory_with_getpot.h"
+
+namespace GRINS
+{
+  //! Abstract factory that provides availability of GetPot and a physics_name
+  template<typename Base>
+  class FactoryWithGetPotPhysicsName : public FactoryWithGetPot<Base>
+  {
+  public:
+    FactoryWithGetPotPhysicsName( const std::string& name )
+      : FactoryWithGetPot<Base>(name)
+    {}
+
+    ~FactoryWithGetPotPhysicsName(){};
+
+    //! Setter for physics name
+    /*! We need the physics_name to pass to the constructor, so we need
+        to provide a hook to get it. Note that this should be the "full"
+        physics name, including suffixes, etc. Subclasses dictate final
+        behavior, but generally, this MUST be called each time build()
+        is called as the expected behavior is for the physics_name to
+        be reset after the build() call. */
+    static void set_physics_name( const std::string& physics_name )
+    { _physics_name = physics_name; }
+
+  protected:
+
+    static std::string _physics_name;
+
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_FACTORY_WITH_GETPOT_PHYSICS_NAME_H

--- a/src/physics/include/grins/physics_factory_base.h
+++ b/src/physics/include/grins/physics_factory_base.h
@@ -26,11 +26,8 @@
 #define GRINS_PHYSICS_FACTORY_BASE_H
 
 // GRINS
+#include "grins/factory_with_getpot.h"
 #include "grins/physics.h"
-
-// libMesh
-#include "libmesh/factory.h"
-#include "libmesh/getpot.h"
 
 namespace GRINS
 {
@@ -40,11 +37,11 @@ namespace GRINS
       at construction time, both set_getpot() and  set_physics_name() MUST be called
       before build() function. Note that set_physics_name() MUST be called each time
       a new Physics is built.*/
-  class PhysicsFactoryBase : public libMesh::Factory<Physics>
+  class PhysicsFactoryBase : public FactoryWithGetPot<Physics>
   {
   public:
     PhysicsFactoryBase( const std::string& physics_name )
-      : Factory<Physics>(physics_name)
+      : FactoryWithGetPot<Physics>(physics_name)
     {}
 
     ~PhysicsFactoryBase(){};
@@ -57,20 +54,12 @@ namespace GRINS
     static void set_physics_name( const std::string& physics_name )
     { _physics_name = physics_name; }
 
-    static void set_getpot( const GetPot& input )
-    { _input = &input; }
-
   protected:
 
     virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name ) =0;
 
     static std::string _physics_name;
-
-    /*! We store only a raw pointer here because we *can't* make a copy.
-        Otherwise, the UFO detection will be all screwed. We are not taking
-        ownership of this, so we need to *not* delete this.*/
-    static const GetPot* _input;
 
   private:
 

--- a/src/physics/include/grins/physics_factory_base.h
+++ b/src/physics/include/grins/physics_factory_base.h
@@ -26,7 +26,7 @@
 #define GRINS_PHYSICS_FACTORY_BASE_H
 
 // GRINS
-#include "grins/factory_with_getpot.h"
+#include "grins/factory_with_getpot_physics_name.h"
 #include "grins/physics.h"
 
 namespace GRINS
@@ -37,29 +37,19 @@ namespace GRINS
       at construction time, both set_getpot() and  set_physics_name() MUST be called
       before build() function. Note that set_physics_name() MUST be called each time
       a new Physics is built.*/
-  class PhysicsFactoryBase : public FactoryWithGetPot<Physics>
+  class PhysicsFactoryBase : public FactoryWithGetPotPhysicsName<Physics>
   {
   public:
     PhysicsFactoryBase( const std::string& physics_name )
-      : FactoryWithGetPot<Physics>(physics_name)
+      : FactoryWithGetPotPhysicsName<Physics>(physics_name)
     {}
 
     ~PhysicsFactoryBase(){};
-
-    //! Setter for physics name
-    /*! We need the physics_name to pass to the constructor, so we need
-        to provide a hook to get it. Note that this should be the "full"
-        physics name, including suffixes, etc.  MUST be called each time
-        a new Physics is built as we reset the internal name each time. */
-    static void set_physics_name( const std::string& physics_name )
-    { _physics_name = physics_name; }
 
   protected:
 
     virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name ) =0;
-
-    static std::string _physics_name;
 
   private:
 

--- a/src/physics/src/physics_factory_base.C
+++ b/src/physics/src/physics_factory_base.C
@@ -40,7 +40,8 @@ namespace libMesh
 // Definition of static members
 namespace GRINS
 {
-  std::string PhysicsFactoryBase::_physics_name = std::string("DIE!");
+  template<>
+  std::string FactoryWithGetPotPhysicsName<Physics>::_physics_name = std::string("DIE!");
 
   template<>
   const GetPot* FactoryWithGetPot<Physics>::_input = NULL;


### PR DESCRIPTION
Add a couple of low-level abstract factories so that we can reuse things like `set_getpot` across many different factories.