### PR TITLE
Constrained Variables and Variable Registration

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -219,6 +219,7 @@ libgrins_la_SOURCES += variables/src/species_mass_fracs_variables.C
 libgrins_la_SOURCES += variables/src/variables_factory_base.C
 libgrins_la_SOURCES += variables/src/variables_factory.C
 libgrins_la_SOURCES += variables/src/variables_factory_with_physics_name.C
+libgrins_la_SOURCES += variables/src/variable_warehouse.C
 
 # src/utilities files
 libgrins_la_SOURCES += utilities/src/grins_version.C
@@ -487,6 +488,7 @@ include_HEADERS += variables/include/grins/variables_parsing.h
 include_HEADERS += variables/include/grins/variables_factory_base.h
 include_HEADERS += variables/include/grins/variables_factory.h
 include_HEADERS += variables/include/grins/variables_factory_with_physics_name.h
+include_HEADERS += variables/include/grins/variable_warehouse.h
 
 # src/utilities headers
 include_HEADERS += $(top_builddir)/src/utilities/include/grins/grins_version.h

--- a/src/physics/include/grins/axisym_boussinesq_buoyancy.h
+++ b/src/physics/include/grins/axisym_boussinesq_buoyancy.h
@@ -103,6 +103,8 @@ namespace GRINS
     //! Read options from GetPot input file.
     void read_input_options( const GetPot& input );
 
+    void register_variables();
+
   }; // class AxisymmetricBoussinesqBuoyancy
 
 } // namespace GRINS

--- a/src/physics/include/grins/axisym_heat_transfer.h
+++ b/src/physics/include/grins/axisym_heat_transfer.h
@@ -116,6 +116,7 @@ namespace GRINS
     //! Read options from GetPot input file.
     void read_input_options( const GetPot& input );
 
+    void register_variables();
   };
 
 } //End namespace block

--- a/src/physics/include/grins/boussinesq_buoyancy_base.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_base.h
@@ -85,6 +85,8 @@ namespace GRINS
 
     BoussinesqBuoyancyBase();
 
+    void register_variables();
+
   };
 
 } // end namespace GRINS

--- a/src/physics/include/grins/heat_conduction.h
+++ b/src/physics/include/grins/heat_conduction.h
@@ -83,6 +83,7 @@ namespace GRINS
 
     HeatConduction();
 
+    void register_variables();
 
   };
 

--- a/src/physics/include/grins/heat_transfer_base.h
+++ b/src/physics/include/grins/heat_transfer_base.h
@@ -92,6 +92,7 @@ namespace GRINS
   private:
     HeatTransferBase();
 
+    void register_variables();
   };
 
 } //End namespace block

--- a/src/physics/include/grins/inc_navier_stokes_base.h
+++ b/src/physics/include/grins/inc_navier_stokes_base.h
@@ -92,6 +92,8 @@ namespace GRINS
   private:
     IncompressibleNavierStokesBase();
 
+    void register_variables();
+
   };
 
 } //End namespace block

--- a/src/physics/include/grins/low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_base.h
@@ -123,6 +123,8 @@ namespace GRINS
     //! Read options from GetPot input file.
     void read_input_options( const GetPot& input );
 
+    void register_variables();
+
   };
 
   template<class V, class SH, class TC>

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_abstract.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_abstract.h
@@ -108,6 +108,8 @@ namespace GRINS
     //! Read options from GetPot input file.
     void read_input_options( const GetPot& input );
 
+    void register_variables();
+
   }; // class ReactingLowMachNavierStokesAbstract
 
 

--- a/src/physics/include/grins/solid_mechanics_abstract.h
+++ b/src/physics/include/grins/solid_mechanics_abstract.h
@@ -62,6 +62,8 @@ namespace GRINS
 
     SolidMechanicsAbstract();
 
+    void register_variables();
+
   };
 
 } // end namespace GRINS

--- a/src/physics/include/grins/spalart_allmaras.h
+++ b/src/physics/include/grins/spalart_allmaras.h
@@ -118,6 +118,8 @@ namespace GRINS
   private:
     SpalartAllmaras();
 
+    void register_variables();
+
   };
 
 } //End namespace block

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -29,6 +29,8 @@
 // GRINS
 #include "grins/assembly_context.h"
 #include "grins/grins_enums.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/utility.h"
@@ -48,6 +50,7 @@ namespace GRINS
       _temp_vars(input, PhysicsNaming::axisymmetric_heat_transfer())
   {
     this->read_input_options(input);
+    this->register_variables();
   }
 
   void AxisymmetricBoussinesqBuoyancy::read_input_options( const GetPot& input )
@@ -66,6 +69,16 @@ namespace GRINS
     _g(1) = input("Physics/"+PhysicsNaming::axisymmetric_boussinesq_buoyancy()+"/g", 0.0, 1 );
 
     return;
+  }
+
+  void AxisymmetricBoussinesqBuoyancy::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::pressure_section(),
+                                                                 this->_press_var);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::velocity_section(),
+                                                                 this->_flow_vars);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::temperature_section(),
+                                                                 this->_temp_vars);
   }
 
   void AxisymmetricBoussinesqBuoyancy::init_variables( libMesh::FEMSystem* system )

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -44,7 +44,7 @@ namespace GRINS
 								  const GetPot& input )
     : Physics(physics_name, input),
       _flow_vars(input, PhysicsNaming::incompressible_navier_stokes()),
-      _press_var(input,PhysicsNaming::incompressible_navier_stokes()),
+      _press_var(input,PhysicsNaming::incompressible_navier_stokes(), true /*is_constraint_var*/),
       _temp_vars(input, PhysicsNaming::axisymmetric_heat_transfer())
   {
     this->read_input_options(input);

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -33,6 +33,8 @@
 #include "grins/grins_enums.h"
 #include "grins/heat_transfer_macros.h"
 #include "grins/materials_parsing.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/utility.h"
@@ -58,6 +60,8 @@ namespace GRINS
     // This is deleted in the base class
     this->_bc_handler = new AxisymmetricHeatTransferBCHandling( physics_name, input );
     this->_ic_handler = new GenericICHandler( physics_name, input );
+
+    this->register_variables();
   }
 
   template< class Conductivity>
@@ -66,6 +70,17 @@ namespace GRINS
     MaterialsParsing::read_density( PhysicsNaming::axisymmetric_heat_transfer(), input, (*this), this->_rho );
 
     MaterialsParsing::read_specific_heat( PhysicsNaming::axisymmetric_heat_transfer(), input, (*this), this->_Cp );
+  }
+
+  template< class Conductivity>
+  void AxisymmetricHeatTransfer<Conductivity>::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::pressure_section(),
+                                                                 this->_press_var);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::velocity_section(),
+                                                                 this->_flow_vars);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::temperature_section(),
+                                                                 this->_temp_vars);
   }
 
   template< class Conductivity>

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -49,7 +49,7 @@ namespace GRINS
 								    const GetPot& input)
     : Physics(physics_name, input),
       _flow_vars(input, PhysicsNaming::incompressible_navier_stokes()),
-      _press_var(input,PhysicsNaming::incompressible_navier_stokes()),
+      _press_var(input,PhysicsNaming::incompressible_navier_stokes(), true /*is_constraint_var*/),
       _temp_vars(input, PhysicsNaming::axisymmetric_heat_transfer()),
       _k(input,MaterialsParsing::material_name(input,PhysicsNaming::axisymmetric_heat_transfer()))
   {

--- a/src/physics/src/boussinesq_buoyancy_base.C
+++ b/src/physics/src/boussinesq_buoyancy_base.C
@@ -30,6 +30,8 @@
 // GRINS
 #include "grins/common.h"
 #include "grins/materials_parsing.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -72,12 +74,22 @@ namespace GRINS
     if( g_dim == 3)
       _g(2) = input("Physics/"+PhysicsNaming::boussinesq_buoyancy()+"/g", 0.0, 2 );
 
-    return;
+    this->register_variables();
   }
 
   BoussinesqBuoyancyBase::~BoussinesqBuoyancyBase()
   {
     return;
+  }
+
+  void BoussinesqBuoyancyBase::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::pressure_section(),
+                                                                 this->_press_var);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::velocity_section(),
+                                                                 this->_flow_vars);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::temperature_section(),
+                                                                 this->_temp_vars);
   }
 
   void BoussinesqBuoyancyBase::init_variables( libMesh::FEMSystem* system )

--- a/src/physics/src/boussinesq_buoyancy_base.C
+++ b/src/physics/src/boussinesq_buoyancy_base.C
@@ -42,7 +42,7 @@ namespace GRINS
   BoussinesqBuoyancyBase::BoussinesqBuoyancyBase( const std::string& physics_name, const GetPot& input )
     : Physics(physics_name,input),
       _flow_vars(input,PhysicsNaming::incompressible_navier_stokes()),
-      _press_var(input,PhysicsNaming::incompressible_navier_stokes()),
+      _press_var(input,PhysicsNaming::incompressible_navier_stokes(), true /*is_constraint_var*/),
       _temp_vars(input,PhysicsNaming::heat_transfer()),
       _rho(0.0),
       _T_ref(1.0),
@@ -68,7 +68,7 @@ namespace GRINS
 
     _g(0) = input("Physics/"+PhysicsNaming::boussinesq_buoyancy()+"/g", 0.0, 0 );
     _g(1) = input("Physics/"+PhysicsNaming::boussinesq_buoyancy()+"/g", 0.0, 1 );
-  
+
     if( g_dim == 3)
       _g(2) = input("Physics/"+PhysicsNaming::boussinesq_buoyancy()+"/g", 0.0, 2 );
 

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -34,6 +34,8 @@
 #include "grins/heat_transfer_macros.h"
 #include "grins/physics_naming.h"
 #include "grins/materials_parsing.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/quadrature.h"
@@ -54,6 +56,8 @@ namespace GRINS
 
     MaterialsParsing::read_specific_heat( PhysicsNaming::heat_conduction(), input, (*this), this->_Cp );
 
+    this->register_variables();
+
     // This is deleted in the base class
     this->_bc_handler = new HeatTransferBCHandling( physics_name, input );
     this->_ic_handler = new GenericICHandler( physics_name, input );
@@ -65,6 +69,13 @@ namespace GRINS
   HeatConduction<K>::~HeatConduction()
   {
     return;
+  }
+
+  template<class K>
+  void HeatConduction<K>::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::temperature_section(),
+                                                                 this->_temp_vars);
   }
 
   template<class K>

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -32,6 +32,8 @@
 #include "grins/assembly_context.h"
 #include "grins/heat_transfer_macros.h"
 #include "grins/materials_parsing.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/utility.h"
@@ -56,6 +58,19 @@ namespace GRINS
     MaterialsParsing::read_density( core_physics_name, input, (*this), this->_rho );
 
     MaterialsParsing::read_specific_heat( core_physics_name, input, (*this), this->_Cp );
+
+    this->register_variables();
+  }
+
+  template<class K>
+  void HeatTransferBase<K>::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::pressure_section(),
+                                                                 this->_press_var);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::velocity_section(),
+                                                                 this->_flow_vars);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::temperature_section(),
+                                                                 this->_temp_vars);
   }
 
   template<class K>

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -47,7 +47,7 @@ namespace GRINS
                                          const GetPot& input )
     : Physics(physics_name, input),
       _flow_vars(input,PhysicsNaming::incompressible_navier_stokes()),
-      _press_var(input,PhysicsNaming::incompressible_navier_stokes()),
+      _press_var(input,PhysicsNaming::incompressible_navier_stokes(), true /*is_constraint_var*/),
       _temp_vars(input,PhysicsNaming::heat_transfer()),
       _rho(0.0),
       _Cp(0.0),

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -32,6 +32,8 @@
 #include "grins/physics_naming.h"
 #include "grins/inc_nav_stokes_macro.h"
 #include "grins/materials_parsing.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/utility.h"
@@ -52,6 +54,16 @@ namespace GRINS
       _mu(input,MaterialsParsing::material_name(input,core_physics_name))
   {
     MaterialsParsing::read_density( core_physics_name, input, (*this), this->_rho );
+    this->register_variables();
+  }
+
+  template<class Mu>
+  void IncompressibleNavierStokesBase<Mu>::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::pressure_section(),
+                                                                 this->_press_var);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::velocity_section(),
+                                                                 this->_flow_vars);
   }
 
   template<class Mu>

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -47,7 +47,7 @@ namespace GRINS
                                                                      const GetPot& input )
     : Physics(my_physics_name, input),
       _flow_vars(input, core_physics_name),
-      _press_var(input, core_physics_name),
+      _press_var(input, core_physics_name, true /*is_constraint_var*/),
       _rho(0.0),
       _mu(input,MaterialsParsing::material_name(input,core_physics_name))
   {

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -33,6 +33,8 @@
 #include "grins/constant_conductivity.h"
 #include "grins/grins_enums.h"
 #include "grins/materials_parsing.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -60,6 +62,21 @@ namespace GRINS
       _p0_var.reset( new ThermoPressureFEVariable(input,core_physics_name, true /*is_constraint_var*/) );
 
     this->read_input_options(input);
+    this->register_variables();
+  }
+
+  template<class Mu, class SH, class TC>
+  void LowMachNavierStokesBase<Mu,SH,TC>::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::pressure_section(),
+                                                                 this->_press_var);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::velocity_section(),
+                                                                 this->_flow_vars);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::temperature_section(),
+                                                                 this->_temp_vars);
+    if( this->_enable_thermo_press_calc )
+      GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::thermo_pressure_section(),
+                                                                   *(this->_p0_var));
   }
 
   template<class Mu, class SH, class TC>

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -48,7 +48,7 @@ namespace GRINS
                                                              const GetPot& input)
     : Physics(physics_name, input),
       _flow_vars(input, core_physics_name),
-      _press_var(input,core_physics_name),
+      _press_var(input,core_physics_name, true /*is_constraint_var*/),
       _temp_vars(input, core_physics_name),
       _p0_var(NULL),
       _mu(input,MaterialsParsing::material_name(input,core_physics_name)),
@@ -57,7 +57,7 @@ namespace GRINS
   {
     _enable_thermo_press_calc = input("Physics/"+PhysicsNaming::low_mach_navier_stokes()+"/enable_thermo_press_calc", false );
     if( _enable_thermo_press_calc )
-      _p0_var.reset( new ThermoPressureFEVariable(input,core_physics_name) );
+      _p0_var.reset( new ThermoPressureFEVariable(input,core_physics_name, true /*is_constraint_var*/) );
 
     this->read_input_options(input);
   }

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -48,7 +48,7 @@ namespace GRINS
                                                                            const GetPot& input)
     : Physics(physics_name, input),
       _flow_vars(input, PhysicsNaming::reacting_low_mach_navier_stokes()),
-      _press_var(input,PhysicsNaming::reacting_low_mach_navier_stokes()),
+      _press_var(input,PhysicsNaming::reacting_low_mach_navier_stokes(), true /*is_constraint_var*/),
       _temp_vars(input, PhysicsNaming::reacting_low_mach_navier_stokes()),
       _p0_var(NULL),
       _species_vars(input, PhysicsNaming::reacting_low_mach_navier_stokes()),
@@ -62,7 +62,7 @@ namespace GRINS
 
     _enable_thermo_press_calc = input("Physics/"+PhysicsNaming::reacting_low_mach_navier_stokes()+"/enable_thermo_press_calc", false );
     if( _enable_thermo_press_calc )
-      _p0_var.reset( new ThermoPressureFEVariable(input, PhysicsNaming::reacting_low_mach_navier_stokes()) );
+      _p0_var.reset( new ThermoPressureFEVariable(input, PhysicsNaming::reacting_low_mach_navier_stokes(), true /*is_constraint_var*/) );
 
     this->read_input_options(input);
   }

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -35,6 +35,8 @@
 #include "grins/grins_enums.h"
 #include "grins/antioch_mixture.h"
 #include "grins/materials_parsing.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/string_to_enum.h"
@@ -65,6 +67,7 @@ namespace GRINS
       _p0_var.reset( new ThermoPressureFEVariable(input, PhysicsNaming::reacting_low_mach_navier_stokes(), true /*is_constraint_var*/) );
 
     this->read_input_options(input);
+    this->register_variables();
   }
 
   void ReactingLowMachNavierStokesAbstract::read_input_options( const GetPot& input )
@@ -86,6 +89,21 @@ namespace GRINS
     if( g_dim == 3)
       _g(2) = input("Physics/"+PhysicsNaming::reacting_low_mach_navier_stokes()+"/g", 0.0, 2 );
 
+  }
+
+  void ReactingLowMachNavierStokesAbstract::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::pressure_section(),
+                                                                 this->_press_var);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::velocity_section(),
+                                                                 this->_flow_vars);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::temperature_section(),
+                                                                 this->_temp_vars);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::species_mass_fractions_section(),
+                                                                 this->_species_vars);
+    if( this->_enable_thermo_press_calc )
+      GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::thermo_pressure_section(),
+                                                                   *(this->_p0_var));
   }
 
   void ReactingLowMachNavierStokesAbstract::init_variables( libMesh::FEMSystem* system )

--- a/src/physics/src/solid_mechanics_abstract.C
+++ b/src/physics/src/solid_mechanics_abstract.C
@@ -27,6 +27,8 @@
 
 // GRINS
 #include "grins/materials_parsing.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -38,7 +40,9 @@ namespace GRINS
                                                  const GetPot& input )
     : Physics(physics_name,input),
       _disp_vars(input,physics_name,false,true)// is_2D = false, is_3D = true
-  {}
+  {
+    this->register_variables();
+  }
 
   void SolidMechanicsAbstract::init_variables( libMesh::FEMSystem* system )
   {
@@ -51,6 +55,12 @@ namespace GRINS
     system->time_evolving(_disp_vars.u());
     system->time_evolving(_disp_vars.v());
     system->time_evolving(_disp_vars.w());
+  }
+
+  void SolidMechanicsAbstract::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::displacement_section(),
+                                                                 this->_disp_vars);
   }
 
 } // end namespace GRINS

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -47,7 +47,7 @@ namespace GRINS
   SpalartAllmaras<Mu>::SpalartAllmaras(const std::string& physics_name, const GetPot& input )
     : TurbulenceModelsBase<Mu>(physics_name, input), // Define class variables
     _flow_vars(input,PhysicsNaming::incompressible_navier_stokes()),
-    _press_var(input,PhysicsNaming::incompressible_navier_stokes()),
+    _press_var(input,PhysicsNaming::incompressible_navier_stokes(), true /*is_constraint_var*/),
     _turbulence_vars(input, PhysicsNaming::spalart_allmaras()),
     _spalart_allmaras_helper(input),
     _sa_params(input),

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -35,6 +35,8 @@
 #include "grins/constant_viscosity.h"
 #include "grins/parsed_viscosity.h"
 #include "grins/spalart_allmaras_viscosity.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/quadrature.h"
@@ -67,6 +69,8 @@ namespace GRINS
         std::cout<<"Boundary Id: "<<*b_id<<std::endl;
       }
 
+    this->register_variables();
+
     // This is deleted in the base class
     this->_bc_handler = new SpalartAllmarasBCHandling( physics_name, input );
 
@@ -79,6 +83,17 @@ namespace GRINS
   SpalartAllmaras<Mu>::~SpalartAllmaras()
   {
     return;
+  }
+
+  template<class Mu>
+  void SpalartAllmaras<Mu>::register_variables()
+  {
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::pressure_section(),
+                                                                 this->_press_var);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::velocity_section(),
+                                                                 this->_flow_vars);
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(VariablesParsing::turbulence_section(),
+                                                                 this->_turbulence_vars);
   }
 
   template<class Mu>

--- a/src/variables/include/grins/displacement_fe_variables.h
+++ b/src/variables/include/grins/displacement_fe_variables.h
@@ -43,7 +43,8 @@ namespace GRINS
      *  or 3D (is_3D = true) space or 2D shell manifolds in 3D (is_3D = true). */
     DisplacementFEVariables( const GetPot& input,
                              const std::string& physics_name,
-                             bool is_2D, bool is_3D );
+                             bool is_2D, bool is_3D,
+                             bool _is_constraint_var = false );
 
     virtual ~DisplacementFEVariables(){};
 

--- a/src/variables/include/grins/fe_variables_base.h
+++ b/src/variables/include/grins/fe_variables_base.h
@@ -51,7 +51,9 @@ namespace GRINS
   {
   public:
 
-    FEVariablesBase(){};
+    FEVariablesBase( bool _is_constraint_var )
+      : _is_constraint_var(_is_constraint_var)
+    {}
 
     ~FEVariablesBase(){};
 
@@ -60,6 +62,9 @@ namespace GRINS
         time. Most subclasses should be able to use default_fe_init, once
         they subclass this and VariablesBase. */
     virtual void init( libMesh::FEMSystem* system ) =0;
+
+    bool is_constraint_var() const
+    { return _is_constraint_var; }
 
   protected:
 
@@ -76,6 +81,15 @@ namespace GRINS
     std::vector<GRINSEnums::FEFamily> _family;
 
     std::vector<GRINSEnums::Order> _order;
+
+    //! Tracks whether this is a constraint variable
+    /*! By constraint variable, we mean a variable that is
+        effectively a Lagrange multiplier. The intended use
+        case is to determine whether this variable requires
+        boundary conditions to be specified (constraint variables
+        do not). This should be set by the finite element
+        type subclasses. */
+    bool _is_constraint_var;
 
   };
 } // end namespace GRINS

--- a/src/variables/include/grins/generic_fe_type_variable.h
+++ b/src/variables/include/grins/generic_fe_type_variable.h
@@ -44,8 +44,9 @@ namespace GRINS
   public:
 
     GenericFETypeVariable( const GetPot& input,
-                           const std::string& physics_name )
-      : SingleFETypeVariable(input,this->section_name(physics_name)),
+                           const std::string& physics_name,
+                           bool _is_constraint_var = false )
+      : SingleFETypeVariable(input,this->section_name(physics_name),_is_constraint_var),
         GenericVariable(input,physics_name)
     {}
 

--- a/src/variables/include/grins/pressure_fe_variable.h
+++ b/src/variables/include/grins/pressure_fe_variable.h
@@ -43,8 +43,9 @@ namespace GRINS
   {
   public:
 
-    PressureFEVariable( const GetPot& input, const std::string& physics_name )
-      :  SingleFETypeVariable(input,physics_name,"P_",this->subsection(),"LAGRANGE","FIRST"),
+    PressureFEVariable( const GetPot& input, const std::string& physics_name,
+                        bool _is_constraint_var = false )
+      :  SingleFETypeVariable(input,physics_name,"P_",this->subsection(),"LAGRANGE","FIRST",_is_constraint_var),
          PressureVariable(input)
     {}
 

--- a/src/variables/include/grins/primitive_temp_fe_variables.h
+++ b/src/variables/include/grins/primitive_temp_fe_variables.h
@@ -43,8 +43,9 @@ namespace GRINS
   {
   public:
 
-    PrimitiveTempFEVariables( const GetPot& input, const std::string& physics_name )
-      :  SingleFETypeVariable(input,physics_name,"T_",this->subsection(),"LAGRANGE","SECOND"),
+    PrimitiveTempFEVariables( const GetPot& input, const std::string& physics_name,
+                              bool _is_constraint_var = false  )
+      :  SingleFETypeVariable(input,physics_name,"T_",this->subsection(),"LAGRANGE","SECOND",_is_constraint_var),
          PrimitiveTempVariables(input)
     {}
 

--- a/src/variables/include/grins/single_fe_type_variable.h
+++ b/src/variables/include/grins/single_fe_type_variable.h
@@ -47,12 +47,14 @@ namespace GRINS
                           const std::string& old_var_suffix,
                           const std::string& subsection,
                           const std::string& default_family,
-                          const std::string& default_order );
+                          const std::string& default_order,
+                          bool _is_constraint_var );
 
     //! Primary constructor
     /*! Will parse from input section [Variables/<subsection>]. */
     SingleFETypeVariable( const GetPot& input,
-                          const std::string& subsection );
+                          const std::string& subsection,
+                          bool _is_constraint_var);
 
     ~SingleFETypeVariable(){};
 

--- a/src/variables/include/grins/species_mass_fracs_fe_variables.h
+++ b/src/variables/include/grins/species_mass_fracs_fe_variables.h
@@ -38,8 +38,9 @@ namespace GRINS
   {
   public:
 
-    SpeciesMassFractionsFEVariables( const GetPot& input, const std::string& physics_name )
-      :  SingleFETypeVariable(input,physics_name,"species_",this->subsection(),"LAGRANGE","SECOND"),
+    SpeciesMassFractionsFEVariables( const GetPot& input, const std::string& physics_name,
+                                     bool _is_constraint_var = false)
+      :  SingleFETypeVariable(input,physics_name,"species_",this->subsection(),"LAGRANGE","SECOND",_is_constraint_var),
          SpeciesMassFractionsVariables(input, MaterialsParsing::material_name(input,physics_name) )
     {}
 

--- a/src/variables/include/grins/thermo_pressure_fe_variable.h
+++ b/src/variables/include/grins/thermo_pressure_fe_variable.h
@@ -37,8 +37,9 @@ namespace GRINS
   {
   public:
 
-    ThermoPressureFEVariable( const GetPot& input, const std::string& physics_name )
-      :  SingleFETypeVariable(input,physics_name,"",this->subsection(),"SCALAR","FIRST"),
+    ThermoPressureFEVariable( const GetPot& input, const std::string& physics_name,
+                              bool _is_constraint_var = false )
+      :  SingleFETypeVariable(input,physics_name,"",this->subsection(),"SCALAR","FIRST",_is_constraint_var),
          ThermoPressureVariable(input)
     {
       // Currently only support SCALAR and FIRST

--- a/src/variables/include/grins/turbulence_fe_variables.h
+++ b/src/variables/include/grins/turbulence_fe_variables.h
@@ -43,8 +43,9 @@ namespace GRINS
   {
   public:
 
-    TurbulenceFEVariables( const GetPot& input, const std::string& physics_name )
-      :  SingleFETypeVariable(input,physics_name,"TU_",this->subsection(),"LAGRANGE","FIRST"),
+    TurbulenceFEVariables( const GetPot& input, const std::string& physics_name,
+                           bool _is_constraint_var = false )
+      :  SingleFETypeVariable(input,physics_name,"TU_",this->subsection(),"LAGRANGE","FIRST",_is_constraint_var),
          TurbulenceVariables(input)
     {}
 

--- a/src/variables/include/grins/variable_warehouse.h
+++ b/src/variables/include/grins/variable_warehouse.h
@@ -1,0 +1,119 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_VARIABLE_WAREHOUSE_H
+#define GRINS_VARIABLE_WAREHOUSE_H
+
+// GRINS
+#include "grins/fe_variables_base.h"
+
+// libMesh
+#include "libmesh/libmesh_common.h"
+
+namespace GRINS
+{
+  //! Not intended for users as a public API
+  namespace GRINSPrivate
+  {
+    //! Track what FEVariablesBase objects have been created
+    /*! Several modules need to interact with the Variables
+        in use. So, this object creates a place to register
+        a Variable class.
+
+    \todo Currently, we only allow only unique variable types. This will
+          change in the future once we allow per-subdomain variables.
+          Hence, we have this in GRINSPrivate since the API may
+          change in the future. */
+    class VariableWarehouse
+    {
+    public:
+      VariableWarehouse(){};
+
+      ~VariableWarehouse(){};
+
+      //! Check if variable is registered
+      static bool is_registered( const std::string& var_name );
+
+      //! First check if var_name is registered and then register
+      /*! Use this API if you may be attempting to register the same
+          variable more than once. */
+      static void check_and_register_variable( const std::string& var_name,
+                                               const FEVariablesBase& variable );
+
+      static void register_variable( const std::string& var_name,
+                                     const FEVariablesBase& variable );
+
+      static const FEVariablesBase& get_variable( const std::string& var_name );
+
+    protected:
+
+      static std::map<std::string,const FEVariablesBase*>& var_map();
+
+    };
+
+    inline
+    bool VariableWarehouse::is_registered( const std::string& var_name )
+    {
+      bool var_found = (var_map().find(var_name) != var_map().end() );
+      return var_found;
+    }
+
+    inline
+    void VariableWarehouse::check_and_register_variable( const std::string& var_name,
+                                                         const FEVariablesBase& variable )
+    {
+      if( !VariableWarehouse::is_registered(var_name) )
+        VariableWarehouse::register_variable(var_name,variable);
+    }
+
+    inline
+    void VariableWarehouse::register_variable( const std::string& var_name,
+                                               const FEVariablesBase& variable )
+    {
+      if( VariableWarehouse::is_registered(var_name) )
+        libmesh_error_msg("ERROR: Duplicate FEVariable registration not allowed!");
+
+      var_map()[var_name] = &variable;
+    }
+
+    inline
+    const FEVariablesBase& VariableWarehouse::get_variable( const std::string& var_name )
+    {
+      if( var_map().find(var_name) == var_map().end() )
+        libmesh_error_msg("ERROR: Could not find FEVariable "+var_name+"!");
+
+      const FEVariablesBase* var_ptr = var_map()[var_name];
+
+      if( !var_ptr )
+        libmesh_error_msg("ERROR: FEVariable "+var_name+" is an invalid pointer!");
+
+      return *var_ptr;
+    }
+
+  } // end namespace GRINSPrivate
+
+} // end namespace GRINS
+
+#endif // GRINS_VARIABLE_WAREHOUSE_H

--- a/src/variables/include/grins/variables_base.h
+++ b/src/variables/include/grins/variables_base.h
@@ -103,6 +103,7 @@ namespace GRINS
     std::vector<VariableIndex> _vars;
 
     std::vector<std::string> _var_names;
+
   };
 
 } // end namespace GRINS

--- a/src/variables/include/grins/velocity_fe_variables.h
+++ b/src/variables/include/grins/velocity_fe_variables.h
@@ -38,7 +38,8 @@ namespace GRINS
   {
   public:
 
-    VelocityFEVariables( const GetPot& input, const std::string& physics_name );
+    VelocityFEVariables( const GetPot& input, const std::string& physics_name,
+                         bool _is_constraint_var = false );
     ~VelocityFEVariables(){};
 
     virtual void init( libMesh::FEMSystem* system );

--- a/src/variables/src/displacement_fe_variables.C
+++ b/src/variables/src/displacement_fe_variables.C
@@ -37,8 +37,9 @@ namespace GRINS
 
   DisplacementFEVariables::DisplacementFEVariables( const GetPot& input,
                                                     const std::string& physics_name,
-                                                    bool is_2D, bool is_3D )
-    :  SingleFETypeVariable(input,physics_name,"",this->subsection(),"LAGRANGE","FIRST"),
+                                                    bool is_2D, bool is_3D,
+                                                    bool _is_constraint_var )
+    :  SingleFETypeVariable(input,physics_name,"",this->subsection(),"LAGRANGE","FIRST",_is_constraint_var),
        DisplacementVariables(input),
        _is_2D(is_2D),
        _is_3D(is_3D)

--- a/src/variables/src/single_fe_type_variable.C
+++ b/src/variables/src/single_fe_type_variable.C
@@ -40,8 +40,9 @@ namespace GRINS
                                               const std::string& old_var_suffix,
                                               const std::string& subsection,
                                               const std::string& default_family,
-                                              const std::string& default_order )
-    :  FEVariablesBase()
+                                              const std::string& default_order,
+                                              bool _is_constraint_var )
+    :  FEVariablesBase(_is_constraint_var)
   {
     _family.resize(1,libMesh::INVALID_FE);
     _order.resize(1,libMesh::INVALID_ORDER);
@@ -60,8 +61,9 @@ namespace GRINS
   }
 
   SingleFETypeVariable::SingleFETypeVariable( const GetPot& input,
-                                              const std::string& subsection )
-    :  FEVariablesBase()
+                                              const std::string& subsection,
+                                              bool _is_constraint_var)
+    :  FEVariablesBase(_is_constraint_var)
   {
      _family.resize(1,libMesh::INVALID_FE);
      _order.resize(1,libMesh::INVALID_ORDER);

--- a/src/variables/src/variable_warehouse.C
+++ b/src/variables/src/variable_warehouse.C
@@ -1,0 +1,38 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2015 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/variable_warehouse.h"
+
+namespace GRINS
+{
+  namespace GRINSPrivate
+  {
+    std::map<std::string,const FEVariablesBase*>& VariableWarehouse::var_map()
+    {
+      static std::map<std::string, const FEVariablesBase*> _var_map;
+      return _var_map;
+    }
+  } // end namespace GRINSPrivate
+} // end namespace GRINS

--- a/src/variables/src/velocity_fe_variables.C
+++ b/src/variables/src/velocity_fe_variables.C
@@ -35,8 +35,9 @@
 
 namespace GRINS
 {
-  VelocityFEVariables::VelocityFEVariables( const GetPot& input, const std::string& physics_name )
-    :  SingleFETypeVariable(input,physics_name,"V_",this->subsection(),"LAGRANGE","SECOND"),
+  VelocityFEVariables::VelocityFEVariables( const GetPot& input, const std::string& physics_name,
+                                            bool _is_constraint_var)
+    :  SingleFETypeVariable(input,physics_name,"V_",this->subsection(),"LAGRANGE","SECOND",_is_constraint_var),
        VelocityVariables(input)
   {}
 


### PR DESCRIPTION
This PR adds two things:

1. The notion of a "constrained" variable to `FEVariableBase`
2. `VariableWarehouse`

Both are unit tested in the CppUnit-based test. Both changes are motivated by downstream chagnes in the boundary condition refactoring. 

The first change is to help with determining if a `Variable` requires a boundary condition specified or not. (The plan downstream is, in the new format, every boundary must have a boundary condition for every `Variable`, even if it's just `natural`, to help reduce input file bugs with the boundary conditions.) Constrained variables, e.g. Lagrange multiplier type things, do not require boundary conditions, so the first change allows you specify at construction time whether or not the variable is a constrained variable. Then, we'll be able to determine later if it needs a boundary condition.

The second change is also motivated by downstream changes in the boundary conditions. Originally, I was using the `VariableFactory` to build `VariableBase` objects, but `VariableBase` objects don't have enough information, e.g. the constraint variable bits I just added or, in the case of species mass fractions, I really need to know the material in order to be able to pull out the chemistry library being used for constructing things like catalytic walls. So, the `VariableWarehouse` gives us place to fetch const information about each of the variables registered. We use the centralized naming in `VariablesParsing` so everything should be consistent. I've tucked `VariableWarehouse` in a `GRINSPrivate` namespace because right now, I do not allow duplicate variables to be registered. Once we support per-subdomain variables, that may change and we may need to update the API. So I put this in GRINSPrivate to indicate that the API could be in flux.

As as aside, once the boundary condition refactoring is done (today, hopefully), and along with this PR, we can get rid of `VariableBase` altogether since that was originally needed to provide info to `BCHandling` (which will die with the boundary condition refactoring). The `VariableWarehouse` will give us access to `FEVariableBase`, so we'll be able to reduce the code in the `Variable` design and have `FEVariableBase` be the root class (which makes much more sense I think).