### PR TITLE
Remove duplicate Viscosity objects

### DIFF
--- a/src/physics/include/grins/parsed_velocity_source_adjoint_stab.h
+++ b/src/physics/include/grins/parsed_velocity_source_adjoint_stab.h
@@ -59,8 +59,6 @@ namespace GRINS
 
   protected:
 
-    Viscosity _mu;
-
     IncompressibleNavierStokesStabilizationHelper _stab_helper;
 
   private:

--- a/src/physics/include/grins/velocity_penalty_adjoint_stab.h
+++ b/src/physics/include/grins/velocity_penalty_adjoint_stab.h
@@ -59,8 +59,6 @@ namespace GRINS
 
   protected:
 
-    Viscosity _mu;
-
     IncompressibleNavierStokesStabilizationHelper _stab_helper;
 
   private:

--- a/src/physics/src/parsed_velocity_source_adjoint_stab.C
+++ b/src/physics/src/parsed_velocity_source_adjoint_stab.C
@@ -41,7 +41,6 @@ namespace GRINS
   template<class Mu>
   ParsedVelocitySourceAdjointStabilization<Mu>::ParsedVelocitySourceAdjointStabilization( const std::string& physics_name, const GetPot& input )
     : ParsedVelocitySourceBase<Mu>(physics_name,input),
-      _mu( input ),
       _stab_helper( physics_name+"StabHelper", input )
   {
   }

--- a/src/physics/src/velocity_penalty_adjoint_stab.C
+++ b/src/physics/src/velocity_penalty_adjoint_stab.C
@@ -41,7 +41,6 @@ namespace GRINS
   template<class Mu>
   VelocityPenaltyAdjointStabilization<Mu>::VelocityPenaltyAdjointStabilization( const std::string& physics_name, const GetPot& input )
     : VelocityPenaltyBase<Mu>(physics_name,input),
-      _mu( input ),
       _stab_helper( physics_name+"StabHelper", input )
   {
   }


### PR DESCRIPTION
The Viscosity is in the incompressible_navier_stokes_base class. Thanks to @nicholasmalaya for the concise test input file. @nicholasmalaya, this should fix the problems you were seeing.