### PR TITLE
libMesh::AutoPtr --> libMesh::UniquePtr

### DIFF
--- a/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
@@ -246,7 +246,7 @@ namespace GRINS
                   /* ------------- Parse and construct the corresponding catalyticities ------------- */
 
                   // These are temporary and will be cloned, so let them be destroyed when we're done
-                  libMesh::UniquePtr<CatalycityBase> gamma_r(NULL);
+                  libMesh::UniquePtr<CatalycityBase> gamma_r;
 
                   this->build_catalycities( input, reactant, bc_id_string, bc_id, gamma_r );
 
@@ -358,7 +358,7 @@ namespace GRINS
                 const unsigned int p_species  = _chemistry.species_index( product );
 
                 // This is temporary and will be cloned, so let it be destroyed when we're done
-                libMesh::UniquePtr<CatalycityBase> gamma_r(NULL);
+                libMesh::UniquePtr<CatalycityBase> gamma_r;
 
                 this->build_catalycities( input, gas_reactant, bc_id_string, bc_id, gamma_r );
 

--- a/src/boundary_conditions/include/grins/concentric_cylinder_profile.h
+++ b/src/boundary_conditions/include/grins/concentric_cylinder_profile.h
@@ -58,7 +58,7 @@ namespace GRINS
 
     virtual ~ConcentricCylinderProfile( );
 
-    virtual libMesh::AutoPtr< libMesh::FunctionBase<libMesh::Number> > clone() const;
+    virtual libMesh::UniquePtr< libMesh::FunctionBase<libMesh::Number> > clone() const;
 
     virtual libMesh::Number operator()( const libMesh::Point& p, const libMesh::Real time );
 

--- a/src/boundary_conditions/include/grins/gaussian_xy_profile.h
+++ b/src/boundary_conditions/include/grins/gaussian_xy_profile.h
@@ -42,7 +42,7 @@ namespace GRINS
 
     virtual ~GaussianXYProfile( );
 
-    virtual libMesh::AutoPtr< libMesh::FunctionBase<libMesh::Number> > clone() const;
+    virtual libMesh::UniquePtr< libMesh::FunctionBase<libMesh::Number> > clone() const;
 
     virtual libMesh::Number operator()( const libMesh::Point &p, const libMesh::Real time );
 

--- a/src/boundary_conditions/include/grins/parabolic_profile.h
+++ b/src/boundary_conditions/include/grins/parabolic_profile.h
@@ -53,7 +53,7 @@ namespace GRINS
 
     virtual ~ParabolicProfile( );
 
-    virtual libMesh::AutoPtr< libMesh::FunctionBase<libMesh::Number> > clone() const;
+    virtual libMesh::UniquePtr< libMesh::FunctionBase<libMesh::Number> > clone() const;
 
     virtual libMesh::Number operator()( const libMesh::Point &p, const libMesh::Real time );
 

--- a/src/boundary_conditions/src/concentric_cylinder_profile.C
+++ b/src/boundary_conditions/src/concentric_cylinder_profile.C
@@ -57,9 +57,9 @@ namespace GRINS
     return;
   }
 
-  libMesh::AutoPtr< libMesh::FunctionBase<libMesh::Number> > ConcentricCylinderProfile::clone() const
+  libMesh::UniquePtr< libMesh::FunctionBase<libMesh::Number> > ConcentricCylinderProfile::clone() const
   {
-    return libMesh::AutoPtr< libMesh::FunctionBase<libMesh::Number> >( new ConcentricCylinderProfile( _u0, _r0, _r1 ) );
+    return libMesh::UniquePtr< libMesh::FunctionBase<libMesh::Number> >( new ConcentricCylinderProfile( _u0, _r0, _r1 ) );
   }
 
   libMesh::Number ConcentricCylinderProfile::operator()( const libMesh::Point& p, 

--- a/src/boundary_conditions/src/gaussian_xy_profile.C
+++ b/src/boundary_conditions/src/gaussian_xy_profile.C
@@ -45,9 +45,9 @@ namespace GRINS
     return;
   }
 
-  libMesh::AutoPtr< libMesh::FunctionBase<libMesh::Number> > GRINS::GaussianXYProfile::clone() const
+  libMesh::UniquePtr< libMesh::FunctionBase<libMesh::Number> > GRINS::GaussianXYProfile::clone() const
   {
-    return libMesh::AutoPtr< libMesh::FunctionBase<libMesh::Number> >( new GaussianXYProfile( _a, _mu, std::sqrt(_variance), _b ) );
+    return libMesh::UniquePtr< libMesh::FunctionBase<libMesh::Number> >( new GaussianXYProfile( _a, _mu, std::sqrt(_variance), _b ) );
   }
 
   libMesh::Number GRINS::GaussianXYProfile::operator()( const libMesh::Point &p, 

--- a/src/boundary_conditions/src/parabolic_profile.C
+++ b/src/boundary_conditions/src/parabolic_profile.C
@@ -54,9 +54,9 @@ namespace GRINS
     return;
   }
 
-  libMesh::AutoPtr< libMesh::FunctionBase<libMesh::Number> > ParabolicProfile::clone() const
+  libMesh::UniquePtr< libMesh::FunctionBase<libMesh::Number> > ParabolicProfile::clone() const
   {
-    return libMesh::AutoPtr< libMesh::FunctionBase<libMesh::Number> >( new ParabolicProfile( _a, _b, _c, _d, _e, _f ) );
+    return libMesh::UniquePtr< libMesh::FunctionBase<libMesh::Number> >( new ParabolicProfile( _a, _b, _c, _d, _e, _f ) );
   }
 
   libMesh::Number ParabolicProfile::operator()( const libMesh::Point &p, 

--- a/src/ic_handling/include/grins/ic_handling_base.h
+++ b/src/ic_handling/include/grins/ic_handling_base.h
@@ -83,7 +83,7 @@ namespace GRINS
     
   protected:
 
-    libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > _ic_func;
+    libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > _ic_func;
 
     std::string _physics_name;
 

--- a/src/ic_handling/src/ic_handling_base.C
+++ b/src/ic_handling/src/ic_handling_base.C
@@ -181,14 +181,14 @@ namespace GRINS
       {
       case(PARSED):
 	{
-          _ic_func = libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> >
+          _ic_func = libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
             (new libMesh::ParsedFunction<libMesh::Number>(ic_value_string));
 	}
 	break;
 
       case(CONSTANT):
 	{
-          _ic_func = libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> >
+          _ic_func = libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
             (new libMesh::ConstFunction<libMesh::Number>
               (StringUtilities::string_to_T<libMesh::Number>(ic_value_string)));
 	}

--- a/src/ic_handling/src/ic_handling_base.C
+++ b/src/ic_handling/src/ic_handling_base.C
@@ -50,8 +50,7 @@
 namespace GRINS
 {
   ICHandlingBase::ICHandlingBase(const std::string& physics_name)
-    : _ic_func(NULL),
-      _physics_name( physics_name )
+    : _physics_name( physics_name )
   {
     return;
   }

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -115,7 +115,7 @@ namespace GRINS
         libMesh::ParameterMultiAccessor<libMesh::Number>& param_pointer );
 
     //! Override FEMSystem::build_context in order to use our own AssemblyContext
-    virtual libMesh::AutoPtr<libMesh::DiffContext> build_context();
+    virtual libMesh::UniquePtr<libMesh::DiffContext> build_context();
 
     //! Context initialization. Calls each physics implementation of init_context()
     virtual void init_context( libMesh::DiffContext &context );

--- a/src/physics/include/grins/parsed_velocity_source_base.h
+++ b/src/physics/include/grins/parsed_velocity_source_base.h
@@ -60,7 +60,7 @@ namespace GRINS
    
   protected:
 
-    libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
       velocity_source_function;
 
   private:

--- a/src/physics/include/grins/scalar_ode.h
+++ b/src/physics/include/grins/scalar_ode.h
@@ -90,7 +90,7 @@ namespace GRINS
 
     // ParsedFEMFunctions evaluating the mass, time derivative, and
     // constraint components of an ODE.
-    libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
       time_deriv_function,
       constraint_function,
       mass_residual_function;

--- a/src/physics/include/grins/spalart_allmaras.h
+++ b/src/physics/include/grins/spalart_allmaras.h
@@ -80,10 +80,10 @@ namespace GRINS
                                 CachedValues& cache );
 
     // A distance function to get distances from boundaries to qps
-    libMesh::AutoPtr<DistanceFunction> distance_function;
+    libMesh::UniquePtr<DistanceFunction> distance_function;
 
     // Boundary mesh objected that will be updated using the wall ids
-    libMesh::AutoPtr<libMesh::SerialMesh> boundary_mesh;
+    libMesh::UniquePtr<libMesh::SerialMesh> boundary_mesh;
 
     // Registers all parameters in this physics and in its property
     // classes

--- a/src/physics/include/grins/velocity_penalty_base.h
+++ b/src/physics/include/grins/velocity_penalty_base.h
@@ -65,10 +65,10 @@ namespace GRINS
 
     bool _quadratic_scaling;
 
-    libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
       normal_vector_function;
 
-    libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
       base_velocity_function;
 
   private:

--- a/src/physics/src/elastic_cable.C
+++ b/src/physics/src/elastic_cable.C
@@ -149,7 +149,7 @@ namespace GRINS
         const libMesh::DenseSubVector<libMesh::Number>& w_coeffs = context.get_elem_solution( this->_disp_vars.w() );
 
         // Build new FE for the current point. We need this to build tensors at point.
-        libMesh::AutoPtr<libMesh::FEGenericBase<libMesh::Real> > fe_new =  this->build_new_fe( context.get_elem(), this->get_fe(context), point );
+        libMesh::UniquePtr<libMesh::FEGenericBase<libMesh::Real> > fe_new =  this->build_new_fe( context.get_elem(), this->get_fe(context), point );
 
         const std::vector<std::vector<libMesh::Real> >& dphi_dxi =  fe_new->get_dphidxi();
 

--- a/src/physics/src/elastic_membrane.C
+++ b/src/physics/src/elastic_membrane.C
@@ -390,7 +390,7 @@ namespace GRINS
         const libMesh::DenseSubVector<libMesh::Number>& w_coeffs = context.get_elem_solution( this->_disp_vars.w() );
 
         // Build new FE for the current point. We need this to build tensors at point.
-        libMesh::AutoPtr<libMesh::FEGenericBase<libMesh::Real> > fe_new =
+        libMesh::UniquePtr<libMesh::FEGenericBase<libMesh::Real> > fe_new =
           this->build_new_fe( context.get_elem(), this->get_fe(context),
                               point );
 

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -52,7 +52,6 @@ namespace GRINS
       _flow_vars(input, core_physics_name),
       _press_var(input,core_physics_name, true /*is_constraint_var*/),
       _temp_vars(input, core_physics_name),
-      _p0_var(NULL),
       _mu(input,MaterialsParsing::material_name(input,core_physics_name)),
       _cp(input,MaterialsParsing::material_name(input,core_physics_name)),
       _k(input,MaterialsParsing::material_name(input,core_physics_name))

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -187,11 +187,11 @@ namespace GRINS
     return;
   }
 
-  libMesh::AutoPtr<libMesh::DiffContext> MultiphysicsSystem::build_context()
+  libMesh::UniquePtr<libMesh::DiffContext> MultiphysicsSystem::build_context()
   {
     AssemblyContext* context = new AssemblyContext(*this);
 
-    libMesh::AutoPtr<libMesh::DiffContext> ap(context);
+    libMesh::UniquePtr<libMesh::DiffContext> ap(context);
 
     libMesh::DifferentiablePhysics* phys = libMesh::FEMSystem::get_physics();
 

--- a/src/physics/src/physics.C
+++ b/src/physics/src/physics.C
@@ -299,7 +299,7 @@ namespace GRINS
 
     unsigned int elem_dim = &elem ? elem.dim() : 0;
 
-    AutoPtr<FEGenericBase<libMesh::Real> >
+    UniquePtr<FEGenericBase<libMesh::Real> >
       fe_new(FEGenericBase<libMesh::Real>::build(elem_dim, fe_type));
 
     // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -52,7 +52,6 @@ namespace GRINS
       _flow_vars(input, PhysicsNaming::reacting_low_mach_navier_stokes()),
       _press_var(input,PhysicsNaming::reacting_low_mach_navier_stokes(), true /*is_constraint_var*/),
       _temp_vars(input, PhysicsNaming::reacting_low_mach_navier_stokes()),
-      _p0_var(NULL),
       _species_vars(input, PhysicsNaming::reacting_low_mach_navier_stokes()),
       _n_species(_species_vars.n_species()),
       _fixed_density( input("Physics/"+PhysicsNaming::reacting_low_mach_navier_stokes()+"/fixed_density", false ) ),

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -209,7 +209,7 @@ namespace GRINS
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     // Auto pointer to distance fcn evaluated at quad points
-    libMesh::AutoPtr< libMesh::DenseVector<libMesh::Real> > distance_qp;
+    libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> > distance_qp;
 
     // Fill the vector of distances to quadrature points
     distance_qp = this->distance_function->interpolate(&elem_pointer, context.get_element_qrule().get_points());

--- a/src/physics/src/spalart_allmaras_spgsm_stab.C
+++ b/src/physics/src/spalart_allmaras_spgsm_stab.C
@@ -100,7 +100,7 @@ namespace GRINS
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     // Auto pointer to distance fcn evaluated at quad points
-    libMesh::AutoPtr< libMesh::DenseVector<libMesh::Real> > distance_qp;
+    libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> > distance_qp;
 
     // Fill the vector of distances to quadrature points
     distance_qp = this->distance_function->interpolate(&elem_pointer, context.get_element_qrule().get_points());
@@ -187,7 +187,7 @@ namespace GRINS
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     // Auto pointer to distance fcn evaluated at quad points
-    libMesh::AutoPtr< libMesh::DenseVector<libMesh::Real> > distance_qp;
+    libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> > distance_qp;
 
     // Fill the vector of distances to quadrature points
     distance_qp = this->distance_function->interpolate(&elem_pointer, context.get_element_qrule().get_points());

--- a/src/properties/src/antioch_chemistry.C
+++ b/src/properties/src/antioch_chemistry.C
@@ -43,7 +43,6 @@ namespace GRINS
 {
   AntiochChemistry::AntiochChemistry( const GetPot& input,
                                       const std::string& material )
-    : _antioch_gas(NULL)
   {
     std::vector<std::string> species_list;
     MaterialsParsing::parse_chemical_species(input,material,species_list);

--- a/src/properties/src/antioch_constant_transport_mixture.C
+++ b/src/properties/src/antioch_constant_transport_mixture.C
@@ -38,10 +38,7 @@ namespace GRINS
   template<typename Thermo>
   AntiochConstantTransportMixture<Thermo>::AntiochConstantTransportMixture( const GetPot& input,
                                                                             const std::string& material )
-    : AntiochMixture(input,material),
-      _mu(NULL),
-      _conductivity(NULL),
-      _diffusivity(NULL)
+    : AntiochMixture(input,material)
   {
     libMesh::Real Le = MaterialsParsing::parse_lewis_number(input,material);
     _diffusivity.reset( new Antioch::ConstantLewisDiffusivity<libMesh::Real>(Le) );

--- a/src/properties/src/antioch_evaluator.C
+++ b/src/properties/src/antioch_evaluator.C
@@ -42,7 +42,6 @@ namespace GRINS
   template<typename Thermo>
   AntiochEvaluator<Thermo>::AntiochEvaluator( const AntiochMixture& mixture )
     : _chem( mixture ),
-      _thermo( NULL ),
       _kinetics( new AntiochKinetics(mixture) ),
       _temp_cache( new Antioch::TempCache<libMesh::Real>(1.0) )
   {

--- a/src/properties/src/antioch_mixture_averaged_transport_mixture.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_mixture.C
@@ -41,13 +41,7 @@ namespace GRINS
   template<typename T, typename V, typename C, typename D>
   AntiochMixtureAveragedTransportMixture<T,V,C,D>::AntiochMixtureAveragedTransportMixture( const GetPot& input,
                                                                                            const std::string& material )
-    : AntiochMixture(input,material),
-      _trans_mixture(NULL),
-      _wilke_mixture(NULL),
-      _thermo(NULL),
-      _viscosity(NULL),
-      _conductivity(NULL),
-      _diffusivity(NULL)
+    : AntiochMixture(input,material)
   {
     std::string transport_data_filename = input( "Materials/"+material+"/GasMixture/Antioch/transport_data", "default" );
     if( transport_data_filename == std::string("default") )

--- a/src/properties/src/cantera_mixture.C
+++ b/src/properties/src/cantera_mixture.C
@@ -39,8 +39,6 @@
 namespace GRINS
 {
   CanteraMixture::CanteraMixture( const GetPot& input, const std::string& material )
-    : _cantera_gas(NULL),
-      _cantera_transport(NULL)
   {
     const std::string cantera_chem_file = MaterialsParsing::parse_chemical_kinetics_datafile_name( input, material );
 

--- a/src/qoi/include/grins/composite_qoi.h
+++ b/src/qoi/include/grins/composite_qoi.h
@@ -63,7 +63,7 @@ namespace GRINS
     //! Required to provide clone for adding QoI object to libMesh objects.
     /*! Note that we do a deep copy here since the previous object might
         get destroyed and wipe out the objects being pointed to in _qois. */
-    virtual libMesh::AutoPtr<libMesh::DifferentiableQoI> clone();
+    virtual libMesh::UniquePtr<libMesh::DifferentiableQoI> clone();
 
     virtual void add_qoi( const QoIBase& qoi );
 

--- a/src/qoi/include/grins/parsed_boundary_qoi.h
+++ b/src/qoi/include/grins/parsed_boundary_qoi.h
@@ -75,14 +75,14 @@ namespace GRINS
 
   protected:
 
-    libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
       qoi_functional;
 
 
     //! List of boundary ids on which we want to compute this QoI
     std::set<libMesh::boundary_id_type> _bc_ids;
 
-    //! Manual copy constructor due to the AutoPtr
+    //! Manual copy constructor due to the UniquePtr
     ParsedBoundaryQoI(const ParsedBoundaryQoI& original);
 
   private:

--- a/src/qoi/include/grins/parsed_interior_qoi.h
+++ b/src/qoi/include/grins/parsed_interior_qoi.h
@@ -75,10 +75,10 @@ namespace GRINS
 
   protected:
 
-    libMesh::AutoPtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
       qoi_functional;
 
-    //! Manual copy constructor due to the AutoPtr
+    //! Manual copy constructor due to the UniquePtr
     ParsedInteriorQoI(const ParsedInteriorQoI& original);
 
   private:

--- a/src/qoi/src/composite_qoi.C
+++ b/src/qoi/src/composite_qoi.C
@@ -55,7 +55,7 @@ namespace GRINS
     return;
   }
 
-  libMesh::AutoPtr<libMesh::DifferentiableQoI> CompositeQoI::clone()
+  libMesh::UniquePtr<libMesh::DifferentiableQoI> CompositeQoI::clone()
   {
     CompositeQoI* clone = new CompositeQoI;
 
@@ -64,7 +64,7 @@ namespace GRINS
         clone->add_qoi( this->get_qoi(q) );
       }
 
-    return libMesh::AutoPtr<libMesh::DifferentiableQoI>(clone);
+    return libMesh::UniquePtr<libMesh::DifferentiableQoI>(clone);
   }
 
   void CompositeQoI::add_qoi( const QoIBase& qoi )

--- a/src/solver/src/grins_steady_solver.C
+++ b/src/solver/src/grins_steady_solver.C
@@ -55,7 +55,7 @@ namespace GRINS
   {
     libMesh::SteadySolver* time_solver = new libMesh::SteadySolver( *(system) );
 
-    system->time_solver = libMesh::AutoPtr<libMesh::TimeSolver>(time_solver);
+    system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>(time_solver);
     return;
   }
 

--- a/src/solver/src/grins_unsteady_solver.C
+++ b/src/solver/src/grins_unsteady_solver.C
@@ -96,12 +96,12 @@ namespace GRINS
         outer_solver->quiet = false;
 
         outer_solver->core_time_solver =
-          libMesh::AutoPtr<libMesh::UnsteadySolver>(time_solver);
-        system->time_solver = libMesh::AutoPtr<libMesh::TimeSolver>(outer_solver);
+          libMesh::UniquePtr<libMesh::UnsteadySolver>(time_solver);
+        system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>(outer_solver);
       }
     else
       {
-        system->time_solver = libMesh::AutoPtr<libMesh::TimeSolver>(time_solver);
+        system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>(time_solver);
       }
 
     time_solver->reduce_deltat_on_diffsolver_failure = this->_backtrack_deltat;

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -40,8 +40,7 @@ namespace GRINS
   MeshAdaptiveSolverBase::MeshAdaptiveSolverBase( const GetPot& input )
     : _error_estimator_options(input),
       _mesh_adaptivity_options(input),
-      _refinement_type(INVALID),
-      _mesh_refinement(NULL)
+      _refinement_type(INVALID)
   {
     this->set_refinement_type( input, _mesh_adaptivity_options, _refinement_type );
   }

--- a/src/solver/src/parameter_manager.C
+++ b/src/solver/src/parameter_manager.C
@@ -76,7 +76,7 @@ namespace GRINS
           }
 
         this->parameter_vector.push_back
-          (libMesh::AutoPtr<libMesh::ParameterAccessor<libMesh::Number> >
+          (libMesh::UniquePtr<libMesh::ParameterAccessor<libMesh::Number> >
            (next_param));
       }
   }

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -57,7 +57,7 @@ namespace GRINS
   {
     libMesh::SteadySolver* time_solver = new libMesh::SteadySolver( *(system) );
 
-    system->time_solver = libMesh::AutoPtr<libMesh::TimeSolver>( time_solver );
+    system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>( time_solver );
 
     return;
   }

--- a/src/utilities/include/grins/distance_function.h
+++ b/src/utilities/include/grins/distance_function.h
@@ -83,7 +83,7 @@ namespace GRINS {
     /**
      * Interpolate distance function to points qpts (in reference space) for element *elem
      */
-    libMesh::AutoPtr< libMesh::DenseVector<libMesh::Real> > interpolate (const libMesh::Elem* elem, const std::vector<libMesh::Point>& qts) const;
+    libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> > interpolate (const libMesh::Elem* elem, const std::vector<libMesh::Point>& qts) const;
 
 
 
@@ -107,7 +107,7 @@ namespace GRINS {
      * Currently type is hardcoded to first order, Lagrange
      * (see constructor), but this could be easily changed.
      */
-    libMesh::AutoPtr<libMesh::FEBase> _dist_fe;
+    libMesh::UniquePtr<libMesh::FEBase> _dist_fe;
 
   };
 
@@ -257,7 +257,7 @@ namespace GRINS {
     const unsigned int _dim;
     const libMesh::Point& _p;
 
-    libMesh::AutoPtr<libMesh::FEBase> _fe;
+    libMesh::UniquePtr<libMesh::FEBase> _fe;
     libMesh::FEBase *fe;
 
     // work vectors

--- a/src/utilities/src/distance_function.C
+++ b/src/utilities/src/distance_function.C
@@ -500,7 +500,7 @@ namespace GRINS {
                     // physical space and use it to evaluate the distance
 
                     // assuming first order lagrange basis here
-                    libMesh::AutoPtr<libMesh::FEBase> fe( libMesh::FEBase::build(2, libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE)) );
+                    libMesh::UniquePtr<libMesh::FEBase> fe( libMesh::FEBase::build(2, libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE)) );
 
                     std::vector<libMesh::Point> xi(1);
                     xi[0](0) = X(0);
@@ -611,7 +611,7 @@ namespace GRINS {
   //---------------------------------------------------
   // Interpolate nodal data
   //
-  libMesh::AutoPtr< libMesh::DenseVector<libMesh::Real> >
+  libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> >
   DistanceFunction::interpolate (const libMesh::Elem* elem, const std::vector<libMesh::Point>& qpts) const
   {
     libmesh_assert( elem != NULL );    // can't interpolate in NULL elem
@@ -630,7 +630,7 @@ namespace GRINS {
     const unsigned int n_pts = qpts.size();
 
     // instantiate auto_ptr to dense vector to hold results
-    libMesh::AutoPtr< DenseVector<libMesh::Real> > ap( new libMesh::DenseVector<libMesh::Real>(qpts.size()) );
+    libMesh::UniquePtr< DenseVector<libMesh::Real> > ap( new libMesh::DenseVector<libMesh::Real>(qpts.size()) );
     (*ap).zero();
 
     // pull off distance function at nodes on this element

--- a/src/visualization/include/grins/postprocessed_quantities.h
+++ b/src/visualization/include/grins/postprocessed_quantities.h
@@ -47,10 +47,10 @@ namespace GRINS
     /* Methods to override from FEMFunctionBase needed for libMesh-based evaluations */
     virtual void init_context( const libMesh::FEMContext & context);
 
-    virtual libMesh::AutoPtr<libMesh::FEMFunctionBase<NumericType> >
+    virtual libMesh::UniquePtr<libMesh::FEMFunctionBase<NumericType> >
     clone() const
     {
-      return libMesh::AutoPtr<libMesh::FEMFunctionBase<NumericType> >
+      return libMesh::UniquePtr<libMesh::FEMFunctionBase<NumericType> >
         ( new PostProcessedQuantities(*this) );
     }
 

--- a/src/visualization/src/unsteady_visualization.C
+++ b/src/visualization/src/unsteady_visualization.C
@@ -70,7 +70,7 @@ namespace GRINS
     // the solution and the rhs vector stashed in the system. Once we're done,
     // we'll reset the time solver pointer back to the original guy.
 
-    libMesh::UniquePtr<libMesh::TimeSolver> prev_time_solver(system->time_solver);
+    libMesh::TimeSolver* prev_time_solver = system->time_solver.get();
 
     libMesh::SteadySolver* steady_solver = new libMesh::SteadySolver( *(system) );
 
@@ -90,9 +90,7 @@ namespace GRINS
     system->solution->swap( *(system->rhs) );
     equation_system->update();
 
-    system->time_solver = prev_time_solver;
-
-    return;
+    system->time_solver.reset(prev_time_solver);
   }
 
   void UnsteadyVisualization::output_residual_sensitivities

--- a/src/visualization/src/unsteady_visualization.C
+++ b/src/visualization/src/unsteady_visualization.C
@@ -70,11 +70,11 @@ namespace GRINS
     // the solution and the rhs vector stashed in the system. Once we're done,
     // we'll reset the time solver pointer back to the original guy.
 
-    libMesh::AutoPtr<libMesh::TimeSolver> prev_time_solver(system->time_solver);
+    libMesh::UniquePtr<libMesh::TimeSolver> prev_time_solver(system->time_solver);
 
     libMesh::SteadySolver* steady_solver = new libMesh::SteadySolver( *(system) );
 
-    system->time_solver = libMesh::AutoPtr<libMesh::TimeSolver>(steady_solver);
+    system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>(steady_solver);
 
     system->assembly( true /*residual*/, false /*jacobian*/ );
     system->rhs->close();

--- a/test/regression/test_turbulent_channel.C
+++ b/test/regression/test_turbulent_channel.C
@@ -114,8 +114,8 @@ public:
     output(0) = u_nu_values(0)/21.995539;
   }
 
-  virtual libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > clone() const
-  { return libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > (new TurbulentBdyFunctionU(turbulent_bc_values)); }
+  virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > clone() const
+  { return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > (new TurbulentBdyFunctionU(turbulent_bc_values)); }
 
 private:
   libMesh::MeshFunction* turbulent_bc_values;
@@ -158,8 +158,8 @@ public:
     output(0) = u_nu_values(1)/(2.0*21.995539);
   }
 
-  virtual libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > clone() const
-  { return libMesh::AutoPtr<libMesh::FunctionBase<libMesh::Number> > (new TurbulentBdyFunctionNu(turbulent_bc_values)); }
+  virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > clone() const
+  { return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > (new TurbulentBdyFunctionNu(turbulent_bc_values)); }
 
 private:
   libMesh::MeshFunction* turbulent_bc_values;
@@ -223,9 +223,9 @@ int main(int argc, char* argv[])
   equation_systems.print_info();
 
   // Prepare a global solution and a MeshFunction of the Turbulent system
-  libMesh::AutoPtr<libMesh::MeshFunction> turbulent_bc_values;
+  libMesh::UniquePtr<libMesh::MeshFunction> turbulent_bc_values;
 
-  libMesh::AutoPtr<libMesh::NumericVector<libMesh::Number> > turbulent_bc_soln = libMesh::NumericVector<libMesh::Number>::build(equation_systems.comm());
+  libMesh::UniquePtr<libMesh::NumericVector<libMesh::Number> > turbulent_bc_soln = libMesh::NumericVector<libMesh::Number>::build(equation_systems.comm());
 
   std::vector<libMesh::Number> flow_soln;
 
@@ -239,7 +239,7 @@ int main(int argc, char* argv[])
   turbulent_bc_system_variables.push_back(0);
   turbulent_bc_system_variables.push_back(1);
 
-  turbulent_bc_values = libMesh::AutoPtr<libMesh::MeshFunction>
+  turbulent_bc_values = libMesh::UniquePtr<libMesh::MeshFunction>
     (new libMesh::MeshFunction(equation_systems,
 			       *turbulent_bc_soln,
 			       turbulent_bc_system.get_dof_map(),


### PR DESCRIPTION
This, I believe, completely removes `libMesh::AutoPtr` and moves all of those to `libMesh::UniquePtr`. A few clean ups were needed. I tested this with the latest tip of libMesh master, in particular following the merge of libMesh/libmesh#881.