### PR TITLE
CanteraMixture is now a ParameterUser subclass

### DIFF
--- a/src/properties/src/cantera_mixture.C
+++ b/src/properties/src/cantera_mixture.C
@@ -39,6 +39,7 @@
 namespace GRINS
 {
   CanteraMixture::CanteraMixture( const GetPot& input, const std::string& material )
+    : ParameterUser("CanteraMixture")
   {
     const std::string cantera_chem_file = MaterialsParsing::parse_chemical_kinetics_datafile_name( input, material );
 


### PR DESCRIPTION
So call the correct constructor since the default constructor
does not exist. Fix for compilation problem with Cantera introduced
in #391.

This gets GRINS compiling again for me with Cantera enabled (and make check still passes). Will merge right away.