### PR TITLE
Remove parabolic_profile from test input files

### DIFF
--- a/test/input_files/axisym_reacting_low_mach_antioch_cea_constant_regression.in
+++ b/test/input_files/axisym_reacting_low_mach_antioch_cea_constant_regression.in
@@ -44,15 +44,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '0 1 3'
-vel_bc_types = 'parabolic_profile no_slip axisymmetric'
-
-parabolic_profile_var_0 = 'v'
-parabolic_profile_fix_0 = 'u'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_0 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids       = '0 0 1 3'
+vel_bc_types     = 'parsed_dirichlet parsed_dirichlet no_slip axisymmetric'
+vel_bc_variables = 'v u na na'
+vel_bc_values    = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '0 1'
 temp_bc_types = 'isothermal isothermal'

--- a/test/input_files/backward_facing_step.in
+++ b/test/input_files/backward_facing_step.in
@@ -27,12 +27,10 @@ material = 'TestMaterial'
 # 2 - no slip walls
 # 3 - outlet
 
-bc_ids = '1 2'
-bc_types = 'parabolic_profile no_slip'
-
-parabolic_profile_coeffs_1 = '0.0 0.0 -480.0 0.0 240.0 0.0'
-parabolic_profile_var_1 = 'u'
-parabolic_profile_fix_1 = 'v'
+bc_ids = '1 1 2'
+bc_types = 'parsed_dirichlet parsed_dirichlet no_slip'
+bc_variables = 'u v na'
+bc_values = '240.0*y*(1-2*y) 0.0 na'
 
 pin_pressure = 'false'
 

--- a/test/input_files/coupled_stokes_ns.in
+++ b/test/input_files/coupled_stokes_ns.in
@@ -55,12 +55,10 @@ material = 'TestMaterial'
 
 enabled_subdomains = '2'
 
-bc_ids = '4 6 7 8'
-bc_types = 'no_slip no_slip parabolic_profile no_slip'
-
-parabolic_profile_coeffs_7 = '0.0 0.0 -4.0 0.0 4.0 0.0'
-parabolic_profile_var_7 = 'u'
-parabolic_profile_fix_7 = 'v'
+bc_ids = '7 7 4 6 8'
+bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip no_slip'
+bc_variables = 'u v na na na'
+bc_values = '4*y*(1-y) 0.0 na na na'
 
 # Options for Navier Stokes physics
 [../IncompressibleNavierStokes]

--- a/test/input_files/locally_refine.in
+++ b/test/input_files/locally_refine.in
@@ -14,12 +14,10 @@ material = 'TestMaterial'
 # 2 - no slip walls
 # 3 - outlet
 
-bc_ids = '1 2'
-bc_types = 'parabolic_profile no_slip'
-
-parabolic_profile_coeffs_1 = '0.0 0.0 -480.0 0.0 240.0 0.0'
-parabolic_profile_var_1 = 'u'
-parabolic_profile_fix_1 = 'v'
+bc_ids = '1 1 2'
+bc_types = 'parsed_dirichlet parsed_dirichlet no_slip'
+bc_variables = 'u v na'
+bc_values = '240*y*(1-2*y) 0.0 na'
 
 pin_pressure = 'false'
 

--- a/test/input_files/reacting_low_mach_antioch_cea_constant_prandtl_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_cea_constant_prandtl_regression.in
@@ -42,15 +42,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_antioch_cea_constant_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_cea_constant_regression.in
@@ -41,15 +41,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_antioch_kinetics_theory_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_kinetics_theory_regression.in
@@ -36,15 +36,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in
@@ -38,15 +38,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_catalytic_wall_regression.in
@@ -38,15 +38,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_gassolid_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_gassolid_catalytic_wall_regression.in
@@ -38,15 +38,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in
@@ -38,15 +38,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_regression.in
@@ -38,15 +38,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_antioch_statmech_constant_prandtl_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_constant_prandtl_regression.in
@@ -42,15 +42,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_antioch_statmech_constant_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_constant_regression.in
@@ -42,15 +42,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/reacting_low_mach_cantera_regression.in
+++ b/test/input_files/reacting_low_mach_cantera_regression.in
@@ -39,15 +39,10 @@ g = '0.0 0.0' #[m/s^2]
 # i = bottom -> 3
 # i = top    -> 1
 
-vel_bc_ids = '3 2 0'
-vel_bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_3 = 'v'
-
-# c = -U0/y0^2, f = U0
-# y0 = 1.0 
-parabolic_profile_coeffs_3 = '0.0 0.0 -1 0.0 0.0 1'
+vel_bc_ids = '3 3 2 0'
+vel_bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+vel_bc_variables = 'u v na na'
+vel_bc_values = '(1-y^2) 0.0 na na'
 
 temp_bc_ids = '3 2 0'
 temp_bc_types = 'isothermal isothermal isothermal'

--- a/test/input_files/redistribute.in
+++ b/test/input_files/redistribute.in
@@ -24,12 +24,10 @@ material = 'TestMaterial'
 # 2 - no slip walls
 # 3 - outlet
 
-bc_ids = '1 2'
-bc_types = 'parabolic_profile no_slip'
-
-parabolic_profile_coeffs_1 = '0.0 0.0 -40.0 0.0 40.0 0.0'
-parabolic_profile_var_1 = 'u'
-parabolic_profile_fix_1 = 'v'
+bc_ids = '1 1 2'
+bc_types = 'parsed_dirichlet parsed_dirichlet no_slip'
+bc_variables = 'u v na'
+bc_values = '40*y*(1-y) 0.0 na'
 
 pin_pressure = 'false'
 

--- a/test/input_files/stokes_invalid_pin_location_unit.in
+++ b/test/input_files/stokes_invalid_pin_location_unit.in
@@ -41,15 +41,10 @@ enabled_physics = 'Stokes'
 
 material = 'TestMaterial'
 
-bc_ids = '1 3 2 0'
-bc_types = 'parabolic_profile parabolic_profile no_slip no_slip'
-
-parabolic_profile_coeffs_1 = '0.0 0.0 -4.0 0.0 4.0 0.0'
-parabolic_profile_coeffs_3 = '0.0 0.0 -4.0 0.0 4.0 0.0'
-parabolic_profile_var_1 = 'u'
-parabolic_profile_var_3 = 'u'
-parabolic_profile_fix_1 = 'v'
-parabolic_profile_fix_3 = 'v'
+bc_ids = '1 1 3 3 2 0'
+bc_types = 'parsed_dirichlet parsed_dirichlet  parsed_dirichlet  parsed_dirichlet   no_slip no_slip'
+bc_variables = 'u v u v na na'
+bc_values = '4*y*(1-y) 0.0 4*y*(1-y) 0.0 na na'
 
 pin_pressure = 'true'
 pin_value = '100.0'

--- a/test/input_files/vorticity_qoi.in
+++ b/test/input_files/vorticity_qoi.in
@@ -55,12 +55,10 @@ enabled_physics = 'Stokes'
 
 material = 'TestMaterial'
 
-bc_ids = '1 3 4'
-bc_types = 'parabolic_profile no_slip no_slip'
-
-parabolic_profile_coeffs_1 = '0.0 0.0 -4.0 0.0 4.0 0.0'
-parabolic_profile_var_1 = 'u'
-parabolic_profile_fix_1 = 'v'
+bc_ids = '1 1 3 4'
+bc_types = 'parsed_dirichlet parsed_dirichlet no_slip no_slip'
+bc_variables = 'u v na na'
+bc_values = '4*y*(1-y) 0.0 na na'
 
 pin_pressure = 'false'
 


### PR DESCRIPTION
This doesn't remove `ParabolicProfile` from the code (that'll be later), this just removes its usage from the tests and puts `parsed_dirichlet` in its place.