### PR TITLE
Variable Factories

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -217,6 +217,7 @@ libgrins_la_SOURCES += variables/src/displacement_variables.C
 libgrins_la_SOURCES += variables/src/displacement_fe_variables.C
 libgrins_la_SOURCES += variables/src/species_mass_fracs_variables.C
 libgrins_la_SOURCES += variables/src/variables_factory_base.C
+libgrins_la_SOURCES += variables/src/variables_factory.C
 
 # src/utilities files
 libgrins_la_SOURCES += utilities/src/grins_version.C
@@ -483,6 +484,7 @@ include_HEADERS += variables/include/grins/variable_name_defaults.h
 include_HEADERS += variables/include/grins/variables_base.h
 include_HEADERS += variables/include/grins/variables_parsing.h
 include_HEADERS += variables/include/grins/variables_factory_base.h
+include_HEADERS += variables/include/grins/variables_factory.h
 
 # src/utilities headers
 include_HEADERS += $(top_builddir)/src/utilities/include/grins/grins_version.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -218,6 +218,7 @@ libgrins_la_SOURCES += variables/src/displacement_fe_variables.C
 libgrins_la_SOURCES += variables/src/species_mass_fracs_variables.C
 libgrins_la_SOURCES += variables/src/variables_factory_base.C
 libgrins_la_SOURCES += variables/src/variables_factory.C
+libgrins_la_SOURCES += variables/src/variables_factory_with_physics_name.C
 
 # src/utilities files
 libgrins_la_SOURCES += utilities/src/grins_version.C
@@ -485,6 +486,7 @@ include_HEADERS += variables/include/grins/variables_base.h
 include_HEADERS += variables/include/grins/variables_parsing.h
 include_HEADERS += variables/include/grins/variables_factory_base.h
 include_HEADERS += variables/include/grins/variables_factory.h
+include_HEADERS += variables/include/grins/variables_factory_with_physics_name.h
 
 # src/utilities headers
 include_HEADERS += $(top_builddir)/src/utilities/include/grins/grins_version.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -216,6 +216,7 @@ libgrins_la_SOURCES += variables/src/velocity_fe_variables.C
 libgrins_la_SOURCES += variables/src/displacement_variables.C
 libgrins_la_SOURCES += variables/src/displacement_fe_variables.C
 libgrins_la_SOURCES += variables/src/species_mass_fracs_variables.C
+libgrins_la_SOURCES += variables/src/variables_factory_base.C
 
 # src/utilities files
 libgrins_la_SOURCES += utilities/src/grins_version.C
@@ -481,6 +482,7 @@ include_HEADERS += variables/include/grins/turbulence_fe_variables.h
 include_HEADERS += variables/include/grins/variable_name_defaults.h
 include_HEADERS += variables/include/grins/variables_base.h
 include_HEADERS += variables/include/grins/variables_parsing.h
+include_HEADERS += variables/include/grins/variables_factory_base.h
 
 # src/utilities headers
 include_HEADERS += $(top_builddir)/src/utilities/include/grins/grins_version.h

--- a/src/variables/include/grins/variables_factory.h
+++ b/src/variables/include/grins/variables_factory.h
@@ -1,0 +1,54 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_VARIABLES_FACTORY_H
+#define GRINS_VARIABLES_FACTORY_H
+
+// GRINS
+#include "grins/variables_factory_base.h"
+
+namespace GRINS
+{
+  //! Builds common types of VariablesBase objects
+  /*! This factory will build VariablesBase subclasses that only
+      require a GetPot object to their constructor. */
+  template<typename DerivedVariables>
+  class VariablesFactory : public VariablesFactoryBase
+  {
+  public:
+    VariablesFactory( const std::string& variable_name )
+      : VariablesFactoryBase(variable_name)
+    {}
+
+    ~VariablesFactory(){};
+
+  protected:
+
+    virtual libMesh::UniquePtr<VariablesBase> build_vars( const GetPot& input );
+
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_VARIABLES_FACTORY_H

--- a/src/variables/include/grins/variables_factory_base.h
+++ b/src/variables/include/grins/variables_factory_base.h
@@ -1,0 +1,73 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_VARIABLES_FACTORY_BASE_H
+#define GRINS_VARIABLES_FACTORY_BASE_H
+
+// GRINS
+#include "grins/factory_with_getpot_physics_name.h"
+#include "grins/variables_base.h"
+
+namespace GRINS
+{
+  //! Builds VariableBase objects
+  /*! Most variable classes only require a GetPot object to the constructor, but
+      others may require more information. Subclasses can dictate the necessary
+      behavior. */
+  class VariablesFactoryBase : public FactoryWithGetPotPhysicsName<VariablesBase>
+  {
+  public:
+    VariablesFactoryBase( const std::string& variable_name )
+      : FactoryWithGetPotPhysicsName<VariablesBase>(variable_name)
+    {}
+
+    ~VariablesFactoryBase(){};
+
+  protected:
+
+    //! Subclasses implement this method for building the VariablesBase object.
+    virtual libMesh::UniquePtr<VariablesBase> build_vars( const GetPot& input ) =0;
+
+  private:
+
+    virtual libMesh::UniquePtr<VariablesBase> create();
+
+  };
+
+  inline
+  libMesh::UniquePtr<VariablesBase> VariablesFactoryBase::create()
+  {
+    if( !_input )
+      libmesh_error_msg("ERROR: must call set_getpot() before building VariablesBase!");
+
+    libMesh::UniquePtr<VariablesBase> new_vars = this->build_vars( *_input );
+
+    libmesh_assert(new_vars);
+
+    return new_vars;
+  }
+
+} // end namespace GRINS
+
+#endif // GRINS_VARIABLES_FACTORY_BASE_H

--- a/src/variables/include/grins/variables_factory_with_physics_name.h
+++ b/src/variables/include/grins/variables_factory_with_physics_name.h
@@ -1,0 +1,55 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_VARIABLES_FACTORY_WITH_PHYSICS_NAME_H
+#define GRINS_VARIABLES_FACTORY_WITH_PHYSICS_NAME_H
+
+// GRINS
+#include "grins/variables_factory_base.h"
+
+namespace GRINS
+{
+  //! Builds VariablesBase objects that require physics_name in the constructor
+  /*! This factory will build VariablesBase subclasses that
+      require a GetPot object to their constructor. Examples include
+      the GenericVariable. */
+  template<typename DerivedVariables>
+  class VariablesFactoryWithPhysicsName : public VariablesFactoryBase
+  {
+  public:
+    VariablesFactoryWithPhysicsName( const std::string& variable_name )
+      : VariablesFactoryBase(variable_name)
+    {}
+
+    ~VariablesFactoryWithPhysicsName(){};
+
+  protected:
+
+    virtual libMesh::UniquePtr<VariablesBase> build_vars( const GetPot& input );
+
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_VARIABLES_FACTORY_WITH_PHYSICS_NAME_H

--- a/src/variables/src/variables_factory.C
+++ b/src/variables/src/variables_factory.C
@@ -1,0 +1,54 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/variables_factory.h"
+
+// GRINS
+#include "grins/variables_parsing.h"
+#include "grins/displacement_variables.h"
+#include "grins/pressure_variable.h"
+#include "grins/primitive_temp_variables.h"
+#include "grins/thermo_pressure_variable.h"
+#include "grins/turbulence_variables.h"
+#include "grins/velocity_variables.h"
+#include "grins/species_mass_fracs_variables.h"
+
+namespace GRINS
+{
+  template<typename DerivedVariables>
+  libMesh::UniquePtr<VariablesBase> VariablesFactory<DerivedVariables>::build_vars( const GetPot& input )
+  {
+    return libMesh::UniquePtr<VariablesBase>( new DerivedVariables(input) );
+  }
+
+  // Instantiate all the "Basic" Variables factories.
+  // These shouldn't be directly used by the user, we just need to instantiate them.
+  VariablesFactory<DisplacementVariables> grins_factory_displacement_vars(VariablesParsing::displacement_section());
+  VariablesFactory<PressureVariable> grins_factory_pressure_var(VariablesParsing::pressure_section());
+  VariablesFactory<PrimitiveTempVariables> grins_factory_prim_temp_vars(VariablesParsing::temperature_section());
+  VariablesFactory<ThermoPressureVariable> grins_factory_thermo_pressure_var(VariablesParsing::thermo_pressure_section());
+  VariablesFactory<VelocityVariables> grins_factory_velocity_vars(VariablesParsing::velocity_section());
+  VariablesFactory<SpeciesMassFractionsVariables> grins_factory_species_mass_frac_vars(VariablesParsing::species_mass_fractions_section());
+} // end namespace GRINS

--- a/src/variables/src/variables_factory_base.C
+++ b/src/variables/src/variables_factory_base.C
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/variables_factory_base.h"
+
+// Full specialization for the Factory<VariablesBase>
+namespace libMesh
+{
+  template<>
+  std::map<std::string, libMesh::Factory<GRINS::VariablesBase>*>&
+  libMesh::Factory<GRINS::VariablesBase>::factory_map()
+  {
+    static std::map<std::string, libMesh::Factory<GRINS::VariablesBase>*> _map;
+    return _map;
+  }
+} // end namespace libMesh
+
+// Definition of static members
+namespace GRINS
+{
+  template<>
+  std::string FactoryWithGetPotPhysicsName<VariablesBase>::_physics_name = std::string("DIE!");
+
+  template<>
+  const GetPot* FactoryWithGetPot<VariablesBase>::_input = NULL;
+} // end namespace GRINS

--- a/src/variables/src/variables_factory_with_physics_name.C
+++ b/src/variables/src/variables_factory_with_physics_name.C
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/variables_factory_with_physics_name.h"
+
+// GRINS
+#include "grins/variables_parsing.h"
+#include "grins/generic_variable.h"
+
+namespace GRINS
+{
+  template<typename DerivedVariables>
+  libMesh::UniquePtr<VariablesBase> VariablesFactoryWithPhysicsName<DerivedVariables>::build_vars( const GetPot& input )
+  {
+    // Make sure user set the physics name
+    if( _physics_name == std::string("DIE!") )
+      libmesh_error_msg("ERROR: must call set_physics_name() before building VariablesBase!");
+
+    libMesh::UniquePtr<VariablesBase> new_var( new DerivedVariables(input,_physics_name) );
+
+    // Reset the _physics_name for error checking
+    _physics_name = std::string("DIE!");
+
+    return new_var;
+  }
+
+  // Instantiate all the Variables factories that require a physics_name in the constructor
+  // These shouldn't be directly used by the user, we just need to instantiate them.
+  VariablesFactoryWithPhysicsName<GenericVariable> grins_factory_generic_var(VariablesParsing::generic_section());
+
+} // end namespace GRINS

--- a/test/unit/variables.C
+++ b/test/unit/variables.C
@@ -39,6 +39,7 @@
 #include "grins/velocity_fe_variables.h"
 #include "grins/primitive_temp_fe_variables.h"
 #include "grins/species_mass_fracs_fe_variables.h"
+#include "grins/variables_factory.h"
 
 namespace GRINSTesting
 {
@@ -90,6 +91,16 @@ namespace GRINSTesting
         const std::vector<std::string>& var_names = vel_vars.active_var_names();
         this->test_vel_var_names_2d(var_names);
       }
+
+      // Now try using the variables factory
+      {
+        GRINS::VariablesFactoryBase::set_getpot(*_input);
+        libMesh::UniquePtr<GRINS::VariablesBase> vel_vars =  GRINS::VariablesFactoryBase::build("Velocity");
+        vel_vars->init_vars(_system);
+
+        const std::vector<std::string>& var_names = vel_vars->active_var_names();
+        this->test_vel_var_names_2d(var_names);
+      }
     }
 
     void test_velocity_3d()
@@ -118,6 +129,16 @@ namespace GRINSTesting
         vel_vars.init_vars(_system);
 
         const std::vector<std::string>& var_names = vel_vars.active_var_names();
+        this->test_vel_var_names_3d(var_names);
+      }
+
+      // Now try using the variables factory
+      {
+        GRINS::VariablesFactoryBase::set_getpot(*_input);
+        libMesh::UniquePtr<GRINS::VariablesBase> vel_vars =  GRINS::VariablesFactoryBase::build("Velocity");
+        vel_vars->init_vars(_system);
+
+        const std::vector<std::string>& var_names = vel_vars->active_var_names();
         this->test_vel_var_names_3d(var_names);
       }
     }
@@ -150,6 +171,16 @@ namespace GRINSTesting
         const std::vector<std::string>& var_names = temp_vars.active_var_names();
         this->test_temp_var_names(var_names);
       }
+
+      // Now try using the variables factory
+      {
+        GRINS::VariablesFactoryBase::set_getpot(*_input);
+        libMesh::UniquePtr<GRINS::VariablesBase> temp_vars =  GRINS::VariablesFactoryBase::build("Temperature");
+        temp_vars->init_vars(_system);
+
+        const std::vector<std::string>& var_names = temp_vars->active_var_names();
+        this->test_temp_var_names(var_names);
+      }
     }
 
     void test_species_mass_fracs()
@@ -180,13 +211,17 @@ namespace GRINSTesting
 
         const std::vector<std::string>& var_names =
         species_vars.active_var_names();
+        this->test_species_var_names_no_order(var_names);
+      }
 
-        // For this one, we can't guarantee the order, so we check to
-        // make sure both the species are there.
-        CPPUNIT_ASSERT( std::find( var_names.begin(), var_names.end(),"Y_N2")
-                        != var_names.end() );
-        CPPUNIT_ASSERT( std::find( var_names.begin(), var_names.end(),"Y_N")
-                        != var_names.end() );
+      // Now try using the variables factory
+      {
+        GRINS::VariablesFactoryBase::set_getpot(*_input);
+        libMesh::UniquePtr<GRINS::VariablesBase> species_vars =  GRINS::VariablesFactoryBase::build("SpeciesMassFractions");
+        species_vars->init_vars(_system);
+
+        const std::vector<std::string>& var_names = species_vars->active_var_names();
+        this->test_species_var_names_no_order(var_names);
       }
     }
 
@@ -220,6 +255,17 @@ namespace GRINSTesting
       CPPUNIT_ASSERT_EQUAL(2,(int)var_names.size());
       CPPUNIT_ASSERT_EQUAL(std::string("Y_N2"),var_names[0]);
       CPPUNIT_ASSERT_EQUAL(std::string("Y_N"),var_names[1]);
+    }
+
+    void test_species_var_names_no_order( const std::vector<std::string>& var_names )
+    {
+      // For this one, we can't guarantee the order, so we check to
+      // make sure both the species are there.
+      CPPUNIT_ASSERT_EQUAL(2,(int)var_names.size());
+      CPPUNIT_ASSERT( std::find( var_names.begin(), var_names.end(),"Y_N2")
+                        != var_names.end() );
+      CPPUNIT_ASSERT( std::find( var_names.begin(), var_names.end(),"Y_N")
+                        != var_names.end() );
     }
 
     void test_vel_fe_2d( const libMesh::System& system )


### PR DESCRIPTION
This PR adds factories for building `VariableBase` objects. We don't use these in the `Physics` as that's not the intended use case. Instead, we will use these to extract variable names during the boundary condition construction (downstream of this PR). This included CppUnit-based testing of several of the factories and testing of the use of `init_vars` in the intended use case.