### PR TITLE
Physics/Axisymmetry Consistency

### DIFF
--- a/src/bc_handling/include/grins/bc_handling_base.h
+++ b/src/bc_handling/include/grins/bc_handling_base.h
@@ -123,9 +123,8 @@ namespace GRINS
 					  GRINS::BCType bc_type ) const;
     
 
-    GRINS::BCType get_dirichlet_bc_type( const GRINS::BoundaryID bc_id ) const;
 
-    bool is_axisymmetric() const;
+    GRINS::BCType get_dirichlet_bc_type( const GRINS::BoundaryID bc_id ) const;
 
   protected:
 
@@ -166,21 +165,12 @@ namespace GRINS
                   PARSED_FEM_DIRICHLET,
                   AXISYMMETRIC };
 
-    //! Flag to cache whether or not there is an axisymmetric boundary present
-    static bool _axisymmetric;
-
   private:
     BCHandlingBase();
 
   };
 
   /* ------------------------- Inline Functions -------------------------*/
-  inline
-  bool BCHandlingBase::is_axisymmetric() const
-  {
-    return _axisymmetric;
-  }
-
   inline
   const libMesh::Point& BCHandlingBase::get_neumann_bc_value( GRINS::BoundaryID bc_id ) const
   {

--- a/src/bc_handling/src/bc_handling_base.C
+++ b/src/bc_handling/src/bc_handling_base.C
@@ -46,8 +46,6 @@
 
 namespace GRINS
 {
-  bool BCHandlingBase::_axisymmetric = false; 
-
   BCHandlingBase::BCHandlingBase(const std::string& physics_name)
     : _num_periodic_bcs(0),
       _physics_name( physics_name )   
@@ -304,7 +302,6 @@ namespace GRINS
     else if( bc_type_in == "axisymmetric" )
       {
         bc_type_out = AXISYMMETRIC;
-        this->_axisymmetric = true;
 
         // Check and make sure the Physics is axisymmetric. If not, that's an error
         if( !Physics::is_axisymmetric() )

--- a/src/bc_handling/src/bc_handling_base.C
+++ b/src/bc_handling/src/bc_handling_base.C
@@ -29,6 +29,7 @@
 // GRINS
 #include "grins/string_utils.h"
 #include "grins/shared_ptr.h"
+#include "grins/physics.h"
 
 // libMesh
 #include "libmesh/composite_function.h"
@@ -304,6 +305,10 @@ namespace GRINS
       {
         bc_type_out = AXISYMMETRIC;
         this->_axisymmetric = true;
+
+        // Check and make sure the Physics is axisymmetric. If not, that's an error
+        if( !Physics::is_axisymmetric() )
+          libmesh_error_msg("ERROR: Physics/is_axisymmetric must be set to true if using axisymmetric boundary conditions!\n");
       }
     else
       {

--- a/src/bc_handling/src/heat_transfer_bc_handling.C
+++ b/src/bc_handling/src/heat_transfer_bc_handling.C
@@ -26,6 +26,9 @@
 // This class
 #include "grins/heat_transfer_bc_handling.h"
 
+// GRINS
+#include "grins/physics.h"
+
 // libMesh
 #include "libmesh/const_function.h"
 #include "libmesh/dirichlet_boundaries.h"
@@ -191,7 +194,7 @@ namespace GRINS
 	// Prescribed constant heat flux
       case(PRESCRIBED_HEAT_FLUX):
 	{
-          if( this->is_axisymmetric() )
+          if(Physics::is_axisymmetric())
             {
               _bound_conds.apply_neumann_axisymmetric( context, _temp_vars.T(), -1.0,
                                                        this->get_neumann_bc_value(bc_id) );
@@ -206,7 +209,7 @@ namespace GRINS
 	// General heat flux from user specified function
       case(GENERAL_HEAT_FLUX):
 	{
-          if( this->is_axisymmetric() )
+          if(Physics::is_axisymmetric())
             {
               _bound_conds.apply_neumann_axisymmetric( context, cache, request_jacobian, _temp_vars.T(), -1.0, 
                                                        this->get_neumann_bound_func( bc_id, _temp_vars.T() ) );

--- a/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
+++ b/src/bc_handling/src/reacting_low_mach_navier_stokes_bc_handling.C
@@ -36,6 +36,7 @@
 #include "grins/materials_parsing.h"
 #include "grins/physics_naming.h"
 #include "grins/catalycity_factory_old_style_base.h"
+#include "grins/physics.h"
 
 // libMesh
 #include "libmesh/fem_system.h"
@@ -406,14 +407,8 @@ namespace GRINS
             std::pair< it_type, it_type > it_range = _catalytic_walls.equal_range( bc_id );
 
             for( it_type it = it_range.first; it != it_range.second; ++it )
-              {
-                (it->second)->init(system);
+              (it->second)->init(system);
 
-                if( this->is_axisymmetric() )
-                  {
-                    (it->second)->set_axisymmetric(true);
-                  }
-              }
           } // if( bc_type == GAS_RECOMBINATION_CATALYTIC_WALL )
 
       } // end loop over bc_ids
@@ -519,7 +514,7 @@ namespace GRINS
 	    {
               unsigned int var = _species_vars.species(s);
 
-              if( this->is_axisymmetric() )
+              if(Physics::is_axisymmetric())
                 {
                   _bound_conds.apply_neumann_normal_axisymmetric( context, cache,
                                                                   request_jacobian, var, -1.0,

--- a/src/boundary_conditions/include/grins/catalytic_wall_base.h
+++ b/src/boundary_conditions/include/grins/catalytic_wall_base.h
@@ -61,8 +61,6 @@ namespace GRINS
 
     virtual void init( const libMesh::FEMSystem& system );
 
-    void set_axisymmetric( bool is_axisymmetric );
-
     //! \f$ \rho_s \gamma \sqrt{ \frac{R_s T}{2\pi} } \f$
     libMesh::Real omega_dot( const libMesh::Real rho_s, const libMesh::Real T ) const;
 
@@ -81,8 +79,6 @@ namespace GRINS
 
     //! \f$ \sqrt{ \frac{R_s}{2\pi} } \f$
     const libMesh::Real _C;
-
-    bool _is_axisymmetric;
 
   };
 

--- a/src/boundary_conditions/src/catalytic_wall_base.C
+++ b/src/boundary_conditions/src/catalytic_wall_base.C
@@ -42,8 +42,7 @@ namespace GRINS
                                                    const unsigned int reactant_species_idx )
     : _chemistry(chemistry),
       _gamma_s( gamma.clone() ),
-      _C( std::sqrt( chemistry.R(reactant_species_idx)/(GRINS::Constants::two_pi) ) ),
-      _is_axisymmetric(false)
+      _C( std::sqrt( chemistry.R(reactant_species_idx)/(GRINS::Constants::two_pi) ) )
   {
     return;
   }
@@ -59,15 +58,6 @@ namespace GRINS
   {
     return;
   }
-
-  template<typename Chemistry>
-  void CatalyticWallBase<Chemistry>::set_axisymmetric( bool is_axisymmetric )
-  {
-    this->_is_axisymmetric = is_axisymmetric;
-
-    return;
-  }
-  
 
   template<typename Chemistry>
   void CatalyticWallBase<Chemistry>::set_catalycity_params( const std::vector<libMesh::Real>& params )

--- a/src/boundary_conditions/src/gas_recombination_catalytic_wall.C
+++ b/src/boundary_conditions/src/gas_recombination_catalytic_wall.C
@@ -25,6 +25,9 @@
 // This class
 #include "grins/gas_recombination_catalytic_wall.h"
 
+// GRINS
+#include "grins/physics.h"
+
 // libMesh
 #include "libmesh/quadrature.h"
 
@@ -99,7 +102,7 @@ namespace GRINS
       {
         libMesh::Real jac = JxW_side[qp];
 
-        if( this->_is_axisymmetric )
+        if(Physics::is_axisymmetric())
           {
             const libMesh::Number r = var_qpoint[qp](0);
             jac *= r;

--- a/src/boundary_conditions/src/gas_solid_catalytic_wall.C
+++ b/src/boundary_conditions/src/gas_solid_catalytic_wall.C
@@ -25,6 +25,9 @@
 // This class
 #include "grins/gas_solid_catalytic_wall.h"
 
+// GRINS
+#include "grins/physics.h"
+
 // libMesh
 #include "libmesh/quadrature.h"
 
@@ -101,7 +104,7 @@ namespace GRINS
       {
         libMesh::Real jac = JxW_side[qp];
 
-        if( this->_is_axisymmetric )
+        if(Physics::is_axisymmetric())
           {
             const libMesh::Number r = var_qpoint[qp](0);
             jac *= r;

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -126,6 +126,13 @@ namespace GRINS
     //! Returns whether or not this physics is being solved with a steady solver.
     bool is_steady() const;
 
+    //! Set whether we should treat the problem as axisymmetric
+    static void set_is_axisymmetric( bool is_axisymmetric )
+    { _is_axisymmetric = is_axisymmetric; }
+
+    static bool is_axisymmetric()
+    { return _is_axisymmetric; }
+
     //! Set which variables are time evolving.
     /*!
       Set those variables which evolve in time (as opposed to variables that behave like constraints).
@@ -279,7 +286,8 @@ namespace GRINS
       depending on whether the solver is steady or unsteady. */
     static bool _is_steady;
 
-    bool _is_axisymmetric;
+    //! Caches whether we are solving an axisymmetric problem or not
+    static bool _is_axisymmetric;
 
 #ifdef GRINS_USE_GRVY_TIMERS
     GRVY::GRVY_Timer_Class* _timer;

--- a/src/physics/src/heat_transfer.C
+++ b/src/physics/src/heat_transfer.C
@@ -50,9 +50,6 @@ namespace GRINS
     // This is deleted in the base class
     this->_bc_handler = new HeatTransferBCHandling( physics_name, input );
 
-    if( this->_bc_handler->is_axisymmetric() )
-      Physics::set_is_axisymmetric(true);
-
     this->_ic_handler = new GenericICHandler( physics_name, input );
   }
 

--- a/src/physics/src/heat_transfer.C
+++ b/src/physics/src/heat_transfer.C
@@ -51,9 +51,7 @@ namespace GRINS
     this->_bc_handler = new HeatTransferBCHandling( physics_name, input );
 
     if( this->_bc_handler->is_axisymmetric() )
-      {
-        this->_is_axisymmetric = true;
-      }
+      Physics::set_is_axisymmetric(true);
 
     this->_ic_handler = new GenericICHandler( physics_name, input );
   }
@@ -169,7 +167,7 @@ namespace GRINS
 	// Compute the conductivity at this qp
 	libMesh::Real _k_qp = this->_k(context, qp);
 
-        if( this->_is_axisymmetric )
+        if(Physics::is_axisymmetric())
           {
             jac *= r;
           }
@@ -287,7 +285,7 @@ namespace GRINS
 
         libMesh::Real jac = JxW[qp];
 
-        if( this->_is_axisymmetric )
+        if(Physics::is_axisymmetric())
           {
             jac *= r;
           }

--- a/src/physics/src/inc_navier_stokes.C
+++ b/src/physics/src/inc_navier_stokes.C
@@ -51,9 +51,7 @@ namespace GRINS
     this->_bc_handler = new IncompressibleNavierStokesBCHandling( physics_name, input );
 
     if( this->_bc_handler->is_axisymmetric() )
-      {
-        this->_is_axisymmetric = true;
-      }
+      Physics::set_is_axisymmetric(true);
 
     this->_ic_handler = new GenericICHandler( physics_name, input );
 
@@ -219,7 +217,7 @@ namespace GRINS
 	// Compute the viscosity at this qp
 	libMesh::Real _mu_qp = this->_mu(context, qp);
 
-        if( this->_is_axisymmetric )
+        if(Physics::is_axisymmetric())
           {
             jac *= r;
           }
@@ -235,7 +233,7 @@ namespace GRINS
                -_mu_qp*(u_gradphi[i][qp]*grad_u) ); // diffusion term
 
             /*! \todo Would it be better to put this in its own DoF loop and do the if check once?*/
-            if( this->_is_axisymmetric )
+            if(Physics::is_axisymmetric())
               {
                 Fu(i) += u_phi[i][qp]*( p/r - _mu_qp*U(0)/(r*r) )*jac;
               }
@@ -268,7 +266,7 @@ namespace GRINS
                        -_mu_qp*(u_gradphi[i][qp]*u_gradphi[j][qp])); // diffusion term
 
 
-                    if( this->_is_axisymmetric )
+                    if(Physics::is_axisymmetric())
                       {
                         Kuu(i,j) -= u_phi[i][qp]*_mu_qp*u_phi[j][qp]/(r*r)*jac * context.get_elem_solution_derivative();
                       }
@@ -314,7 +312,7 @@ namespace GRINS
                         (*Kwp)(i,j) += u_gradphi[i][qp](2)*p_phi[j][qp]*jac * context.get_elem_solution_derivative();
                       }
 
-                    if( this->_is_axisymmetric )
+                    if(Physics::is_axisymmetric())
                       {
                         Kup(i,j) += u_phi[i][qp]*p_phi[j][qp]/r*jac * context.get_elem_solution_derivative();
                       }
@@ -406,7 +404,7 @@ namespace GRINS
 
         libMesh::Real jac = JxW[qp];
 
-        if( this->_is_axisymmetric )
+        if(Physics::is_axisymmetric())
           {
             libMesh::Number u = context.interior_value( this->_flow_vars.u(), qp );
             divU += u/r;
@@ -430,7 +428,7 @@ namespace GRINS
                     if (this->_dim == 3)
                       (*Kpw)(i,j) += p_phi[i][qp]*u_gradphi[j][qp](2)*jac * context.get_elem_solution_derivative();
 
-                    if( this->_is_axisymmetric )
+                    if(Physics::is_axisymmetric())
                       {
                         Kpu(i,j) += p_phi[i][qp]*u_phi[j][qp]/r*jac * context.get_elem_solution_derivative();
                       }
@@ -510,7 +508,7 @@ namespace GRINS
 
         libMesh::Real jac = JxW[qp];
 
-        if( this->_is_axisymmetric )
+        if(Physics::is_axisymmetric())
           {
             jac *= r;
           }

--- a/src/physics/src/inc_navier_stokes.C
+++ b/src/physics/src/inc_navier_stokes.C
@@ -50,9 +50,6 @@ namespace GRINS
     // This is deleted in the base class
     this->_bc_handler = new IncompressibleNavierStokesBCHandling( physics_name, input );
 
-    if( this->_bc_handler->is_axisymmetric() )
-      Physics::set_is_axisymmetric(true);
-
     this->_ic_handler = new GenericICHandler( physics_name, input );
 
     this->_pin_pressure = input("Physics/"+PhysicsNaming::incompressible_navier_stokes()+"/pin_pressure", false );

--- a/src/physics/src/physics.C
+++ b/src/physics/src/physics.C
@@ -39,21 +39,23 @@ namespace GRINS
 {
   // Initialize static members
   bool Physics::_is_steady = false;
+  bool Physics::_is_axisymmetric = false;
 
   Physics::Physics( const std::string& physics_name,
 		    const GetPot& input )
     : ParameterUser(physics_name),
       _physics_name( physics_name ),
       _bc_handler(NULL),
-      _ic_handler(new ICHandlingBase(physics_name)),
-      _is_axisymmetric(false)
+      _ic_handler(new ICHandlingBase(physics_name))
   {
     this->parse_enabled_subdomains(input,physics_name);
 
-    if( input( "Physics/is_axisymmetric", false ) )
-      {
-        _is_axisymmetric = true;
-      }
+    // Check if this is an axisymmetric problem
+    // There will be redundant calls for multiple Physics objects,
+    // but this guarantees we've parsed is_axisymmetric and then
+    // we can check in subclasses and error out if the Physics
+    // doesn't support axisymmetry.
+    Physics::set_is_axisymmetric( input("Physics/is_axisymmetric",false) );
   }
 
   Physics::~Physics()

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -53,9 +53,7 @@ namespace GRINS
                                                                                                       this->_gas_mixture.chemistry() );
 
     if( this->_bc_handler->is_axisymmetric() )
-      {
-        this->_is_axisymmetric = true;
-      }
+      Physics::set_is_axisymmetric(true);
 
     this->_pin_pressure = input("Physics/"+PhysicsNaming::reacting_low_mach_navier_stokes()+"/pin_pressure", false );
 
@@ -294,7 +292,7 @@ namespace GRINS
 
         libMesh::Real jac = JxW[qp];
 
-        if( this->_is_axisymmetric )
+        if(Physics::is_axisymmetric())
           {
             divU += U(0)/r;
             jac *= r;
@@ -346,7 +344,7 @@ namespace GRINS
 
             /*! \todo Would it be better to put this in its own DoF loop
                       and do the if check once?*/
-            if( this->_is_axisymmetric )
+            if(Physics::is_axisymmetric())
               {
                 Fu(i) += u_phi[i][qp]*( p/r - 2*mu*U(0)/(r*r) - 2.0/3.0*mu*divU/r )*jac;
               }

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -52,9 +52,6 @@ namespace GRINS
     this->_bc_handler = new ReactingLowMachNavierStokesBCHandling<typename Mixture::ChemistryParent>( physics_name, input,
                                                                                                       this->_gas_mixture.chemistry() );
 
-    if( this->_bc_handler->is_axisymmetric() )
-      Physics::set_is_axisymmetric(true);
-
     this->_pin_pressure = input("Physics/"+PhysicsNaming::reacting_low_mach_navier_stokes()+"/pin_pressure", false );
 
     this->_ic_handler = new GenericICHandler( physics_name, input );

--- a/src/variables/include/grins/fe_variables_base.h
+++ b/src/variables/include/grins/fe_variables_base.h
@@ -69,12 +69,6 @@ namespace GRINS
     bool is_constraint_var() const
     { return _is_constraint_var; }
 
-    static void set_is_axisymmetric( bool is_axisymmetric )
-    { _is_axisymmetric = is_axisymmetric; }
-
-    static bool is_axisymmetric()
-    { return _is_axisymmetric; }
-
     //! Reset whetever Neumann bc is postive or not
     /*! Postive means a value of 1.0 will be used in front of
         NeumannBC terms while is_positive = false indicates a
@@ -108,11 +102,6 @@ namespace GRINS
         do not). This should be set by the finite element
         type subclasses. */
     bool _is_constraint_var;
-
-    //! Track whether this is an axisymmetric problem
-    /*! This is static because either everyone thinks the problem
-        axisymmetric or not. */
-    static bool _is_axisymmetric;
 
     //! Track the sign of the Neumann BC term. Defaults to 1.0.
     /*! Depending on the Physics/Variable combination, the sign in

--- a/src/variables/src/fe_variables_base.C
+++ b/src/variables/src/fe_variables_base.C
@@ -31,9 +31,6 @@
 
 namespace GRINS
 {
-  // Instantiate static variables
-  bool FEVariablesBase::_is_axisymmetric = false;
-
   // Implementations
   void FEVariablesBase::default_fe_init( libMesh::FEMSystem* system,
                                          const std::vector<std::string>& var_names,

--- a/test/input_files/axi_poiseuille_flow_input.in
+++ b/test/input_files/axi_poiseuille_flow_input.in
@@ -51,6 +51,7 @@
 [Physics]
 
    enabled_physics = 'IncompressibleNavierStokes'
+   is_axisymmetric = 'true'
 
    [./IncompressibleNavierStokes]
 

--- a/test/input_files/axi_thermally_driven_flow.in
+++ b/test/input_files/axi_thermally_driven_flow.in
@@ -59,6 +59,7 @@ echo_physics = 'true'
 [Physics]
 
 enabled_physics = 'IncompressibleNavierStokes AxisymmetricHeatTransfer AxisymmetricBoussinesqBuoyancy'
+is_axisymmetric = 'true'
 
 # Boundary ids:
 # j = bottom -> 0


### PR DESCRIPTION
This centralizes the notion of axisymmetry to the Physics. Originally, doing the BC refactoring, I was thinking the Variables would hold this, but I changed my mind and I think it makes more sense to keep this in the `Physics`. It still doesn't feel quite right, but I don't have a better solution at this point. 

Following this PR, the user will now be *required* to set `Physics/is_axisymmetric = true` if using the `axisymmetry` boundary condition. I asked @nicholasmalaya offline if he ran any axisymmetric cases and he said no, but I also think this extra safety is worth the backward-compatibility breakage.

I will also note that the somewhat incongruous usage of `Physics::is_axisymmetric()` in the catalytic wall boundary conditions will go away in the BC refactoring. The new API for Neumann functions will include a boolean argument `is_axisymmetric`. Then, the only places touching `Physics::is_axisymmetric()` will be the Physics classes themselves and `MultiphysicsSystem`.