### PR TITLE
More FEVariableBase Updates

### DIFF
--- a/src/physics/src/convection_diffusion.C
+++ b/src/physics/src/convection_diffusion.C
@@ -32,6 +32,7 @@
 #include "grins/materials_parsing.h"
 #include "grins/generic_bc_handling.h"
 #include "grins/generic_ic_handler.h"
+#include "grins/variable_warehouse.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -58,6 +59,8 @@ namespace GRINS
     this->set_parameter(this->_kappa, input,
                         "Materials/"+material_name+"/Diffusivity/value",
                         "DIE!");
+
+    GRINSPrivate::VariableWarehouse::check_and_register_variable(this->_var.section_name(physics_name), this->_var);
 
     _bc_handler = new GenericBCHandling(physics_name,input);
     _ic_handler = new GenericICHandler(physics_name,input);

--- a/src/variables/include/grins/fe_variables_base.h
+++ b/src/variables/include/grins/fe_variables_base.h
@@ -84,6 +84,9 @@ namespace GRINS
     const std::vector<std::string>& active_var_names() const
     { return _var_names; }
 
+    const std::vector<VariableIndex>& var_indices() const
+    { return _vars; }
+
   protected:
 
     //! Method to parse variable names from input

--- a/src/variables/include/grins/generic_fe_type_variable.h
+++ b/src/variables/include/grins/generic_fe_type_variable.h
@@ -52,12 +52,12 @@ namespace GRINS
 
     VariableIndex var() const;
 
+    std::string section_name(const std::string& physics_name) const
+    { return VariablesParsing::generic_section()+":"+physics_name; }
+
   protected:
 
     GenericFETypeVariable();
-
-    std::string section_name(const std::string& physics_name) const
-    { return VariablesParsing::generic_section()+":"+physics_name; }
 
     std::string default_name() const
     { return "u"; }

--- a/src/variables/include/grins/species_mass_fracs_fe_variables.h
+++ b/src/variables/include/grins/species_mass_fracs_fe_variables.h
@@ -49,6 +49,9 @@ namespace GRINS
     const std::string& material() const
     { return _material; }
 
+    const std::string& prefix() const
+    { return _prefix; }
+
   private:
 
     SpeciesMassFractionsFEVariables();

--- a/src/variables/include/grins/variable_warehouse.h
+++ b/src/variables/include/grins/variable_warehouse.h
@@ -77,6 +77,10 @@ namespace GRINS
         return derived_var;
       }
 
+      //! Clears the var_map()
+      static void clear()
+      { var_map().clear(); }
+
     protected:
 
       static std::map<std::string,const FEVariablesBase*>& var_map();

--- a/test/unit/variables.C
+++ b/test/unit/variables.C
@@ -162,6 +162,8 @@ namespace GRINSTesting
         CPPUNIT_ASSERT(press_base.is_constraint_var());
       }
 
+      // Clear out the VariableWarehouse so it doesn't interfere with other tests.
+      GRINS::GRINSPrivate::VariableWarehouse::clear();
     }
 
     void test_pressure()


### PR DESCRIPTION
Added two more accessors needed. Also updated `GenericFETypeVariable` to make `section_name()` public so the `Physics` can query it when registering. Finally, now have `ConvectionDiffusion` registering it's variable with the `VariableWarehouse`.