### PR TITLE
Add missing init_context() overrides

### DIFF
--- a/src/physics/include/grins/axisym_boussinesq_buoyancy.h
+++ b/src/physics/include/grins/axisym_boussinesq_buoyancy.h
@@ -66,6 +66,8 @@ namespace GRINS
     //! Initialization of AxisymmetricBoussinesqBuoyancy variables
     virtual void init_variables( libMesh::FEMSystem* system );
 
+    virtual void init_context( AssemblyContext& context );
+
     //! Source term contribution for AxisymmetricBoussinesqBuoyancy
     /*! This is the main part of the class. This will add the source term to
         the AxisymmetricIncompNavierStokes class.

--- a/src/physics/include/grins/parsed_source_term.h
+++ b/src/physics/include/grins/parsed_source_term.h
@@ -42,6 +42,8 @@ namespace GRINS
 
     virtual ~ParsedSourceTerm();
 
+    virtual void init_context( AssemblyContext& context );
+
     virtual void element_time_derivative( bool compute_jacobian,
 					  AssemblyContext& context,
 					  CachedValues& cache );

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -90,6 +90,14 @@ namespace GRINS
     this->_press_var.init(system);
   }
 
+  void AxisymmetricBoussinesqBuoyancy::init_context( AssemblyContext& context )
+  {
+      context.get_element_fe(_flow_vars.u())->get_JxW();
+      context.get_element_fe(_flow_vars.u())->get_phi();
+      context.get_element_fe(_flow_vars.u())->get_xyz();
+      context.get_element_fe(_temp_vars.T())->get_phi();
+  }
+
   void AxisymmetricBoussinesqBuoyancy::element_time_derivative( bool compute_jacobian,
 								AssemblyContext& context,
 								CachedValues& /*cache*/ )

--- a/src/physics/src/parsed_source_term.C
+++ b/src/physics/src/parsed_source_term.C
@@ -49,6 +49,19 @@ namespace GRINS
     return;
   }
 
+  void ParsedSourceTerm::init_context( AssemblyContext& context )
+  {
+    for( std::vector<VariableIndex>::const_iterator v_it = _vars.begin();
+         v_it != _vars.end(); ++v_it )
+      {
+        VariableIndex var = *v_it;
+
+        context.get_element_fe(var)->get_JxW();
+        context.get_element_fe(var)->get_phi();
+        context.get_element_fe(var)->get_xyz();
+      }
+  }
+
   void ParsedSourceTerm::element_time_derivative( bool /*compute_jacobian*/,
                                                   AssemblyContext& context,
                                                   CachedValues& /*cache*/ )


### PR DESCRIPTION
This should help prevent possible bugs if users choose stranger combinations of physics operators.

I was working on this preemptively to also fix any bugs triggered by https://github.com/libMesh/libmesh/pull/892 - however if there are any such, we don't hit them in the test suite.