### PR TITLE
Fix amr test

### DIFF
--- a/test/amr/convection_diffusion_unsteady_2d.sh
+++ b/test/amr/convection_diffusion_unsteady_2d.sh
@@ -13,7 +13,7 @@ ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT
 # Untar the files into a local directory in the build tree
 LOCALTESTDIR="./convection_diffusion_unsteady_2d_amr_test_tmp"
 
-mkdir $LOCALTESTDIR
+mkdir -p $LOCALTESTDIR
 tar -xzf ${GRINS_TEST_SRCDIR_DIR}/amr/gold_data/convection_diffusion_unsteady_2d/files.tar.gz --directory $LOCALTESTDIR
 
 # Now give prefixes for the gold data

--- a/test/amr/input_files/convection_diffusion_unsteady_2d_amr.in
+++ b/test/amr/input_files/convection_diffusion_unsteady_2d_amr.in
@@ -51,6 +51,7 @@
 []
 
 [Mesh]
+   class = 'serial'
    [./Read]
       filename = './grids/mixed_quad_tri_square_mesh.xda'
    [../Refinement]


### PR DESCRIPTION
Sorry it took me so long to get around to this; GRINS "make check" wasn't working on libMesh --enable-parmesh builds.