### PR TITLE
RayfireMesh AMR

### DIFF
--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -98,6 +98,15 @@ namespace GRINS
     @return NULL if the given elem_id does not correspond to an elem through which the rayfire passes
     */
     const libMesh::Elem* map_to_rayfire_elem(const libMesh::dof_id_type elem_id);
+    
+    /*!
+    Checks for refined main mesh elements along the rayfire path.
+    If INACTIVE elements are found, they are passed to refine() to update the rayfire mesh.
+
+    Only 1 refinement can be done between reinit() calls
+    @param mesh: reference to main mesh, needed to get Elem* from the stored elem_id's
+    */
+    void reinit(const libMesh::MeshBase& mesh_base);
 
 
   private:
@@ -178,6 +187,9 @@ namespace GRINS
     @return Whether or not the solver converged before hitting the iteration limit
     */
     bool newton_solve_intersection(libMesh::Point& initial_point, const libMesh::Elem* edge_elem, libMesh::Point* intersection_point);
+    
+    //! Refinement of a rayfire element whose main mesh counterpart was refined
+    void refine(const libMesh::Elem* main_elem, libMesh::Elem* rayfire_elem);
   };
       
 }

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -59,6 +59,9 @@ namespace GRINS
   can access the 1D elements, prescribe a desired quadrature rule, and perform
   integration directly along the line, rather than using the entire 2D/3D elements
   of the main mesh.
+  
+  Refinement of the rayfire mesh is supported through the reinit() function.
+  Coarsening is not yet supported.
   */
   class RayfireMesh
   {
@@ -103,7 +106,8 @@ namespace GRINS
     Checks for refined main mesh elements along the rayfire path.
     If INACTIVE elements are found, they are passed to refine() to update the rayfire mesh.
 
-    Only 1 refinement can be done between reinit() calls
+    Only 1 refinement can be done between reinit() calls.
+    Coarsening is not yet supported
     @param mesh: reference to main mesh, needed to get Elem* from the stored elem_id's
     */
     void reinit(const libMesh::MeshBase& mesh_base);

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -135,6 +135,32 @@ namespace GRINS
 
     return NULL;
   }
+  
+  
+  void RayfireMesh::reinit(const libMesh::MeshBase& mesh_base)
+  {
+    // store the elems to be refined until later
+    // so we don't mess with the _elem_id_map while we
+    // iterate over it
+    std::vector<std::pair<const libMesh::Elem*,libMesh::Elem*> > elems_to_refine;
+
+    // iterate over all elems along the rayfire and looks for INATCIVE ones
+    // that were just refined
+    std::map<libMesh::dof_id_type,libMesh::Elem*>::iterator it = _elem_id_map.begin();
+    for(; it != _elem_id_map.end(); it++)
+      {
+        const libMesh::Elem* main_elem = mesh_base.elem(it->first);
+        libmesh_assert(main_elem);
+        libMesh::Elem::RefinementState state = main_elem->refinement_flag();
+
+        if(state == libMesh::Elem::INACTIVE)
+          elems_to_refine.push_back(std::pair<const libMesh::Elem*, libMesh::Elem*>(main_elem,it->second));
+      }
+
+    // refine the elements that need it
+    for (unsigned int i=0; i<elems_to_refine.size(); i++)
+      refine(elems_to_refine[i].first, elems_to_refine[i].second);
+  }
 
 
   // private functions
@@ -335,6 +361,80 @@ namespace GRINS
 
     // no convergence
     return false;
+  }
+  
+  
+  void RayfireMesh::refine(const libMesh::Elem* main_elem, libMesh::Elem* rayfire_elem)
+  {
+    // these nodes cannot change
+    libMesh::Node* start_node = rayfire_elem->get_node(0);
+    libMesh::Node* end_node   = rayfire_elem->get_node(1);
+
+    // remove unrefined elem from _mesh
+    _mesh->delete_elem(rayfire_elem);
+
+    // remove unrefined elem from _elem_id_map
+    std::map<libMesh::dof_id_type,libMesh::Elem*>::iterator it;
+    it = _elem_id_map.find(main_elem->id());
+    _elem_id_map.erase(it);
+
+    // find which child elem we start with
+    unsigned int i=0;
+    while(!(main_elem->child(i))->contains_point(*start_node))
+      i++;
+
+    // we found the starting element, so perform a the rayfire
+    // until we reach the stored end_node
+    libMesh::Point* start_point = start_node;
+    libMesh::Point* end_point = new libMesh::Point();
+
+    const libMesh::Elem* next_elem;
+    const libMesh::Elem* prev_elem = main_elem->child(i);
+    
+    // if prev_elem is INACTIVE, then more than one refinement
+    // has taken place between reinit() calls and will
+    // break this
+    libmesh_assert( prev_elem->refinement_flag() == libMesh::Elem::RefinementState::JUST_REFINED );
+
+    // There are _mesh->n_nodes()-1 number of nodes already in _mesh
+    // so use n_nodes() as the ID of the next node to add
+    unsigned int end_node_id = _mesh->n_nodes();
+
+    unsigned int start_node_id = start_node->id();
+
+    // calculate the end point and
+    // get the second elem in the rayfire
+    next_elem = get_next_elem(prev_elem,start_point,end_point);
+
+    // iterate until we reach the stored end_node
+    while(!(end_point->absolute_fuzzy_equals(*end_node)))
+      {
+        // again, checking for multiple refinements
+        libmesh_assert( next_elem->refinement_flag() == libMesh::Elem::RefinementState::JUST_REFINED );
+        
+        // add end point as node on the rayfire mesh
+        _mesh->add_point(*end_point,end_node_id);
+        libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
+        elem->set_node(0) = _mesh->node_ptr(start_node_id);
+        elem->set_node(1) = _mesh->node_ptr(end_node_id);
+
+        // add new rayfire elem to the map
+        _elem_id_map[prev_elem->id()] = elem;
+        start_point = end_point;
+        prev_elem = next_elem;
+        start_node_id = end_node_id++;
+
+        next_elem = get_next_elem(prev_elem,start_point,end_point);
+      }
+
+    // need to manually assign the end_node to the final edge elem
+    libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
+    elem->set_node(0) = _mesh->node_ptr(start_node_id);
+    elem->set_node(1) = _mesh->node_ptr(end_node->id());
+
+    // add new rayfire elem to the map
+    _elem_id_map[prev_elem->id()] = elem;
+
   }
 
 } //namespace GRINS

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -135,8 +135,8 @@ namespace GRINS
 
     return NULL;
   }
-  
-  
+
+
   void RayfireMesh::reinit(const libMesh::MeshBase& mesh_base)
   {
     // store the elems to be refined until later
@@ -362,8 +362,8 @@ namespace GRINS
     // no convergence
     return false;
   }
-  
-  
+
+
   void RayfireMesh::refine(const libMesh::Elem* main_elem, libMesh::Elem* rayfire_elem)
   {
     // these nodes cannot change
@@ -390,11 +390,11 @@ namespace GRINS
 
     const libMesh::Elem* next_elem;
     const libMesh::Elem* prev_elem = main_elem->child(i);
-    
+
     // if prev_elem is INACTIVE, then more than one refinement
     // has taken place between reinit() calls and will
     // break this
-    libmesh_assert( prev_elem->refinement_flag() == libMesh::Elem::RefinementState::JUST_REFINED );
+    libmesh_assert_equal_to( prev_elem->refinement_flag(), libMesh::Elem::RefinementState::JUST_REFINED );
 
     // There are _mesh->n_nodes()-1 number of nodes already in _mesh
     // so use n_nodes() as the ID of the next node to add
@@ -410,8 +410,8 @@ namespace GRINS
     while(!(end_point->absolute_fuzzy_equals(*end_node)))
       {
         // again, checking for multiple refinements
-        libmesh_assert( next_elem->refinement_flag() == libMesh::Elem::RefinementState::JUST_REFINED );
-        
+        libmesh_assert_equal_to( next_elem->refinement_flag(), libMesh::Elem::RefinementState::JUST_REFINED );
+
         // add end point as node on the rayfire mesh
         _mesh->add_point(*end_point,end_node_id);
         libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -111,7 +111,8 @@ unit_driver_SOURCES = unit/unit_driver.C \
                       unit/variables.C \
                       unit/builder_helper.C \
                       unit/default_bc_builder.C \
-                      unit/rayfire_test.C
+                      unit/rayfire_test.C \
+                      unit/rayfireAMR_test.C
 
 antioch_mixture_SOURCES = unit/antioch_mixture.C
 arrhenius_catalycity_SOURCES = unit/arrhenius_catalycity.C

--- a/test/unit/input_files/mesh_quad4_100elem_2D.in
+++ b/test/unit/input_files/mesh_quad4_100elem_2D.in
@@ -1,0 +1,12 @@
+# Mesh related options                                                                                                                                                                                                                       
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD4'
+      n_elems_x = '10'
+      n_elems_y = '10'
+      y_min = '0'
+      y_max = '10'
+      x_min = '0'
+      x_max = '10'
+[]

--- a/test/unit/input_files/mesh_quad9_100elem_2D.in
+++ b/test/unit/input_files/mesh_quad9_100elem_2D.in
@@ -1,0 +1,12 @@
+# Mesh related options                                                                                                                                                                                                                       
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      n_elems_x = '10'
+      n_elems_y = '10'
+      y_min = '0'
+      y_max = '10'
+      x_min = '0'
+      x_max = '10'
+[]

--- a/test/unit/rayfireAMR_test.C
+++ b/test/unit/rayfireAMR_test.C
@@ -1,0 +1,351 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include "test_comm.h"
+#include "grins_test_paths.h"
+
+// GRINS
+#include "grins/grins_enums.h"
+#include "grins/mesh_builder.h"
+#include "grins/rayfire_mesh.h"
+#include "grins/math_constants.h"
+
+// libMesh
+#include "libmesh/elem.h"
+#include "libmesh/getpot.h"
+#include "libmesh/face_quad4.h"
+#include "libmesh/face_quad9.h"
+#include "libmesh/fe_interface.h"
+#include "libmesh/mesh_refinement.h"
+
+namespace GRINSTesting
+{
+  class RayfireTestAMR : public CppUnit::TestCase
+  {
+  public:
+    CPPUNIT_TEST_SUITE( RayfireTestAMR );
+
+    CPPUNIT_TEST( single_elems );
+    CPPUNIT_TEST( through_vertex_postrefinment );
+    CPPUNIT_TEST( large_2D_mesh );
+    CPPUNIT_TEST( refine_elem_not_on_rayfire );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+
+    //! Refine a single element
+    void single_elems()
+    {
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = build_quad4_elem();
+      test_single_elem(mesh);
+
+      mesh = build_quad9_elem();
+      test_single_elem(mesh);
+    }
+
+    //! After refinement, the rayfire will travel through a vertex
+    void through_vertex_postrefinment()
+    {
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = build_quad4_elem();
+      test_through_vertex(mesh);
+
+      mesh = build_quad9_elem();
+      test_through_vertex(mesh);
+    }
+
+    //! A 10x10 mesh with selectively refined elements
+    void large_2D_mesh()
+    {
+      std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/mesh_quad4_100elem_2D.in";
+      GetPot input_quad4(filename);
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = this->build_mesh(input_quad4);
+      test_large_mesh(mesh);
+
+      filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/mesh_quad9_100elem_2D.in";
+      GetPot input_quad9(filename);
+      mesh = this->build_mesh(input_quad9);
+      test_large_mesh(mesh);
+    }
+
+    //! Make sure refined elements not on the rayfire do not get added
+    void refine_elem_not_on_rayfire()
+    {
+      std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/mesh_quad4_100elem_2D.in";
+      GetPot input(filename);
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = this->build_mesh(input);
+
+      libMesh::Point origin(0.0,6.5);
+      libMesh::Point end_point(10.0,0.25);
+      libMesh::Real theta = calc_theta(origin,end_point);
+
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+
+      // elem 0 is not along the rayfire
+      mesh->elem(0)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+
+      libMesh::MeshRefinement mr(*mesh);
+      mr.refine_elements();
+
+      rayfire->reinit(*mesh);
+
+      // elem 0 should not be in the rayfire
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->id()) ) );
+
+      // no children of elem 0 should be in the rayfire
+      for (unsigned int i=0; i<4; i++)
+        CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem( mesh->elem(0)->child(i)->id() ) ) );
+    }
+
+
+  private:
+
+    libMesh::Real calc_theta(libMesh::Point& start, libMesh::Point end)
+    {
+      return std::atan2( (end(1)-start(1)), (end(0)-start(0)) );
+    }
+
+    GRINS::SharedPtr<libMesh::UnstructuredMesh> build_mesh( const GetPot& input )
+    {
+      GRINS::MeshBuilder mesh_builder;
+      return mesh_builder.build( input, *TestCommWorld );
+    }
+
+    //! Build a single square QUAD4
+    GRINS::SharedPtr<libMesh::UnstructuredMesh> build_quad4_elem()
+    {
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.0,0.0),0 );
+      mesh->add_point( libMesh::Point(1.0,0.0),1 );
+      mesh->add_point( libMesh::Point(1.0,1.0),2 );
+      mesh->add_point( libMesh::Point(0.0,1.0),3 );
+
+      libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad4 );
+      for (unsigned int n=0; n<4; n++)
+        elem->set_node(n) = mesh->node_ptr(n);
+
+      mesh->prepare_for_use();
+
+      return mesh;
+    }
+
+    //! Build a single square QUAD9
+    GRINS::SharedPtr<libMesh::UnstructuredMesh> build_quad9_elem()
+    {
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.0,0.0),0 );
+      mesh->add_point( libMesh::Point(1.0,0.0),1 );
+      mesh->add_point( libMesh::Point(1.0,1.0),2 );
+      mesh->add_point( libMesh::Point(0.0,1.0),3 );
+      mesh->add_point( libMesh::Point(0.5,0.0),4 );
+      mesh->add_point( libMesh::Point(1.0,0.5),5 );
+      mesh->add_point( libMesh::Point(0.5,1.0),6 );
+      mesh->add_point( libMesh::Point(0.0,0.5),7 );
+      mesh->add_point( libMesh::Point(0.5,0.5),8 );
+
+      libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad9 );
+      for (unsigned int n=0; n<9; n++)
+        elem->set_node(n) = mesh->node_ptr(n);
+
+      mesh->prepare_for_use();
+
+      return mesh;
+    }
+
+    //! Runs the test on single square QUADs of unit length and width
+    void test_single_elem(GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh)
+    {
+      CPPUNIT_ASSERT_EQUAL( mesh->n_elem(), (libMesh::dof_id_type)1 );
+
+      libMesh::Point origin(0.0,0.1);
+      libMesh::Point end_point(1.0,0.2);
+      libMesh::Real theta = calc_theta(origin,end_point);
+
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+
+      libMesh::Elem* elem = mesh->elem(0);
+      CPPUNIT_ASSERT(elem);
+
+      elem->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+
+      libMesh::MeshRefinement mr(*mesh);
+      mr.refine_elements();
+
+      rayfire->reinit(*mesh);
+
+      const libMesh::Elem* rayfire_elem0 = rayfire->map_to_rayfire_elem( elem->child(0)->id() );
+      CPPUNIT_ASSERT(rayfire_elem0);
+
+      const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child(1)->id() );
+      CPPUNIT_ASSERT(rayfire_elem1);
+
+      CPPUNIT_ASSERT( (rayfire_elem0->get_node(0))->absolute_fuzzy_equals(origin) );
+      CPPUNIT_ASSERT( (rayfire_elem0->get_node(1))->absolute_fuzzy_equals(libMesh::Point(0.5,0.15)) );
+      CPPUNIT_ASSERT( (rayfire_elem1->get_node(0))->absolute_fuzzy_equals(libMesh::Point(0.5,0.15)) );
+      CPPUNIT_ASSERT( (rayfire_elem1->get_node(1))->absolute_fuzzy_equals(end_point) );
+    }
+
+    void test_through_vertex(GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh)
+    {
+      libMesh::Point origin(0.0,0.0);
+      libMesh::Point end_point(1.0,1.0);
+      libMesh::Real theta = calc_theta(origin,end_point);
+
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+
+      libMesh::Elem* elem = mesh->elem(0);
+      CPPUNIT_ASSERT(elem);
+
+      elem->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+
+      libMesh::MeshRefinement mr(*mesh);
+      mr.refine_elements();
+
+      rayfire->reinit(*mesh);
+
+      const libMesh::Elem* rayfire_elem0 = rayfire->map_to_rayfire_elem( elem->child(0)->id() );
+      CPPUNIT_ASSERT(rayfire_elem0);
+
+      const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child(3)->id() );
+      CPPUNIT_ASSERT(rayfire_elem1);
+
+      CPPUNIT_ASSERT( (rayfire_elem0->get_node(0))->absolute_fuzzy_equals(origin) );
+      CPPUNIT_ASSERT( (rayfire_elem0->get_node(1))->absolute_fuzzy_equals(libMesh::Point(0.5,0.5)) );
+      CPPUNIT_ASSERT( (rayfire_elem1->get_node(0))->absolute_fuzzy_equals(libMesh::Point(0.5,0.5)) );
+      CPPUNIT_ASSERT( (rayfire_elem1->get_node(1))->absolute_fuzzy_equals(end_point) );
+    }
+
+    //! Refine specific elements on a large mesh
+    void test_large_mesh(GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh)
+    {
+      libMesh::Point origin(0.0,6.5);
+      libMesh::Point end_point(10.0,0.25);
+      libMesh::Real theta = calc_theta(origin,end_point);
+
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+
+      // manually refine specific elements
+      // map index 0: main_elem id to refine
+      // map index 1: children that should be in the rayfire post-refinement
+      std::map<unsigned int,std::vector<unsigned int> > refine_elems;
+      refine_elems[60] = std::vector<unsigned int>();
+      refine_elems[60].push_back(0);
+      refine_elems[60].push_back(1);
+
+      refine_elems[52] = std::vector<unsigned int>();
+      refine_elems[52].push_back(0);
+
+      refine_elems[34] = std::vector<unsigned int>();
+      refine_elems[34].push_back(1);
+      refine_elems[34].push_back(2);
+      refine_elems[34].push_back(3);
+
+      refine_elems[25] = std::vector<unsigned int>();
+      refine_elems[25].push_back(3);
+
+      refine_elems[26] = std::vector<unsigned int>();
+      refine_elems[26].push_back(0);
+      refine_elems[26].push_back(1);
+      refine_elems[26].push_back(2);
+
+      refine_elems[17] = std::vector<unsigned int>();
+      refine_elems[17].push_back(2);
+      refine_elems[17].push_back(3);
+
+      refine_elems[9] = std::vector<unsigned int>();
+      refine_elems[9].push_back(1);
+      refine_elems[9].push_back(2);
+      refine_elems[9].push_back(3);
+
+      // check to make sure those elements are along the rayfire
+      // and then set their refinement flags
+      std::map<unsigned int,std::vector<unsigned int> >::iterator it = refine_elems.begin();
+      for(; it != refine_elems.end(); it++)
+        {
+          libMesh::Elem* elem = mesh->elem( it->first );
+          CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem->id()) );
+          elem->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+        }
+
+      // refine the elements
+      libMesh::MeshRefinement mr(*mesh);
+      mr.refine_elements();
+
+      // reinitialize the rayfire
+      rayfire->reinit(*mesh);
+
+      // check the refined elements and their children
+      it = refine_elems.begin();
+      for(; it != refine_elems.end(); it++)
+        {
+          libMesh::Elem* elem = mesh->elem( it->first );
+
+          // make sure it was refined
+          CPPUNIT_ASSERT_EQUAL( elem->refinement_flag(), libMesh::Elem::RefinementState::INACTIVE );
+
+          // make sure it was deleted from the rayfire
+          CPPUNIT_ASSERT( !( rayfire->map_to_rayfire_elem(elem->id()) ) );
+
+          // check that the computed children are in the rayfire
+          // and that the rest are not
+          std::vector<unsigned int> children = it->second;
+          unsigned int index = 0;
+          for(unsigned int c=0; c<elem->n_children(); c++)
+            {
+              if (c==children[index] && index<children.size())
+                {
+                  index++;
+                  std::cout <<it->first <<" child: " <<c <<std::endl;
+                  CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem( elem->child(c)->id() ) );
+                }
+              else
+                CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem( elem->child(c)->id() )) );
+            }
+        }
+    }
+
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( RayfireTestAMR );
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_CPPUNIT

--- a/test/unit/rayfire_test.C
+++ b/test/unit/rayfire_test.C
@@ -65,7 +65,7 @@ namespace GRINSTesting
     CPPUNIT_TEST_SUITE_END();
 
   public:
-    
+
     void quad4_all_sides()
     {
       // vector of intersection points
@@ -74,7 +74,7 @@ namespace GRINSTesting
       pts[1] = libMesh::Point(0.915243860856226,0.0);
       pts[2] = libMesh::Point(1.0,0.25);
       pts[3] = libMesh::Point(0.321046307967165,1.0);
-    
+
       // create the mesh (single square QUAD4 element)
       GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
 
@@ -88,14 +88,14 @@ namespace GRINSTesting
       libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad4 );
       for (unsigned int n=0; n<4; n++)
         elem->set_node(n) = mesh->node_ptr(n);
-        
+
       mesh->prepare_for_use();
-      
+
       run_test_on_all_point_combinations(pts,mesh);
-      
+
     }
-    
-    
+
+
     void quad9_all_sides()
     {
       // vector of intersection points
@@ -104,8 +104,8 @@ namespace GRINSTesting
       pts[1] = libMesh::Point(0.915243860856226,0.0);
       pts[2] = libMesh::Point(1.375,0.25);
       pts[3] = libMesh::Point(0.321046307967165,1.0);
-    
-      // create a non-rectangular QUAD9     
+
+      // create a non-rectangular QUAD9
       GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
 
       mesh->set_mesh_dimension(2);
@@ -123,22 +123,22 @@ namespace GRINSTesting
       libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad9 );
       for (unsigned int n=0; n<9; n++)
         elem->set_node(n) = mesh->node_ptr(n);
-          
+
       mesh->prepare_for_use();
-      
+
       run_test_on_all_point_combinations(pts,mesh);
-      
+
     }
-    
+
     void test_slanted_quad4()
-    {   
+    {
       // vector of intersection points
       std::vector<libMesh::Point> pts(4);
       pts[0] = libMesh::Point(0.5,0.0);
       pts[1] = libMesh::Point(1.75,0.75);
       pts[2] = libMesh::Point(1.5,0.9);
       pts[3] = libMesh::Point(-0.1,0.1);
-    
+
       // create the mesh (single trapezoidal QUAD4 element)
       GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
 
@@ -152,13 +152,13 @@ namespace GRINSTesting
       libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad4 );
       for (unsigned int n=0; n<4; n++)
         elem->set_node(n) = mesh->node_ptr(n);
-          
+
       mesh->prepare_for_use();
-      
+
       run_test_on_all_point_combinations(pts,mesh);
-      
+
     }
-    
+
     void test_vertical_fire()
     {
       // create the mesh (single square QUAD4 element)
@@ -174,153 +174,153 @@ namespace GRINSTesting
       libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad4 );
       for (unsigned int n=0; n<4; n++)
         elem->set_node(n) = mesh->node_ptr(n);
-        
+
       mesh->prepare_for_use();
-        
+
       libMesh::Point start_point(0.3,0.0);
       libMesh::Point end_point(0.3,1.0);
-        
+
       libMesh::Real theta = GRINS::Constants::pi/2.0;
-        
+
       this->run_test_with_mesh(mesh,start_point,theta,end_point,0);
     }
-    
+
     void test_quad4_5elem()
-    {   
+    {
       libMesh::Point origin = libMesh::Point(0,0.5);
-        
+
       libMesh::Node calc_end_node_straight = libMesh::Node(5.0,0.5);
       this->run_test(origin,0.0,calc_end_node_straight,5,4,"quad4",1);
-        
+
       libMesh::Node calc_end_node_angle = libMesh::Node(0.5/std::tan(0.15),1.0);
       this->run_test(origin,0.15,calc_end_node_angle,5,3,"quad4",1);
 
       libMesh::Node calc_end_node_neg_angle = libMesh::Node(0.5/std::tan(0.15),0.0);
-      this->run_test(origin,-0.15,calc_end_node_neg_angle,5,3,"quad4",1); 
+      this->run_test(origin,-0.15,calc_end_node_neg_angle,5,3,"quad4",1);
     }
-    
+
     void test_quad9_5elem()
-    {   
+    {
       libMesh::Point origin = libMesh::Point(0,0.5);
-        
+
       libMesh::Node calc_end_node_straight = libMesh::Node(5.0,0.5);
       this->run_test(origin,0.0,calc_end_node_straight,5,4,"quad9",1);
-        
+
       libMesh::Node calc_end_node_angle = libMesh::Node(0.5/std::tan(0.15),1.0);
       this->run_test(origin,0.15,calc_end_node_angle,5,3,"quad9",1);
 
       libMesh::Node calc_end_node_neg_angle = libMesh::Node(0.5/std::tan(0.15),0.0);
-      this->run_test(origin,-0.15,calc_end_node_neg_angle,5,3,"quad9",1); 
+      this->run_test(origin,-0.15,calc_end_node_neg_angle,5,3,"quad9",1);
     }
-    
+
     void test_quad4_2D()
-    {  
+    {
       libMesh::Point origin = libMesh::Point(0.0,1.5);
-      
+
       libMesh::Node calc_end_node_straight = libMesh::Node(3.0,1.5);
       this->run_test(origin,0.0,calc_end_node_straight,9,5,"quad4",2);
-      
+
       libMesh::Node calc_end_node_small_angle = libMesh::Node(3.0,1.5+3.0*std::tan(0.15));
       this->run_test(origin,0.15,calc_end_node_small_angle,9,5,"quad4",2);
 
       libMesh::Node calc_end_node_small_neg_angle = libMesh::Node(3.0,1.5+3.0*std::tan(-0.15));
       this->run_test(origin,-0.15,calc_end_node_small_neg_angle,9,5,"quad4",2);
-            
+
       libMesh::Node calc_end_node_large_angle = libMesh::Node( (3.0-1.5)/std::tan(1.0), 3.0);
       this->run_test(origin,1.0,calc_end_node_large_angle,9,6,"quad4",2);
 
       libMesh::Node calc_end_node_large_neg_angle = libMesh::Node( (0.0-1.5)/std::tan(-1.0), 0.0);
       this->run_test(origin,-1.0,calc_end_node_large_neg_angle,9,0,"quad4",2);
     }
-    
+
     void test_quad9_2D()
-    {  
+    {
       libMesh::Point origin = libMesh::Point(0.0,1.5);
-        
+
       libMesh::Node calc_end_node_straight = libMesh::Node(3.0,1.5);
       this->run_test(origin,0.0,calc_end_node_straight,9,5,"quad9",2);
-        
+
       libMesh::Node calc_end_node_small_angle = libMesh::Node(3.0,1.5+3.0*std::tan(0.15));
       this->run_test(origin,0.15,calc_end_node_small_angle,9,5,"quad9",2);
 
       libMesh::Node calc_end_node_small_neg_angle = libMesh::Node(3.0,1.5+3.0*std::tan(-0.15));
       this->run_test(origin,-0.15,calc_end_node_small_neg_angle,9,5,"quad9",2);
-            
+
       libMesh::Node calc_end_node_large_angle = libMesh::Node( (3.0-1.5)/std::tan(1.0), 3.0);
       this->run_test(origin,1.0,calc_end_node_large_angle,9,6,"quad9",2);
 
       libMesh::Node calc_end_node_large_neg_angle = libMesh::Node( (0.0-1.5)/std::tan(-1.0), 0.0);
       this->run_test(origin,-1.0,calc_end_node_large_neg_angle,9,0,"quad9",2);
     }
-    
-    
-    
+
+
+
     void fire_through_vertex()
     {
       libMesh::Point origin = libMesh::Point(0.0,0.0);
-        
+
       libMesh::Node calc_end_node_straight = libMesh::Node(3.0,3.0);
-        
+
       // 3x3 QUAD4 mesh
       this->run_test(origin,45.0*GRINS::Constants::pi/180.0,calc_end_node_straight,9,8,"quad4",2);
-        
+
       // 3x3 QUAD9 mesh
       this->run_test(origin,45.0*GRINS::Constants::pi/180.0,calc_end_node_straight,9,8,"quad9",2);
     }
 
-    
+
 
   private:
-  
+
     void run_test(libMesh::Point& origin, libMesh::Real theta, libMesh::Node& calc_end_node, unsigned int n_elem, unsigned int exit_elem, std::string elem_type, unsigned int dim)
     {
       std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/mesh_"+elem_type+"_"+std::to_string(n_elem)+"elem_"+std::to_string(dim)+"D.in";
       GetPot input(filename);
       GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = this->build_mesh(input);
-      
+
       // ensure the mesh has the desired number of elements
       CPPUNIT_ASSERT_EQUAL(n_elem,mesh->n_elem());
-      
+
       run_test_with_mesh(mesh,origin,theta,calc_end_node,exit_elem);
     }
 
     void run_test_on_all_point_combinations(std::vector<libMesh::Point> pts, GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh)
-    {  
+    {
       // iterate over the starting points
       for(unsigned int i=0; i<pts.size(); i++)
       {
         libMesh::Point start_point = pts[i];
-            
+
         // iterate over all the intersection points
         for(unsigned int j=0; j<pts.size(); j++)
         {
           if(j==i)
             continue;
-                    
+
           libMesh::Point end_point = pts[j];
-                
+
           libMesh::Real theta = calc_theta(start_point,end_point);
-                
+
           // run the test
           this->run_test_with_mesh(mesh,start_point,theta,end_point,0);
-        }      
-        
+        }
+
       }
-    
+
     }
-    
+
     void run_test_with_mesh(GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh, libMesh::Point& origin, libMesh::Real theta, libMesh::Point& calc_end_point, unsigned int exit_elem)
-    {      
+    {
       GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
       rayfire->init(*mesh);
-    
+
       const libMesh::Elem* original_elem = mesh->elem(exit_elem);
-    
+
       const libMesh::Elem* rayfire_elem = rayfire->map_to_rayfire_elem(original_elem->id());
-    
+
       if (!rayfire_elem)
         libmesh_error_msg("Attempted to map an element that is not in the Rayfire");
-    
+
       CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(0), (*(rayfire_elem->get_node(1)))(0),libMesh::TOLERANCE);
       CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(1), (*(rayfire_elem->get_node(1)))(1),libMesh::TOLERANCE);
     }
@@ -330,12 +330,12 @@ namespace GRINSTesting
       GRINS::MeshBuilder mesh_builder;
       return mesh_builder.build( input, *TestCommWorld );
     }
-    
+
     libMesh::Real calc_theta(libMesh::Point& start, libMesh::Point end)
     {
       return std::atan2( (end(1)-start(1)), (end(0)-start(0)) );
     }
-    
+
   };
 
   CPPUNIT_TEST_SUITE_REGISTRATION( RayfireTest );


### PR DESCRIPTION
This PR adds AMR support to the RayfireMesh class (added in #418) and associated CPPUnit tests.

Refinement of the Rayfire mesh is done through the `RayfireMesh::reinit()` function, which must be called after each refinement of the main mesh. Right now, this must be done manually. However, in the near future, we will hook into MultiphysicsSystem to call `reinit()` on RayfireMesh objects in an upcoming QoI class.

The API change in the first commit was necessary to allow `RayfireMesh::reinit()` to have an empty parameter list (as will be required when the aforementioned hooks are added). Without a MeshBase object like in the `RayfireMesh::init(MeshBase&)` function, there was no was to get an `Elem*` from the elem IDs stored in the `RayfireMesh::_elem_map`. By storing `Elem*` instead of just their IDs, we can reinit without needing a MeshBase.

`make check` passes using latest `libmesh/master` with GCC 4.8.4 and 5.3.0