### PR TITLE
RayfireMesh class

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,6 +198,7 @@ libgrins_la_SOURCES += qoi/src/composite_qoi.C
 libgrins_la_SOURCES += qoi/src/parsed_boundary_qoi.C
 libgrins_la_SOURCES += qoi/src/parsed_interior_qoi.C
 libgrins_la_SOURCES += qoi/src/weighted_flux_qoi.C
+libgrins_la_SOURCES += qoi/src/rayfire_mesh.C
 
 # src/solver files
 libgrins_la_SOURCES += solver/src/grins_solver.C
@@ -467,6 +468,7 @@ include_HEADERS += qoi/include/grins/composite_qoi.h
 include_HEADERS += qoi/include/grins/parsed_boundary_qoi.h
 include_HEADERS += qoi/include/grins/parsed_interior_qoi.h
 include_HEADERS += qoi/include/grins/weighted_flux_qoi.h
+include_HEADERS += qoi/include/grins/rayfire_mesh.h
 
 # src/solver headers
 include_HEADERS += solver/include/grins/grins_solver.h

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -1,0 +1,126 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_RAYFIRE_MESH_H
+#define GRINS_RAYFIRE_MESH_H
+
+// libMesh
+#include "libmesh/quadrature.h"
+#include "libmesh/mesh.h"
+
+// GRINS
+#include "grins/qoi_base.h"
+#include "grins/variable_name_defaults.h"
+
+namespace GRINS
+{
+    
+  //! RayfireMesh
+  /*!
+  This class creates a 1D mesh of EDGE2 elements to allow
+  for integration of functions along a line across the domain
+  */
+  class RayfireMesh
+  {
+  public:
+    
+    //! 2D Constructor
+    /*! 
+    The init() function must be called after the constructor
+    @param origin Origin point (x,y) of the rayfire on mesh boundary
+    @param theta Spherical polar angle (in radians)
+    */
+    RayfireMesh(libMesh::Point& origin, libMesh::Real theta);
+    
+    //! 3D Constructor
+    /*! 
+    The init() function must be called after the constructor
+    @param origin Origin point (x,y,z) of the rayfire on mesh boundary
+    @param theta  Spherical polar angle (in radians)
+    @param phi    Spherical azimuthal angle (in radians)
+    */
+    RayfireMesh(libMesh::Point& origin, libMesh::Real theta, libMesh::Real phi);
+    
+    //! Initialization
+    /*! 
+    This function performs the rayfire and assembles the 1D mesh 
+    @param mesh_base Reference to the main mesh
+    */
+    void init(const libMesh::MeshBase& mesh_base);
+    
+    /*! 
+    This function takes in an elem_id on the main mesh and returns an elem from the 1D rayfire mesh 
+    @param elem_id The ID of the elem on the main mesh
+    */
+    const libMesh::Elem* translate(const libMesh::dof_id_type elem_id);
+
+
+  private:
+    //! Dimension of the main mesh 
+    const unsigned int _dim;
+    
+    //! Origin point
+    libMesh::Point& _origin;
+    
+    //! Rayfire Spherical polar angle (in radians)
+    libMesh::Real   _theta;
+    
+    //! Rayfire Spherical azimuthal angle (in radians)
+    libMesh::Real   _phi;
+    
+    //! Internal 1D mesh of EDGE2 elements
+    SharedPtr<libMesh::Mesh> _mesh;
+    
+    //! Map of main mesh elem_id to rayfire mesh elems
+    std::map<libMesh::dof_id_type,libMesh::Elem*> _elem_id_map;
+    
+    
+    //! Calculate the intersection point
+    /*!
+    @param[out] end_point The intersection point in (x,y) coordinates
+    @return Elem* if intersection is found
+    @return NULL  if no intersection point found (i.e. start_point is on a boundary)
+    */
+    const libMesh::Elem* _get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point* start_point, libMesh::Point* end_point);
+    
+    //! Ensure the calculated intersection point is on the edge_elem and is not the start_point
+    bool _check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, libMesh::Elem& edge_elem, libMesh::Point* next_point);
+    
+    //! Knowing the intersection_point, get the appropraite next elem along the path
+    const libMesh::Elem* _get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side);
+    
+    //! Ensure the supplied origin is on a boundary of the mesh
+    void _check_origin_on_boundary(const libMesh::Elem* start_elem);
+    
+    //! Iterative solver for calculating the intersection point of the rayfire on the side of an elem
+    /*!
+    @param[out] intersection_point The calculated intersection point (only set if convergence is achieved)
+    @return Whether or not the solver converged before hitting the iteration limit
+    */
+    bool _newton_solver(libMesh::Point& initial_point, const libMesh::Elem* edge_elem, libMesh::Point* intersection_point);
+  };
+      
+}
+#endif //GRINS_RAYFIRE_MESH_H

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -39,8 +39,26 @@ namespace GRINS
     
   //! RayfireMesh
   /*!
-  This class creates a 1D mesh of EDGE2 elements to allow
-  for integration of functions along a line across the domain
+  This class performs a rayfire across a given mesh.
+  The user supplies an origin point on the mesh boundary,
+  and spherical angle(s) theta (and phi for 3D) to describe the direction of the rayfire.
+  As is standard in spherical coordinates, theta is the angle from the x-axis in the xy-plane,
+  with counterclockwise being positive. -2&pi; &le; theta &le; +2&pi;.
+  Phi is the angle from the xy-plane, with phi>0 being in the positive half of the z-plane.
+  -&pi; &le; phi &le; +&pi;
+  
+  Starting at the given origin point, this class will walk in a straight line
+  across the mesh in the prescribed direction. On each element along the line,
+  the class will calculate the point where it enters and leaves that element.
+  Knowing the entering and exiting points, an EDGE2 element
+  is created with those points as nodes, and is added to an internal 1D mesh.
+  This repeats until a main mesh boundary is reached.
+  
+  The intent of this class is to use the 1D mesh to integrate quantities along the
+  rayfire path. Using the map_to_rayfire_elem() function, a separate integration class
+  can access the 1D elements, prescribe a desired quadrature rule, and perform
+  integration directly along the line, rather than using the entire 2D/3D elements
+  of the main mesh.
   */
   class RayfireMesh
   {
@@ -48,7 +66,8 @@ namespace GRINS
     
     //! 2D Constructor
     /*! 
-    The init() function must be called after the constructor
+    This is restricted to 2D meshes. The init() function must
+    be called to perform the actual rayfire.
     @param origin Origin point (x,y) of the rayfire on mesh boundary
     @param theta Spherical polar angle (in radians)
     */
@@ -56,7 +75,8 @@ namespace GRINS
     
     //! 3D Constructor
     /*! 
-    The init() function must be called after the constructor
+    This is restricted to 3D meshes. The init() function must
+    be called to perform the actual rayfire.
     @param origin Origin point (x,y,z) of the rayfire on mesh boundary
     @param theta  Spherical polar angle (in radians)
     @param phi    Spherical azimuthal angle (in radians)
@@ -65,7 +85,8 @@ namespace GRINS
     
     //! Initialization
     /*! 
-    This function performs the rayfire and assembles the 1D mesh 
+    This function performs the rayfire and assembles the 1D mesh.
+    Call this immediately after the constructor.
     @param mesh_base Reference to the main mesh
     */
     void init(const libMesh::MeshBase& mesh_base);
@@ -73,8 +94,10 @@ namespace GRINS
     /*! 
     This function takes in an elem_id on the main mesh and returns an elem from the 1D rayfire mesh 
     @param elem_id The ID of the elem on the main mesh
+    @return Elem* to 1D elem from the rayfire mesh if the elem_id falls along the rayfire path
+    @return NULL if the given elem_id does not correspond to an elem through which the rayfire passes
     */
-    const libMesh::Elem* translate(const libMesh::dof_id_type elem_id);
+    const libMesh::Elem* map_to_rayfire_elem(const libMesh::dof_id_type elem_id);
 
 
   private:
@@ -97,29 +120,64 @@ namespace GRINS
     std::map<libMesh::dof_id_type,libMesh::Elem*> _elem_id_map;
     
     
+    //! User should never call the default constructor
+    RayfireMesh();
+    
     //! Calculate the intersection point
     /*!
     @param[out] end_point The intersection point in (x,y) coordinates
     @return Elem* if intersection is found
     @return NULL  if no intersection point found (i.e. start_point is on a boundary)
     */
-    const libMesh::Elem* _get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point* start_point, libMesh::Point* end_point);
+    const libMesh::Elem* get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point* start_point, libMesh::Point* end_point);
     
     //! Ensure the calculated intersection point is on the edge_elem and is not the start_point
-    bool _check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, libMesh::Elem& edge_elem, libMesh::Point* next_point);
+    bool check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, libMesh::Elem& edge_elem, libMesh::Point* next_point);
     
-    //! Knowing the intersection_point, get the appropraite next elem along the path
-    const libMesh::Elem* _get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side);
+    //! Knowing the end_point, get the appropraite next elem along the path
+    const libMesh::Elem* get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side);
     
     //! Ensure the supplied origin is on a boundary of the mesh
-    void _check_origin_on_boundary(const libMesh::Elem* start_elem);
+    void check_origin_on_boundary(const libMesh::Elem* start_elem);
     
     //! Iterative solver for calculating the intersection point of the rayfire on the side of an elem
     /*!
+    The rayfire line can be represented in point-slope form:
+    
+    y-y0 = m(x-x0)
+    
+    where m is the slope and (x0,y0) is the known initial_point. To find the intersection point,
+    we will use a parametric representation of the edge utilizing the shape functions as such:
+    
+    X(&xi;) = sum( x<SUB>j</SUB> &phi;<SUB>j</SUB>(&xi;) )
+    
+    Y(&xi;) = sum( y<SUB>j</SUB> &phi;<SUB>j</SUB>(&xi;) )
+        
+    where x<SUB>j</SUB> and y<SUB>j</SUB> are the node x- and y-coordinates, respectively,
+     and &phi;<SUB>j</SUB> is the value of shape function j at reference coordinate &xi;
+    
+    The intersection point is then where the x and y coordinates from the point-slope equation 
+    equal the X and Y coordinates from the parametric equations for the given edge, respectively.
+    We can then form a residual by substituting the parametric coordinates into the point slope
+    form and bringing all terms to one side of the equation as:
+    
+    f = 0 = m(X(&xi;)-x0) - (Y(&xi;)-y0)
+    
+    The residual is then a function of a single parameter, namely the reference coordinate &xi;.
+    The derivative is rather trivial and can be expressed as
+    
+    df = m*dX - dY
+    
+    where
+    
+    dX = sum( x<SUB>j</SUB> d&phi;<SUB>j</SUB>/d&xi; )
+    
+    dY = sum( y<SUB>j</SUB> d&phi;<SUB>j</SUB>/d&xi; )
+    
     @param[out] intersection_point The calculated intersection point (only set if convergence is achieved)
     @return Whether or not the solver converged before hitting the iteration limit
     */
-    bool _newton_solver(libMesh::Point& initial_point, const libMesh::Elem* edge_elem, libMesh::Point* intersection_point);
+    bool newton_solve_intersection(libMesh::Point& initial_point, const libMesh::Elem* edge_elem, libMesh::Point* intersection_point);
   };
       
 }

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -30,6 +30,7 @@
 #include "grins/multiphysics_sys.h"
 #include "grins/assembly_context.h"
 #include "grins/materials_parsing.h"
+#include "grins/math_constants.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -46,19 +47,39 @@
 namespace GRINS
 {
   RayfireMesh::RayfireMesh(libMesh::Point& origin, libMesh::Real theta, libMesh::Real phi) : 
-    _dim(3),_origin(origin),_theta(theta),_phi(phi)
+    _dim(3),
+    _origin(origin),
+    _theta(theta),
+    _phi(phi)
   {
     libmesh_not_implemented();
   }
  
  
   RayfireMesh::RayfireMesh(libMesh::Point& origin, libMesh::Real theta) : 
-    _dim(2),_origin(origin),_theta(theta),_phi(0)
-  {}
+    _dim(2),
+    _origin(origin),
+    _theta(theta),
+    _phi(-7.0) // bounds on angles are +/- 2pi
+  {
+    if (std::abs(_theta) > 2.0*Constants::pi)
+      libmesh_error_msg("Please supply a theta value between -2*pi and 2*pi");
+  }
 
 
   void RayfireMesh::init(const libMesh::MeshBase& mesh_base)
   {
+    // consistency check
+    if(mesh_base.mesh_dimension() != _dim)
+    {
+      std::stringstream ss;
+      ss <<"The supplied mesh object is " <<mesh_base.mesh_dimension() 
+         <<"D, but the RayfireMesh object was created with the "
+         <<_dim <<"D constructor";
+         
+      libmesh_error_msg(ss); 
+    }
+      
     _mesh = new libMesh::Mesh(mesh_base.comm(),(unsigned char)1);
     
     unsigned int node_id = 0;
@@ -74,7 +95,7 @@ namespace GRINS
         
     // ensure the origin is on a boundary element
     // AND on the boundary of said element
-    _check_origin_on_boundary(start_elem);
+    check_origin_on_boundary(start_elem);
         
     // add the origin point to the point list
     _mesh->add_point(*start_point,node_id++);
@@ -84,39 +105,28 @@ namespace GRINS
     const libMesh::Elem* next_elem;
     const libMesh::Elem* prev_elem = start_elem;
     
-    // calculate the end point and
-    // get the second elem in the rayfire
-    next_elem = _get_next_elem(start_elem,start_point,end_point);
-    
-    // add end point as node on the rayfire mesh    
-    _mesh->add_point(*end_point,node_id);
-    libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
-    elem->set_node(0) = _mesh->node_ptr(node_id-1);
-    elem->set_node(1) = _mesh->node_ptr(node_id++);
-    
-    // add new rayfire elem to the map  
-    _elem_id_map[prev_elem->id()] = elem;            
-    start_point = end_point;
-    prev_elem = next_elem;
-
-    // continue looping until we reach a boundary
-    while(next_elem)
+    do
     {
-      next_elem = _get_next_elem(prev_elem,start_point,end_point);
-            
+      // calculate the end point and
+      // get the next elem in the rayfire
+      next_elem = get_next_elem(prev_elem,start_point,end_point);
+      
+      // add end point as node on the rayfire mesh    
       _mesh->add_point(*end_point,node_id);
       libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
       elem->set_node(0) = _mesh->node_ptr(node_id-1);
       elem->set_node(1) = _mesh->node_ptr(node_id++);
-            
+      
+      // add new rayfire elem to the map  
       _elem_id_map[prev_elem->id()] = elem;            
       start_point = end_point;
-      prev_elem = next_elem;     
-    } 
+      prev_elem = next_elem;
+    } while(next_elem);
+    
   }
   
   
-  const libMesh::Elem* RayfireMesh::translate(const libMesh::dof_id_type elem_id)
+  const libMesh::Elem* RayfireMesh::map_to_rayfire_elem(const libMesh::dof_id_type elem_id)
   {
     std::map<libMesh::dof_id_type,libMesh::Elem*>::iterator it;
     it = _elem_id_map.find(elem_id);
@@ -129,7 +139,7 @@ namespace GRINS
 
   // private functions
  
-  void RayfireMesh::_check_origin_on_boundary(const libMesh::Elem* start_elem)
+  void RayfireMesh::check_origin_on_boundary(const libMesh::Elem* start_elem)
   {
     // first, make sure the elem is on a boundary
     if ( !(start_elem->on_boundary()) )
@@ -155,7 +165,7 @@ namespace GRINS
   }
   
   
-  const libMesh::Elem* RayfireMesh::_get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point* start_point, libMesh::Point* next_point)
+  const libMesh::Elem* RayfireMesh::get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point* start_point, libMesh::Point* next_point)
   {
     libMesh::Point* intersection_point = new libMesh::Point();
     
@@ -166,12 +176,12 @@ namespace GRINS
       if (edge_elem->contains_point(*start_point))
         continue;
 
-      bool converged = _newton_solver(*start_point,edge_elem.get(),intersection_point);
+      bool converged = newton_solve_intersection(*start_point,edge_elem.get(),intersection_point);
             
       if (converged)
       {
-        if ( _check_valid_point(*intersection_point,*start_point,*edge_elem,next_point) )
-          return _get_correct_neighbor(*intersection_point,cur_elem,s);
+        if ( check_valid_point(*intersection_point,*start_point,*edge_elem,next_point) )
+          return get_correct_neighbor(*intersection_point,cur_elem,s);
       }
       else
         continue;
@@ -182,23 +192,24 @@ namespace GRINS
   }
 
     
-  bool RayfireMesh::_check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, libMesh::Elem& edge_elem, libMesh::Point* next_point)
+  bool RayfireMesh::check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, libMesh::Elem& edge_elem, libMesh::Point* next_point)
   {
     bool is_not_start = !(intersection_point.absolute_fuzzy_equals(start_point));
     bool is_on_edge = edge_elem.contains_point(intersection_point);
         
-    if ( is_not_start && is_on_edge )
+    bool is_valid = is_not_start && is_on_edge;
+    
+    if ( is_valid )
     {
       (*next_point)(0) = intersection_point(0);
-      (*next_point)(1) = intersection_point(1);
-      return true;           
+      (*next_point)(1) = intersection_point(1);           
     }
         
-    return false;
+    return is_valid;
   }
 
 
-  const libMesh::Elem* RayfireMesh::_get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side)
+  const libMesh::Elem* RayfireMesh::get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side)
   {
     // check if side is a boundary
     if( !(cur_elem->neighbor(side)) )
@@ -232,8 +243,6 @@ namespace GRINS
         libMesh::Real L = elem->hmin();
         L *= 0.1;
         
-        
-        
         // parametric representation of rayfire line       
         libMesh::Real x = end_point(0) + L*std::cos(_theta);
         libMesh::Real y = end_point(1) + L*std::sin(_theta);
@@ -254,7 +263,7 @@ namespace GRINS
   }
 
 
-  bool RayfireMesh::_newton_solver(libMesh::Point& initial_point, const libMesh::Elem* edge_elem, libMesh::Point* intersection_point)
+  bool RayfireMesh::newton_solve_intersection(libMesh::Point& initial_point, const libMesh::Elem* edge_elem, libMesh::Point* intersection_point)
   {
     unsigned int iter_max = 20; // max iterations
     
@@ -270,13 +279,13 @@ namespace GRINS
     std::vector<libMesh::Real> dphi(n_sf);
     
     // Newton iteration step
-    libMesh::Real d_ksi;
+    libMesh::Real d_xi;
     
     // tan(theta) is the slope, so precompute since it is used repeatedly  
     libMesh::Real tan_theta = std::tan(_theta);
     
     // Initial guess is center of the edge_elem
-    libMesh::Real ksi = 0.0;
+    libMesh::Real xi = 0.0;
     
     // Newton iteration
     for(unsigned int it=0; it<iter_max; it++)
@@ -288,13 +297,13 @@ namespace GRINS
         phi[i] = libMesh::FE<1,libMesh::LAGRANGE>::shape(edge_elem->type(),
                                                          edge_elem->default_order(),
                                                          i,
-                                                         ksi);
+                                                         xi);
                                                         
         dphi[i] = libMesh::FE<1,libMesh::LAGRANGE>::shape_deriv(edge_elem->type(),
                                                                 edge_elem->default_order(),
                                                                 i,
                                                                 0, // const unsigned int libmesh_dbg_varj
-                                                                ksi);
+                                                                xi);
       } // for i
 
       libMesh::Real X=0.0, Y=0.0, dX=0.0, dY=0.0;
@@ -310,9 +319,9 @@ namespace GRINS
       libMesh::Real  f = tan_theta*(X-x0) - (Y-y0);
       libMesh::Real df = tan_theta*(dX) - dY;
             
-      d_ksi = f/df;
+      d_xi = f/df;
             
-      if(std::abs(d_ksi) < libMesh::TOLERANCE)
+      if(std::abs(d_xi) < libMesh::TOLERANCE)
       {
         // convergence
         (*intersection_point)(0) = X;
@@ -320,7 +329,7 @@ namespace GRINS
         return true;         
       }
       else
-        ksi -= d_ksi;
+        xi -= d_xi;
         
     } // for it  
         

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -1,0 +1,331 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+// This class
+#include "grins/rayfire_mesh.h"
+
+// GRINS
+#include "grins/multiphysics_sys.h"
+#include "grins/assembly_context.h"
+#include "grins/materials_parsing.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+#include "libmesh/fem_system.h"
+#include "libmesh/quadrature.h"
+#include "libmesh/point_locator_list.h"
+#include "libmesh/elem.h"
+#include "libmesh/edge_edge2.h"
+#include "libmesh/analytic_function.h"
+#include "libmesh/enum_elem_type.h"
+#include "libmesh/fe.h"
+#include "libmesh/fe_interface.h"
+
+namespace GRINS
+{
+  RayfireMesh::RayfireMesh(libMesh::Point& origin, libMesh::Real theta, libMesh::Real phi) : 
+    _dim(3),_origin(origin),_theta(theta),_phi(phi)
+  {
+    libmesh_not_implemented();
+  }
+ 
+ 
+  RayfireMesh::RayfireMesh(libMesh::Point& origin, libMesh::Real theta) : 
+    _dim(2),_origin(origin),_theta(theta),_phi(0)
+  {}
+
+
+  void RayfireMesh::init(const libMesh::MeshBase& mesh_base)
+  {
+    _mesh = new libMesh::Mesh(mesh_base.comm(),(unsigned char)1);
+    
+    unsigned int node_id = 0;
+
+    libMesh::Point* start_point = new libMesh::Point(_origin);
+
+    // get first element 
+    libMesh::UniquePtr<libMesh::PointLocatorBase> locator = mesh_base.sub_point_locator();
+    const libMesh::Elem* start_elem = (*locator)(_origin);
+        
+    if (!start_elem)
+      libmesh_error_msg("Origin is not on mesh");
+        
+    // ensure the origin is on a boundary element
+    // AND on the boundary of said element
+    _check_origin_on_boundary(start_elem);
+        
+    // add the origin point to the point list
+    _mesh->add_point(*start_point,node_id++);
+
+    libMesh::Point* end_point = new libMesh::Point();
+
+    const libMesh::Elem* next_elem;
+    const libMesh::Elem* prev_elem = start_elem;
+    
+    // calculate the end point and
+    // get the second elem in the rayfire
+    next_elem = _get_next_elem(start_elem,start_point,end_point);
+    
+    // add end point as node on the rayfire mesh    
+    _mesh->add_point(*end_point,node_id);
+    libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
+    elem->set_node(0) = _mesh->node_ptr(node_id-1);
+    elem->set_node(1) = _mesh->node_ptr(node_id++);
+    
+    // add new rayfire elem to the map  
+    _elem_id_map[prev_elem->id()] = elem;            
+    start_point = end_point;
+    prev_elem = next_elem;
+
+    // continue looping until we reach a boundary
+    while(next_elem)
+    {
+      next_elem = _get_next_elem(prev_elem,start_point,end_point);
+            
+      _mesh->add_point(*end_point,node_id);
+      libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
+      elem->set_node(0) = _mesh->node_ptr(node_id-1);
+      elem->set_node(1) = _mesh->node_ptr(node_id++);
+            
+      _elem_id_map[prev_elem->id()] = elem;            
+      start_point = end_point;
+      prev_elem = next_elem;     
+    } 
+  }
+  
+  
+  const libMesh::Elem* RayfireMesh::translate(const libMesh::dof_id_type elem_id)
+  {
+    std::map<libMesh::dof_id_type,libMesh::Elem*>::iterator it;
+    it = _elem_id_map.find(elem_id);
+    if (it != _elem_id_map.end())
+        return it->second;
+            
+    return NULL;
+  }
+ 
+
+  // private functions
+ 
+  void RayfireMesh::_check_origin_on_boundary(const libMesh::Elem* start_elem)
+  {
+    // first, make sure the elem is on a boundary
+    if ( !(start_elem->on_boundary()) )
+        libmesh_error_msg("The supplied origin point is not on a boundary element");
+        
+    // second, check all boundary sides of the elem
+    // to see if one of them conatins the origin point
+    bool valid = false;
+        
+    for (unsigned int s=0; s<start_elem->n_sides(); s++)
+    {
+      // neighbor() returns NULL on boundary elems
+      if ( start_elem->neighbor(s) )
+        continue;
+            
+      // we found a boundary elem, so make an edge and see if it contains the origin                
+      libMesh::UniquePtr<libMesh::Elem> edge_elem = start_elem->build_edge(s);
+      valid |= edge_elem->contains_point(_origin);
+    }
+        
+    if (!valid)
+      libmesh_error_msg("The supplied origin point is not on the boundary of the starting element");
+  }
+  
+  
+  const libMesh::Elem* RayfireMesh::_get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point* start_point, libMesh::Point* next_point)
+  {
+    libMesh::Point* intersection_point = new libMesh::Point();
+    
+    // loop over all sides of the elem and check each one for intersection
+    for (unsigned int s=0; s<cur_elem->n_sides(); s++)
+    {
+      const libMesh::UniquePtr<libMesh::Elem> edge_elem = cur_elem->build_edge(s);
+      if (edge_elem->contains_point(*start_point))
+        continue;
+
+      bool converged = _newton_solver(*start_point,edge_elem.get(),intersection_point);
+            
+      if (converged)
+      {
+        if ( _check_valid_point(*intersection_point,*start_point,*edge_elem,next_point) )
+          return _get_correct_neighbor(*intersection_point,cur_elem,s);
+      }
+      else
+        continue;
+
+    } // for s
+
+    return NULL; // no intersection          
+  }
+
+    
+  bool RayfireMesh::_check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, libMesh::Elem& edge_elem, libMesh::Point* next_point)
+  {
+    bool is_not_start = !(intersection_point.absolute_fuzzy_equals(start_point));
+    bool is_on_edge = edge_elem.contains_point(intersection_point);
+        
+    if ( is_not_start && is_on_edge )
+    {
+      (*next_point)(0) = intersection_point(0);
+      (*next_point)(1) = intersection_point(1);
+      return true;           
+    }
+        
+    return false;
+  }
+
+
+  const libMesh::Elem* RayfireMesh::_get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side)
+  {
+    // check if side is a boundary
+    if( !(cur_elem->neighbor(side)) )
+      return NULL;
+  
+    // check if the intersection point is a vertex
+    bool is_vertex = false;
+    for(unsigned int n=0; n<4; n++)
+        is_vertex |= (cur_elem->get_node(n))->absolute_fuzzy_equals(end_point);
+        
+    if (is_vertex)
+    {
+      // rayfire goes through vertex
+      
+      // get all elems that share this vertex
+      std::set<const libMesh::Elem*> elem_set;
+      cur_elem->find_point_neighbors(end_point,elem_set);
+      std::set<const libMesh::Elem *>::const_iterator       it  = elem_set.begin();
+      const std::set<const libMesh::Elem *>::const_iterator end = elem_set.end();
+
+      // iterate over each elem
+      for (; it != end; ++it)
+      {
+        const libMesh::Elem* elem = *it;
+        
+        if (elem == cur_elem) // skip the current elem
+          continue;
+        
+        // move a little bit along the rayfire
+        // and see if we are in the elem
+        libMesh::Real L = elem->hmin();
+        L *= 0.1;
+        
+        
+        
+        // parametric representation of rayfire line       
+        libMesh::Real x = end_point(0) + L*std::cos(_theta);
+        libMesh::Real y = end_point(1) + L*std::sin(_theta);
+        
+        if ( elem->contains_point(libMesh::Point(x,y)) )
+          return elem;
+      }
+      
+    }
+    else
+    {
+      // not a vertex, so just get the elem on that side
+      return cur_elem->neighbor(side);
+    }
+    
+    libmesh_error_msg("We shouldn't be here...");    
+    return NULL;
+  }
+
+
+  bool RayfireMesh::_newton_solver(libMesh::Point& initial_point, const libMesh::Elem* edge_elem, libMesh::Point* intersection_point)
+  {
+    unsigned int iter_max = 20; // max iterations
+    
+    // the number of shape functions needed for the edge_elem
+    unsigned int n_sf = libMesh::FE<1,libMesh::LAGRANGE>::n_shape_functions(edge_elem->type(),edge_elem->default_order());
+
+    // starting point on the elem
+    libMesh::Real x0 = initial_point(0);
+    libMesh::Real y0 = initial_point(1);
+       
+     // shape functions and derivatives w.r.t reference coordinate 
+    std::vector<libMesh::Real> phi(n_sf);
+    std::vector<libMesh::Real> dphi(n_sf);
+    
+    // Newton iteration step
+    libMesh::Real d_ksi;
+    
+    // tan(theta) is the slope, so precompute since it is used repeatedly  
+    libMesh::Real tan_theta = std::tan(_theta);
+    
+    // Initial guess is center of the edge_elem
+    libMesh::Real ksi = 0.0;
+    
+    // Newton iteration
+    for(unsigned int it=0; it<iter_max; it++)
+    {
+      // Get the shape function and derivative values at the reference coordinate
+      // phi.size() == dphi.size()            
+      for(unsigned int i=0; i<phi.size(); i++)
+      {
+        phi[i] = libMesh::FE<1,libMesh::LAGRANGE>::shape(edge_elem->type(),
+                                                         edge_elem->default_order(),
+                                                         i,
+                                                         ksi);
+                                                        
+        dphi[i] = libMesh::FE<1,libMesh::LAGRANGE>::shape_deriv(edge_elem->type(),
+                                                                edge_elem->default_order(),
+                                                                i,
+                                                                0, // const unsigned int libmesh_dbg_varj
+                                                                ksi);
+      } // for i
+
+      libMesh::Real X=0.0, Y=0.0, dX=0.0, dY=0.0;
+           
+      for(unsigned int i=0; i<phi.size(); i++)
+      {
+        X  += (*(edge_elem->get_node(i)))(0) * phi[i];
+        dX += (*(edge_elem->get_node(i)))(0) * dphi[i];
+        Y  += (*(edge_elem->get_node(i)))(1) * phi[i];
+        dY += (*(edge_elem->get_node(i)))(1) * dphi[i];
+      }
+            
+      libMesh::Real  f = tan_theta*(X-x0) - (Y-y0);
+      libMesh::Real df = tan_theta*(dX) - dY;
+            
+      d_ksi = f/df;
+            
+      if(std::abs(d_ksi) < libMesh::TOLERANCE)
+      {
+        // convergence
+        (*intersection_point)(0) = X;
+        (*intersection_point)(1) = Y;
+        return true;         
+      }
+      else
+        ksi -= d_ksi;
+        
+    } // for it  
+        
+    // no convergence
+    return false;
+  }
+
+} //namespace GRINS

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -110,7 +110,8 @@ unit_driver_SOURCES = unit/unit_driver.C \
                       unit/mesh_builder.C \
                       unit/variables.C \
                       unit/builder_helper.C \
-                      unit/default_bc_builder.C
+                      unit/default_bc_builder.C \
+                      unit/rayfire_test.C
 
 antioch_mixture_SOURCES = unit/antioch_mixture.C
 arrhenius_catalycity_SOURCES = unit/arrhenius_catalycity.C

--- a/test/unit/input_files/mesh_quad4_5elem_1D.in
+++ b/test/unit/input_files/mesh_quad4_5elem_1D.in
@@ -1,0 +1,12 @@
+# Mesh related options                                                                                                                                                                                                                       
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD4'
+      n_elems_x = '5'
+      n_elems_y = '1'
+      y_min = '0'
+      y_max = '1'
+      x_min = '0'
+      x_max = '5'
+[]

--- a/test/unit/input_files/mesh_quad4_9elem_2D.in
+++ b/test/unit/input_files/mesh_quad4_9elem_2D.in
@@ -1,0 +1,12 @@
+# Mesh related options                                                                                                                                                                                                                       
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD4'
+      n_elems_x = '3'
+      n_elems_y = '3'
+      y_min = '0'
+      y_max = '3'
+      x_min = '0'
+      x_max = '3'
+[]

--- a/test/unit/input_files/mesh_quad9_5elem_1D.in
+++ b/test/unit/input_files/mesh_quad9_5elem_1D.in
@@ -1,0 +1,12 @@
+# Mesh related options                                                                                                                                                                                                                       
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '5'
+      n_elems_y = '1'
+      y_min = '0'
+      y_max = '1'
+      x_min = '0'
+      x_max = '5'
+[]

--- a/test/unit/input_files/mesh_quad9_9elem_2D.in
+++ b/test/unit/input_files/mesh_quad9_9elem_2D.in
@@ -1,0 +1,12 @@
+# Mesh related options                                                                                                                                                                                                                       
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '3'
+      n_elems_y = '3'
+      y_min = '0'
+      y_max = '3'
+      x_min = '0'
+      x_max = '3'
+[]

--- a/test/unit/rayfire_test.C
+++ b/test/unit/rayfire_test.C
@@ -1,0 +1,365 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include "test_comm.h"
+#include "grins_test_paths.h"
+
+// GRINS
+#include "grins/grins_enums.h"
+#include "grins/mesh_builder.h"
+#include "grins/rayfire_mesh.h"
+#include "grins/math_constants.h"
+
+// libMesh
+#include "libmesh/elem.h"
+#include "libmesh/getpot.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/face_quad9.h"
+#include "libmesh/fe_interface.h"
+
+namespace GRINSTesting
+{
+  class RayfireTest : public CppUnit::TestCase
+  {
+  public:
+    CPPUNIT_TEST_SUITE( RayfireTest );
+
+    // test designed to produce libmesh_error
+    // will FAIL make check
+    // CPPUNIT_TEST( origin_not_on_boundary );
+
+    CPPUNIT_TEST( quad4_all_sides );
+    CPPUNIT_TEST( quad9_all_sides );
+    CPPUNIT_TEST( test_slanted_quad4 );
+    CPPUNIT_TEST( test_vertical_fire );
+    CPPUNIT_TEST( test_quad4_5elem );
+    CPPUNIT_TEST( test_quad9_5elem );
+    CPPUNIT_TEST( test_quad4_2D );
+    CPPUNIT_TEST( test_quad9_2D );
+    CPPUNIT_TEST( fire_through_vertex );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+  
+    // these tests should produce a "bad origin" error
+/*    void origin_not_on_boundary()
+    {
+        // origin not on boundary of element
+        // mesh is 1 elem
+//        libMesh::Point origin = libMesh::Point(0.5,0.5);
+//        libMesh::Node calc_end_node_straight = libMesh::Node(1,0.5);
+//        this->run_test(origin,0.0,calc_end_node_straight,1,0,"quad4",1);
+        
+        // origin not on boundary element
+        // mesh is 9 elem in 3x3 square
+//        libMesh::Point origin = libMesh::Point(1.5,1.5);
+//        libMesh::Node calc_end_node_straight = libMesh::Node(3,0.1);
+//        this->run_test(origin,0.0,calc_end_node_straight,9,2,"quad4",2);
+    }*/
+    
+    void quad4_all_sides()
+    {
+      // vector of intersection points
+      std::vector<libMesh::Point> pts(4);
+      pts[0] = libMesh::Point(0.0,0.5);
+      pts[1] = libMesh::Point(0.915243860856226,0.0);
+      pts[2] = libMesh::Point(1.0,0.25);
+      pts[3] = libMesh::Point(0.321046307967165,1.0);
+    
+      // create the mesh (single square QUAD4 element)
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.0,0.0),0 );
+      mesh->add_point( libMesh::Point(1.0,0.0),1 );
+      mesh->add_point( libMesh::Point(1.0,1.0),2 );
+      mesh->add_point( libMesh::Point(0.0,1.0),3 );
+
+      libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad4 );
+      for (unsigned int n=0; n<4; n++)
+        elem->set_node(n) = mesh->node_ptr(n);
+        
+      mesh->prepare_for_use();
+      
+      _run_test_on_all_point_combinations(pts,mesh);
+      
+    }
+    
+    
+    void quad9_all_sides()
+    {
+      // vector of intersection points
+      std::vector<libMesh::Point> pts(4);
+      pts[0] = libMesh::Point(0.0,0.5);
+      pts[1] = libMesh::Point(0.915243860856226,0.0);
+      pts[2] = libMesh::Point(1.375,0.25);
+      pts[3] = libMesh::Point(0.321046307967165,1.0);
+    
+      // create a non-rectangular QUAD9     
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.0,0.0),0 );
+      mesh->add_point( libMesh::Point(1.0,0.0),1 );
+      mesh->add_point( libMesh::Point(1.0,1.0),2 );
+      mesh->add_point( libMesh::Point(0.0,1.0),3 );
+      mesh->add_point( libMesh::Point(0.5,0.0),4 );
+      mesh->add_point( libMesh::Point(1.5,0.5),5 );
+      mesh->add_point( libMesh::Point(0.5,1.0),6 );
+      mesh->add_point( libMesh::Point(0.0,0.5),7 );
+      mesh->add_point( libMesh::Point(0.5,0.5),8 );
+
+      libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad9 );
+      for (unsigned int n=0; n<9; n++)
+        elem->set_node(n) = mesh->node_ptr(n);
+          
+      mesh->prepare_for_use();
+      
+      _run_test_on_all_point_combinations(pts,mesh);
+      
+    }
+    
+    void test_slanted_quad4()
+    {   
+      // vector of intersection points
+      std::vector<libMesh::Point> pts(4);
+      pts[0] = libMesh::Point(0.5,0.0);
+      pts[1] = libMesh::Point(1.75,0.75);
+      pts[2] = libMesh::Point(1.5,0.9);
+      pts[3] = libMesh::Point(-0.1,0.1);
+    
+      // create the mesh (single trapezoidal QUAD4 element)
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.0,0.0),0 );
+      mesh->add_point( libMesh::Point(1.0,0.0),1 );
+      mesh->add_point( libMesh::Point(2.0,1.0),2 );
+      mesh->add_point( libMesh::Point(-0.5,0.5),3 );
+
+      libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad4 );
+      for (unsigned int n=0; n<4; n++)
+        elem->set_node(n) = mesh->node_ptr(n);
+          
+      mesh->prepare_for_use();
+      
+      _run_test_on_all_point_combinations(pts,mesh);
+      
+    }
+    
+    void test_vertical_fire()
+    {
+      // create the mesh (single square QUAD4 element)
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.0,0.0),0 );
+      mesh->add_point( libMesh::Point(1.0,0.0),1 );
+      mesh->add_point( libMesh::Point(1.0,1.0),2 );
+      mesh->add_point( libMesh::Point(0.0,1.0),3 );
+
+      libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad4 );
+      for (unsigned int n=0; n<4; n++)
+        elem->set_node(n) = mesh->node_ptr(n);
+        
+      mesh->prepare_for_use();
+        
+      libMesh::Point start_point(0.3,0.0);
+      libMesh::Point end_point(0.3,1.0);
+        
+      libMesh::Real theta = GRINS::Constants::pi/2.0;
+        
+      this->run_test_with_mesh(mesh,start_point,theta,end_point,0);
+    }
+    
+    void test_quad4_5elem()
+    {   
+      libMesh::Point origin = libMesh::Point(0,0.5);
+        
+      libMesh::Node calc_end_node_straight = libMesh::Node(5.0,0.5);
+      this->run_test(origin,0.0,calc_end_node_straight,5,4,"quad4",1);
+        
+      libMesh::Node calc_end_node_angle = libMesh::Node(0.5/std::tan(0.15),1.0);
+      this->run_test(origin,0.15,calc_end_node_angle,5,3,"quad4",1);
+
+      libMesh::Node calc_end_node_neg_angle = libMesh::Node(0.5/std::tan(0.15),0.0);
+      this->run_test(origin,-0.15,calc_end_node_neg_angle,5,3,"quad4",1); 
+    }
+    
+    void test_quad9_5elem()
+    {   
+      libMesh::Point origin = libMesh::Point(0,0.5);
+        
+      libMesh::Node calc_end_node_straight = libMesh::Node(5.0,0.5);
+      this->run_test(origin,0.0,calc_end_node_straight,5,4,"quad9",1);
+        
+      libMesh::Node calc_end_node_angle = libMesh::Node(0.5/std::tan(0.15),1.0);
+      this->run_test(origin,0.15,calc_end_node_angle,5,3,"quad9",1);
+
+      libMesh::Node calc_end_node_neg_angle = libMesh::Node(0.5/std::tan(0.15),0.0);
+      this->run_test(origin,-0.15,calc_end_node_neg_angle,5,3,"quad9",1); 
+    }
+    
+    void test_quad4_2D()
+    {  
+      libMesh::Point origin = libMesh::Point(0.0,1.5);
+      
+      libMesh::Node calc_end_node_straight = libMesh::Node(3.0,1.5);
+      this->run_test(origin,0.0,calc_end_node_straight,9,5,"quad4",2);
+      
+      libMesh::Node calc_end_node_small_angle = libMesh::Node(3.0,1.5+3.0*std::tan(0.15));
+      this->run_test(origin,0.15,calc_end_node_small_angle,9,5,"quad4",2);
+
+      libMesh::Node calc_end_node_small_neg_angle = libMesh::Node(3.0,1.5+3.0*std::tan(-0.15));
+      this->run_test(origin,-0.15,calc_end_node_small_neg_angle,9,5,"quad4",2);
+            
+      libMesh::Node calc_end_node_large_angle = libMesh::Node( (3.0-1.5)/std::tan(1.0), 3.0);
+      this->run_test(origin,1.0,calc_end_node_large_angle,9,6,"quad4",2);
+
+      libMesh::Node calc_end_node_large_neg_angle = libMesh::Node( (0.0-1.5)/std::tan(-1.0), 0.0);
+      this->run_test(origin,-1.0,calc_end_node_large_neg_angle,9,0,"quad4",2);
+    }
+    
+    void test_quad9_2D()
+    {  
+      libMesh::Point origin = libMesh::Point(0.0,1.5);
+        
+      libMesh::Node calc_end_node_straight = libMesh::Node(3.0,1.5);
+      this->run_test(origin,0.0,calc_end_node_straight,9,5,"quad9",2);
+        
+      libMesh::Node calc_end_node_small_angle = libMesh::Node(3.0,1.5+3.0*std::tan(0.15));
+      this->run_test(origin,0.15,calc_end_node_small_angle,9,5,"quad9",2);
+
+      libMesh::Node calc_end_node_small_neg_angle = libMesh::Node(3.0,1.5+3.0*std::tan(-0.15));
+      this->run_test(origin,-0.15,calc_end_node_small_neg_angle,9,5,"quad9",2);
+            
+      libMesh::Node calc_end_node_large_angle = libMesh::Node( (3.0-1.5)/std::tan(1.0), 3.0);
+      this->run_test(origin,1.0,calc_end_node_large_angle,9,6,"quad9",2);
+
+      libMesh::Node calc_end_node_large_neg_angle = libMesh::Node( (0.0-1.5)/std::tan(-1.0), 0.0);
+      this->run_test(origin,-1.0,calc_end_node_large_neg_angle,9,0,"quad9",2);
+    }
+    
+    
+    
+    void fire_through_vertex()
+    {
+      libMesh::Point origin = libMesh::Point(0.0,0.0);
+        
+      libMesh::Node calc_end_node_straight = libMesh::Node(3.0,3.0);
+        
+      // 3x3 QUAD4 mesh
+      this->run_test(origin,45.0*GRINS::Constants::pi/180.0,calc_end_node_straight,9,8,"quad4",2);
+        
+      // 3x3 QUAD9 mesh
+      this->run_test(origin,45.0*GRINS::Constants::pi/180.0,calc_end_node_straight,9,8,"quad9",2);
+    }
+
+    
+
+  private:
+  
+    void run_test(libMesh::Point& origin, libMesh::Real theta, libMesh::Node& calc_end_node, unsigned int n_elem, unsigned int exit_elem, std::string elem_type, unsigned int dim)
+    {
+      std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/mesh_"+elem_type+"_"+std::to_string(n_elem)+"elem_"+std::to_string(dim)+"D.in";
+      GetPot input(filename);
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = this->build_mesh(input);
+      
+      // ensure the mesh has the desired number of elements
+      CPPUNIT_ASSERT_EQUAL(n_elem,mesh->n_elem());
+      
+      run_test_with_mesh(mesh,origin,theta,calc_end_node,exit_elem);
+    }
+
+    void _run_test_on_all_point_combinations(std::vector<libMesh::Point> pts, GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh)
+    {  
+      // iterate over the starting points
+      for(unsigned int i=0; i<pts.size(); i++)
+      {
+        libMesh::Point start_point = pts[i];
+            
+        // iterate over all the intersection points
+        for(unsigned int j=0; j<pts.size(); j++)
+        {
+          if(j==i)
+            continue;
+                    
+          libMesh::Point end_point = pts[j];
+                
+          libMesh::Real theta = _calc_theta(start_point,end_point);
+                
+          // run the test
+          this->run_test_with_mesh(mesh,start_point,theta,end_point,0);
+        }      
+        
+      }
+    
+    }
+    
+    void run_test_with_mesh(GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh, libMesh::Point& origin, libMesh::Real theta, libMesh::Point& calc_end_point, unsigned int exit_elem)
+    {      
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+    
+      const libMesh::Elem* original_elem = mesh->elem(exit_elem);
+    
+      const libMesh::Elem* rayfire_elem = rayfire->translate(original_elem->id());
+    
+      if (!rayfire_elem)
+        libmesh_error_msg("Attempted to translate an element that is not in the Rayfire");
+    
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(0), (*(rayfire_elem->get_node(1)))(0),libMesh::TOLERANCE);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(1), (*(rayfire_elem->get_node(1)))(1),libMesh::TOLERANCE);
+    }
+
+    GRINS::SharedPtr<libMesh::UnstructuredMesh> build_mesh( const GetPot& input )
+    {
+      GRINS::MeshBuilder mesh_builder;
+      return mesh_builder.build( input, *TestCommWorld );
+    }
+    
+    libMesh::Real _calc_theta(libMesh::Point& start, libMesh::Point end)
+    {
+        return std::atan2( (end(1)-start(1)), (end(0)-start(0)) );
+    }
+    
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( RayfireTest );
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_CPPUNIT

--- a/test/unit/rayfire_test.C
+++ b/test/unit/rayfire_test.C
@@ -52,10 +52,6 @@ namespace GRINSTesting
   public:
     CPPUNIT_TEST_SUITE( RayfireTest );
 
-    // test designed to produce libmesh_error
-    // will FAIL make check
-    // CPPUNIT_TEST( origin_not_on_boundary );
-
     CPPUNIT_TEST( quad4_all_sides );
     CPPUNIT_TEST( quad9_all_sides );
     CPPUNIT_TEST( test_slanted_quad4 );
@@ -69,22 +65,6 @@ namespace GRINSTesting
     CPPUNIT_TEST_SUITE_END();
 
   public:
-  
-    // these tests should produce a "bad origin" error
-/*    void origin_not_on_boundary()
-    {
-        // origin not on boundary of element
-        // mesh is 1 elem
-//        libMesh::Point origin = libMesh::Point(0.5,0.5);
-//        libMesh::Node calc_end_node_straight = libMesh::Node(1,0.5);
-//        this->run_test(origin,0.0,calc_end_node_straight,1,0,"quad4",1);
-        
-        // origin not on boundary element
-        // mesh is 9 elem in 3x3 square
-//        libMesh::Point origin = libMesh::Point(1.5,1.5);
-//        libMesh::Node calc_end_node_straight = libMesh::Node(3,0.1);
-//        this->run_test(origin,0.0,calc_end_node_straight,9,2,"quad4",2);
-    }*/
     
     void quad4_all_sides()
     {
@@ -111,7 +91,7 @@ namespace GRINSTesting
         
       mesh->prepare_for_use();
       
-      _run_test_on_all_point_combinations(pts,mesh);
+      run_test_on_all_point_combinations(pts,mesh);
       
     }
     
@@ -146,7 +126,7 @@ namespace GRINSTesting
           
       mesh->prepare_for_use();
       
-      _run_test_on_all_point_combinations(pts,mesh);
+      run_test_on_all_point_combinations(pts,mesh);
       
     }
     
@@ -175,7 +155,7 @@ namespace GRINSTesting
           
       mesh->prepare_for_use();
       
-      _run_test_on_all_point_combinations(pts,mesh);
+      run_test_on_all_point_combinations(pts,mesh);
       
     }
     
@@ -304,7 +284,7 @@ namespace GRINSTesting
       run_test_with_mesh(mesh,origin,theta,calc_end_node,exit_elem);
     }
 
-    void _run_test_on_all_point_combinations(std::vector<libMesh::Point> pts, GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh)
+    void run_test_on_all_point_combinations(std::vector<libMesh::Point> pts, GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh)
     {  
       // iterate over the starting points
       for(unsigned int i=0; i<pts.size(); i++)
@@ -319,7 +299,7 @@ namespace GRINSTesting
                     
           libMesh::Point end_point = pts[j];
                 
-          libMesh::Real theta = _calc_theta(start_point,end_point);
+          libMesh::Real theta = calc_theta(start_point,end_point);
                 
           // run the test
           this->run_test_with_mesh(mesh,start_point,theta,end_point,0);
@@ -336,10 +316,10 @@ namespace GRINSTesting
     
       const libMesh::Elem* original_elem = mesh->elem(exit_elem);
     
-      const libMesh::Elem* rayfire_elem = rayfire->translate(original_elem->id());
+      const libMesh::Elem* rayfire_elem = rayfire->map_to_rayfire_elem(original_elem->id());
     
       if (!rayfire_elem)
-        libmesh_error_msg("Attempted to translate an element that is not in the Rayfire");
+        libmesh_error_msg("Attempted to map an element that is not in the Rayfire");
     
       CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(0), (*(rayfire_elem->get_node(1)))(0),libMesh::TOLERANCE);
       CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(1), (*(rayfire_elem->get_node(1)))(1),libMesh::TOLERANCE);
@@ -351,9 +331,9 @@ namespace GRINSTesting
       return mesh_builder.build( input, *TestCommWorld );
     }
     
-    libMesh::Real _calc_theta(libMesh::Point& start, libMesh::Point end)
+    libMesh::Real calc_theta(libMesh::Point& start, libMesh::Point end)
     {
-        return std::atan2( (end(1)-start(1)), (end(0)-start(0)) );
+      return std::atan2( (end(1)-start(1)), (end(0)-start(0)) );
     }
     
   };


### PR DESCRIPTION
Adds the RayfireMesh class to QoI. This class creates a 1D mesh representing a straight path across a mesh. The intention is to use this to integrate functions along the rayfire.
Currently, only 2D meshes are supported. The CPPUnit test suite uses QUAD4 and QUAD9 element types, though any element type where build_side() returns an EDGE should (in theory) work.
More element types will be tested and supported as need arises.