### PR TITLE
Doxygen Option Changes

### DIFF
--- a/doxygen/grins.dox.in
+++ b/doxygen/grins.dox.in
@@ -1415,7 +1415,7 @@ UML_LOOK               = NO
 # If set to YES, the inheritance and collaboration graphs will show the 
 # relations between templates and their instances.
 
-TEMPLATE_RELATIONS     = NO
+TEMPLATE_RELATIONS     = YES
 
 # If the ENABLE_PREPROCESSING, SEARCH_INCLUDES, INCLUDE_GRAPH, and HAVE_DOT 
 # tags are set to YES then doxygen will generate a graph for each documented 

--- a/doxygen/grins.dox.in
+++ b/doxygen/grins.dox.in
@@ -99,7 +99,7 @@ ALWAYS_DETAILED_SEC    = NO
 # members were ordinary class members. Constructors, destructors and assignment 
 # operators of the base classes will not be shown.
 
-INLINE_INHERITED_MEMB  = YES 
+INLINE_INHERITED_MEMB  = NO
 
 # If the FULL_PATH_NAMES tag is set to YES then Doxygen will prepend the full 
 # path before files name in the file list and in the header files. If set 


### PR DESCRIPTION
Set `TEMPLATE_RELATIONS = YES` and `INLINE_INHERITED_MEMB = NO`. The former is what I originally expected when using Doxygen with CRTP-type base classes. The latter I've really come to prefer. It significantly declutters looking for methods in the current class while still easily makes available base class methods.