### PR TITLE
Neumann BC sign: Redo FEVariableBase setter/SolidMechanics Sign Convention

### DIFF
--- a/src/physics/include/grins/elastic_cable_base.h
+++ b/src/physics/include/grins/elastic_cable_base.h
@@ -43,14 +43,6 @@ namespace GRINS
 
   protected:
 
-    //! Implementation of element_time_derivative.
-    /*! The lambda argument is needed to support Rayleigh Damping. */
-    void element_time_derivative_impl( bool compute_jacobian,
-                                       AssemblyContext& context,
-                                       VarFuncType get_solution,
-                                       VarDerivType get_solution_deriv,
-                                       libMesh::Real lambda = 1.0 );
-
     //! Implementation of mass_residual.
     /*! The mu argument is needed to support Rayleigh Damping. */
     void mass_residual_impl( bool compute_jacobian,

--- a/src/physics/src/solid_mechanics_abstract.C
+++ b/src/physics/src/solid_mechanics_abstract.C
@@ -42,6 +42,14 @@ namespace GRINS
       _disp_vars(input,physics_name,false,true)// is_2D = false, is_3D = true
   {
     this->register_variables();
+
+    // For solid mechanics problems, we need to set the sign for tractions
+    // to '-' since the second order time solvers use a Newton residual of the form
+    // M(u)\ddot{u} + C(u)\dot{u} + F(u) + G(u) = 0
+    // In this case, then, the natural boundary conditions for the weak form
+    // will all have a '-', so we need to set that so the input tractions are
+    // positive.
+    _disp_vars.set_neumann_bc_is_positive(false);
   }
 
   void SolidMechanicsAbstract::init_variables( libMesh::FEMSystem* system )

--- a/src/variables/include/grins/fe_variables_base.h
+++ b/src/variables/include/grins/fe_variables_base.h
@@ -75,10 +75,11 @@ namespace GRINS
     static bool is_axisymmetric()
     { return _is_axisymmetric; }
 
-    //! Reset Neumann bc sign to 1.0 or -1.0.
-    /*! Error is thrown if incoming neumann_bc_sign does not have
-        magnitude 1. */
-    void reset_neumann_bc_sign( libMesh::Real neumann_bc_sign );
+    //! Reset whetever Neumann bc is postive or not
+    /*! Postive means a value of 1.0 will be used in front of
+        NeumannBC terms while is_positive = false indicates a
+        value of -1.0 should be used.*/
+    void set_neumann_bc_is_positive( bool is_positive );
 
     libMesh::Real neumann_bc_sign() const
     { return _neumann_bc_sign; }
@@ -121,11 +122,12 @@ namespace GRINS
   };
 
   inline
-  void FEVariablesBase::reset_neumann_bc_sign( libMesh::Real neumann_bc_sign )
+  void FEVariablesBase::set_neumann_bc_is_positive( bool is_positive )
   {
-    _neumann_bc_sign = neumann_bc_sign;
-    if( std::abs( _neumann_bc_sign - 1.0 ) > std::numeric_limits<libMesh::Real>::epsilon() )
-      libmesh_error_msg("ERROR: neumann_bc_sign must be 1.0 or -1.0!");
+    if(is_positive)
+      _neumann_bc_sign = 1.0;
+    else
+      _neumann_bc_sign = -1.0;
   }
 
 } // end namespace GRINS


### PR DESCRIPTION
API for setting Neumann BC sign introduced in #386 was stupid. This one is better. Also set up the correct sign for `SolidMechanics` `Physics`.  This does not effect code in master, but rather downstream in the BC refactoring, where it has been successfully tested.