### PR TITLE
FEVariableBase: fixup, test, axisymmetry, Neumann BC sign

### DIFF
--- a/src/variables/include/grins/fe_variables_base.h
+++ b/src/variables/include/grins/fe_variables_base.h
@@ -66,6 +66,12 @@ namespace GRINS
     bool is_constraint_var() const
     { return _is_constraint_var; }
 
+    static void set_is_axisymmetric( bool is_axisymmetric )
+    { _is_axisymmetric = is_axisymmetric; }
+
+    static bool is_axisymmetric()
+    { return _is_axisymmetric; }
+
   protected:
 
     //! Default method for init'ing variables
@@ -90,6 +96,11 @@ namespace GRINS
         do not). This should be set by the finite element
         type subclasses. */
     bool _is_constraint_var;
+
+    //! Track whether this is an axisymmetric problem
+    /*! This is static because either everyone thinks the problem
+        axisymmetric or not. */
+    static bool _is_axisymmetric;
 
   };
 } // end namespace GRINS

--- a/src/variables/include/grins/fe_variables_base.h
+++ b/src/variables/include/grins/fe_variables_base.h
@@ -51,8 +51,8 @@ namespace GRINS
   {
   public:
 
-    FEVariablesBase( bool _is_constraint_var )
-      : _is_constraint_var(_is_constraint_var)
+    FEVariablesBase( bool is_constraint_var )
+      : _is_constraint_var(is_constraint_var)
     {}
 
     ~FEVariablesBase(){};

--- a/src/variables/src/fe_variables_base.C
+++ b/src/variables/src/fe_variables_base.C
@@ -31,6 +31,10 @@
 
 namespace GRINS
 {
+  // Instantiate static variables
+  bool FEVariablesBase::_is_axisymmetric = false;
+
+  // Implementations
   void FEVariablesBase::default_fe_init( libMesh::FEMSystem* system,
                                          const std::vector<std::string>& var_names,
                                          std::vector<VariableIndex>& vars ) const


### PR DESCRIPTION
Cherry-picked these off my bc-refactor branch. First commit is just a fixup (would've been nice to get a compiler warning).  Second is an extra test I'd gone ahead and plopped in. The last two commits add new features.

The first new feature is adding the notion of axisymmetry to the `FEVariableBase` objects. That is, downstream of this PR, we can decide (from parsing the input file) if we're working on axisymmetric problem or not. This is important for Neumann boundary conditions where we'll need the extra `r` factor in the Jacobian.

The second feature adds the tracking of the sign that will go in front of the Neumann boundary terms. For example, the heat equation and Maxwell's equation give differing signs on the natural boundary condition term.  However, it is preferable to be able to just say that a "user-supplied flux is always positive outward". This allows the Physics class to encode that at construction time in the `FEVariableBase` object. Then, downstream of this PR, we can query the `FEVariableBase` object for that corresponding Neumann BC and pass the correct sign to the function.