### PR TITLE
Include serial_mesh.h in new rayfire test

### DIFF
--- a/test/unit/rayfire_test.C
+++ b/test/unit/rayfire_test.C
@@ -44,6 +44,7 @@
 #include "libmesh/face_quad4.h"
 #include "libmesh/face_quad9.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/serial_mesh.h"
 
 namespace GRINSTesting
 {


### PR DESCRIPTION
Otherwise when we build with a --enable-parmesh libMesh, this test
doesn't know what a serial mesh is.