### PR TITLE
Require Mesh=serial for new restart test

### DIFF
--- a/test/input_files/heat_eqn_unsteady_2d_restart_pt1.in
+++ b/test/input_files/heat_eqn_unsteady_2d_restart_pt1.in
@@ -53,6 +53,8 @@
 []
 
 [Mesh]
+   class = 'serial'
+
    [./Read]
       filename = './grids/mixed_quad_tri_square_mesh.xda'
    [../Refinement]

--- a/test/input_files/heat_eqn_unsteady_2d_restart_pt2.in
+++ b/test/input_files/heat_eqn_unsteady_2d_restart_pt2.in
@@ -54,6 +54,8 @@
 []
 
 [Mesh]
+   class = 'serial'
+
    [./Read]
       filename = './heat_eqn_unsteady_2d_restart_pt1.24_mesh.xda'
 []


### PR DESCRIPTION
This isn't a GRINS bug, it's an exposure of a libMesh bug, but
unfortunately it's not a libMesh bug I have time to fix right now.