### PR TITLE
Rayfire coarsening

### DIFF
--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -266,7 +266,7 @@ namespace GRINS
 
     // check if the intersection point is a vertex
     bool is_vertex = false;
-    for(unsigned int n=0; n<4; n++)
+    for(unsigned int n=0; n<cur_elem->n_nodes(); n++)
       is_vertex |= (cur_elem->get_node(n))->absolute_fuzzy_equals(end_point);
 
     if (is_vertex)

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -145,17 +145,16 @@ namespace GRINS
         const libMesh::Elem* main_elem = mesh_base.elem(it->first);
         libmesh_assert(main_elem);
 
+        if (main_elem->parent())
+          {
+            if (main_elem->parent()->refinement_flag() == libMesh::Elem::RefinementState::JUST_COARSENED)
+              elems_to_coarsen.push_back(main_elem);
+          }
+
         libMesh::Elem::RefinementState state = main_elem->refinement_flag();
 
         if (state == libMesh::Elem::RefinementState::INACTIVE)
           {
-            // could be a refined parent or a coarsened child
-            if (main_elem->parent())
-              {
-                if (main_elem->parent()->refinement_flag() == libMesh::Elem::RefinementState::JUST_COARSENED)
-                  elems_to_coarsen.push_back(main_elem);
-              }
-
             if (main_elem->has_children())
               if (main_elem->child(0)->refinement_flag() == libMesh::Elem::RefinementState::JUST_REFINED)
                 elems_to_refine.push_back(std::pair<const libMesh::Elem*, libMesh::Elem*>(main_elem,it->second));

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -27,22 +27,14 @@
 #include "grins/rayfire_mesh.h"
 
 // GRINS
-#include "grins/multiphysics_sys.h"
-#include "grins/assembly_context.h"
-#include "grins/materials_parsing.h"
 #include "grins/math_constants.h"
 
 // libMesh
 #include "libmesh/getpot.h"
-#include "libmesh/fem_system.h"
-#include "libmesh/quadrature.h"
-#include "libmesh/point_locator_base.h"
 #include "libmesh/elem.h"
 #include "libmesh/edge_edge2.h"
-#include "libmesh/analytic_function.h"
 #include "libmesh/enum_elem_type.h"
 #include "libmesh/fe.h"
-#include "libmesh/fe_interface.h"
 
 namespace GRINS
 {
@@ -95,7 +87,7 @@ namespace GRINS
 
     // ensure the origin is on a boundary element
     // AND on the boundary of said element
-    check_origin_on_boundary(start_elem);
+    this->check_origin_on_boundary(start_elem);
 
     // add the origin point to the point list
     _mesh->add_point(*start_point,node_id++);
@@ -109,7 +101,7 @@ namespace GRINS
       {
         // calculate the end point and
         // get the next elem in the rayfire
-        next_elem = get_next_elem(prev_elem,start_point,end_point);
+        next_elem = this->get_next_elem(prev_elem,start_point,end_point);
 
         // add end point as node on the rayfire mesh
         _mesh->add_point(*end_point,node_id);
@@ -159,7 +151,7 @@ namespace GRINS
 
     // refine the elements that need it
     for (unsigned int i=0; i<elems_to_refine.size(); i++)
-      refine(elems_to_refine[i].first, elems_to_refine[i].second);
+      this->refine(elems_to_refine[i].first, elems_to_refine[i].second);
   }
 
 
@@ -202,12 +194,12 @@ namespace GRINS
         if (edge_elem->contains_point(*start_point))
           continue;
 
-        bool converged = newton_solve_intersection(*start_point,edge_elem.get(),intersection_point);
+        bool converged = this->newton_solve_intersection(*start_point,edge_elem.get(),intersection_point);
 
         if (converged)
           {
-            if ( check_valid_point(*intersection_point,*start_point,*edge_elem,next_point) )
-              return get_correct_neighbor(*intersection_point,cur_elem,s);
+            if ( this->check_valid_point(*intersection_point,*start_point,*edge_elem,next_point) )
+              return this->get_correct_neighbor(*intersection_point,cur_elem,s);
           }
         else
           continue;
@@ -404,7 +396,7 @@ namespace GRINS
 
     // calculate the end point and
     // get the second elem in the rayfire
-    next_elem = get_next_elem(prev_elem,start_point,end_point);
+    next_elem = this->get_next_elem(prev_elem,start_point,end_point);
 
     // iterate until we reach the stored end_node
     while(!(end_point->absolute_fuzzy_equals(*end_node)))
@@ -424,7 +416,7 @@ namespace GRINS
         prev_elem = next_elem;
         start_node_id = end_node_id++;
 
-        next_elem = get_next_elem(prev_elem,start_point,end_point);
+        next_elem = this->get_next_elem(prev_elem,start_point,end_point);
       }
 
     // need to manually assign the end_node to the final edge elem

--- a/test/unit/input_files/mixed_quad_tri.in
+++ b/test/unit/input_files/mixed_quad_tri.in
@@ -1,0 +1,4 @@
+[Mesh]
+   [./Read]
+      filename = './grids/mixed_quad_tri_square_mesh.xda'
+[]

--- a/test/unit/rayfireAMR_test.C
+++ b/test/unit/rayfireAMR_test.C
@@ -54,13 +54,15 @@ namespace GRINSTesting
   public:
     CPPUNIT_TEST_SUITE( RayfireTestAMR );
 
-//    CPPUNIT_TEST( single_elems );
-//    CPPUNIT_TEST( through_vertex_postrefinment );
-//    CPPUNIT_TEST( large_2D_mesh );
-//    CPPUNIT_TEST( refine_elem_not_on_rayfire );
-//    CPPUNIT_TEST( multiple_refinements );
-
+    CPPUNIT_TEST( single_elems );
+    CPPUNIT_TEST( through_vertex_postrefinment );
+    CPPUNIT_TEST( large_2D_mesh );
+    CPPUNIT_TEST( refine_elem_not_on_rayfire );
+    CPPUNIT_TEST( multiple_refinements );
     CPPUNIT_TEST( coarsen_elements );
+    CPPUNIT_TEST( refine_and_coarsen );
+    CPPUNIT_TEST( mixed_type_mesh );
+    CPPUNIT_TEST( start_with_refined_mesh );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -154,6 +156,159 @@ namespace GRINSTesting
       test_coarsen(mesh);
     }
 
+    //! Refine and coarsen before calling reinit()
+    void refine_and_coarsen()
+    {
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = build_quad4_elem();
+
+      libMesh::Point origin(0.0,0.1);
+      libMesh::Point end_point(1.0,0.1);
+      libMesh::Real theta = calc_theta(origin,end_point);
+
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+
+      libMesh::MeshRefinement mr(*mesh);
+      mr.uniformly_refine();
+      rayfire->reinit(*mesh);
+      mr.uniformly_refine();
+      rayfire->reinit(*mesh);
+
+      // refine elem(0)->child(1)->child(1)
+      mesh->elem(0)->child(1)->child(1)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+      // coarsen elem(0)->child(0)
+      for (unsigned int c=0; c<mesh->elem(0)->child(0)->n_children(); c++)
+        mesh->elem(0)->child(0)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+
+      mr.refine_and_coarsen_elements();
+      rayfire->reinit(*mesh);
+
+      CPPUNIT_ASSERT( mesh->elem(0)->child(0)->active() );
+
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(1)->child(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(1)->child(1)->id()) );
+
+
+    }
+
+    //! Mesh contains 2 QUAD4 and 2 TRI3
+    void mixed_type_mesh()
+    {
+      std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/mixed_quad_tri.in";
+      GetPot input(filename);
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = this->build_mesh(input);
+
+      libMesh::Point origin(0.0,0.25);
+      libMesh::Point end_point(1.0,0.25);
+      libMesh::Real theta = calc_theta(origin,end_point);
+
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+
+      // check that the rayfire is through the right elems
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(0) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(6) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(9) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(8) );
+
+      // and not through others
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(2)) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(3)) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(4)) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(5)) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(1)) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(7)) );
+
+      // now do a uniform refinement
+      libMesh::MeshRefinement mr(*mesh);
+      mr.uniformly_refine();
+
+      rayfire->reinit(*mesh);
+
+      // check post-refinement
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(6)->child(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(9)->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(8)->child(2)->id()) );
+
+      // coarsen two of the TRIs
+      for (unsigned int c=0; c<mesh->elem(6)->n_children(); c++)
+        {
+          mesh->elem(6)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem(9)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+        }
+
+      mr.coarsen_elements();
+      rayfire->reinit(*mesh);
+
+      CPPUNIT_ASSERT( mesh->elem(6)->active() );
+      CPPUNIT_ASSERT( mesh->elem(9)->active() );
+
+      // check post-coarsen
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(8)->child(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(6) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(9) );
+
+      for (unsigned int c=0; c<mesh->elem(6)->n_children(); c++)
+        {
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(6)->child(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(9)->child(c)->id())) );
+        }
+    }
+
+    //! Mesh given to init() is already refined
+    void start_with_refined_mesh()
+    {
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = build_quad4_elem();
+
+      // uniform refinement
+      libMesh::MeshRefinement mr(*mesh);
+      mr.uniformly_refine();
+
+      // now init the rayfire
+      libMesh::Point origin(0.0,0.1);
+      libMesh::Point end_point(1.0,0.1);
+      libMesh::Real theta = calc_theta(origin,end_point);
+
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->id()) );
+
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->child(2)->id())) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->child(3)->id())) );
+
+      // refine again
+      mr.uniformly_refine();
+      rayfire->reinit(*mesh);
+
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->child(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(1)->id()) );
+
+      // uniformly coarsen twice to get back to a single elem
+      mr.uniformly_coarsen();
+      rayfire->reinit(*mesh);
+      mr.uniformly_coarsen();
+      rayfire->reinit(*mesh);
+
+      // ensure the original elem is active
+      CPPUNIT_ASSERT( mesh->elem(0)->active() );
+
+      // the original elem should be in the rayfire
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(0) );
+
+      // and no other elem
+      for (unsigned int e=1; e<mesh->n_elem(); e++)
+        CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(e)) );
+    }
 
   private:
 


### PR DESCRIPTION
Adds coarsening functionality to RayfireMesh, and a CPPUnit test for it.

Coarsening of the rayfire is done through storing the parent of refined rayfire elements. If that same element is later coarsened, we simply inactivate the children and activate the parent. The `RefinementState` is checked  in `map_to_rayfire_elem()` to ensure that only active rayfire elements get returned.

Note that the initial rayfire performed by `RayfireMesh::init()` must be done on the coarsest mesh before any refinements are done. Similar to how libMesh operates, we cannot coarsen the rayfire mesh beyond its initial version. Thus, a check was added to `RayfireMesh::init()` in 5370c06 to ensure that all elements along the rayfire are level 0.

Hooks to call `RayfireMesh::reinit()` post-refinement/coarsening will be placed into MultiphysicsSystem soon, but without a rayfire-based QoI implemented, there is no way to test them.

`make check` passes with libMesh `--enable-parmesh`