### PR TITLE
Add preassembly() hook for Physics

### DIFF
--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -124,6 +124,12 @@ namespace GRINS
     //! Context initialization. Calls each physics implementation of init_context()
     virtual void init_context( libMesh::DiffContext &context );
 
+    //! Override FEMSystem::assembly
+    /*! This allows us to insert things like preassembly(). */
+    virtual void assembly( bool get_residual,
+                           bool get_jacobian,
+                           bool apply_heterogeneous_constraints = false );
+
     // residual and jacobian calculations
     // element_*, side_* as *time_derivative, *constraint, *mass_residual
 

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -162,6 +162,9 @@ namespace GRINS
     //! Initialize context for added physics variables
     virtual void init_context( AssemblyContext& context );
 
+    //! Perform any necessary setup before element assembly begins
+    virtual void preassembly( MultiphysicsSystem & /*system*/ ){};
+
     // residual and jacobian calculations
     // element_*, side_* as *time_derivative, *constraint, *mass_residual
 

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -256,6 +256,19 @@ namespace GRINS
     return;
   }
 
+  void MultiphysicsSystem::assembly( bool get_residual,
+                                     bool get_jacobian,
+                                     bool apply_heterogeneous_constraints )
+  {
+    // First do any preassembly that the Physics requires (which by default is none)
+    for( PhysicsListIter physics_iter = _physics_list.begin();
+         physics_iter != _physics_list.end();
+         physics_iter++ )
+      (physics_iter->second)->preassembly(*this);
+
+    // Now do the assembly
+    libMesh::FEMSystem::assembly(get_residual,get_jacobian,apply_heterogeneous_constraints);
+  }
 
   bool MultiphysicsSystem::_general_residual( bool request_jacobian,
 					      libMesh::DiffContext& context,


### PR DESCRIPTION
We override `FEMSystem::assembly()` and first do a `preassembly()` pass over each Physics. I have at least two use cases for this.

The one thing that concerns me though is that `System::update()` is called in `FEMSystem::assembly()` and one my of use cases will need to use the solution (to accumulate solution values along the (1D) mesh). This means that we'll endup calling `System::update()` twice in that case.

One solution could be we add an optional fourth argument to `FEMSystem::assembly()` - `bool do_solution_localization = true`. This will be compatible with internal library usage and give the hook for us to do the `update()` first and avoid the redundancy, but will obviously break API compatibility for anyone overriding `FEMSystem::assembly()`. Thoughts @roystgnr? (Obviously, this last bit is orthogonal to this PR, but wanted to bring it up for discussion in this context before cooking up the libMesh PR.)