### PR TITLE
Uncollide helper function name with Antioch macro name

### DIFF
--- a/src/physics/include/grins/physics_factory_reacting_flows.h
+++ b/src/physics/include/grins/physics_factory_reacting_flows.h
@@ -46,10 +46,10 @@ namespace GRINS
     virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name );
 
-    void antioch_error_msg( const std::string& viscosity_model,
-                            const std::string& conductivity_model,
-                            const std::string& diffusivity_model,
-                            const std::string& thermo_model ) const;
+    void grins_antioch_model_error_msg( const std::string& viscosity_model,
+                                        const std::string& conductivity_model,
+                                        const std::string& diffusivity_model,
+                                        const std::string& thermo_model ) const;
 
   };
 

--- a/src/physics/src/physics_factory_reacting_flows.C
+++ b/src/physics/src/physics_factory_reacting_flows.C
@@ -117,7 +117,7 @@ namespace GRINS
 #endif // ANTIOCH_HAVE_GSL
               }
             else
-              this->antioch_error_msg(viscosity_model,conductivity_model,diffusivity_model,thermo_model);
+              this->grins_antioch_model_error_msg(viscosity_model,conductivity_model,diffusivity_model,thermo_model);
           }
 
         else if( transport_model == std::string("constant") )
@@ -157,7 +157,7 @@ namespace GRINS
                                   (physics_name,input) );
               }
             else
-              this->antioch_error_msg(viscosity_model,conductivity_model,diffusivity_model,thermo_model);
+              this->grins_antioch_model_error_msg(viscosity_model,conductivity_model,diffusivity_model,thermo_model);
           }
         else // transport_model
           {
@@ -188,10 +188,11 @@ namespace GRINS
   }
 
   template<template<typename,typename> class DerivedPhysics>
-  void PhysicsFactoryReactingFlows<DerivedPhysics>::antioch_error_msg( const std::string& viscosity_model,
-                                                                       const std::string& conductivity_model,
-                                                                       const std::string& diffusivity_model,
-                                                                       const std::string& thermo_model ) const
+  void PhysicsFactoryReactingFlows<DerivedPhysics>::grins_antioch_model_error_msg
+  ( const std::string& viscosity_model,
+    const std::string& conductivity_model,
+    const std::string& diffusivity_model,
+    const std::string& thermo_model ) const
   {
     std::string error = "Error: Unknown Antioch model combination:\n";
     error += "viscosity_model    = "+viscosity_model+"\n";


### PR DESCRIPTION
Had a name collision with the antioch-error-macro name that got
added in libantioch/antioch#185.

CI-server is supposed to be delievered 4/22. Hopefully it will be up and running shortly thereafter to catch this stuff. Sorry.

Going to merge right away since without this we can't compile with current Antioch master.