### PR TITLE
Use header for PointLocatorBase

### DIFF
--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -36,7 +36,7 @@
 #include "libmesh/getpot.h"
 #include "libmesh/fem_system.h"
 #include "libmesh/quadrature.h"
-#include "libmesh/point_locator_list.h"
+#include "libmesh/point_locator_base.h"
 #include "libmesh/elem.h"
 #include "libmesh/edge_edge2.h"
 #include "libmesh/analytic_function.h"


### PR DESCRIPTION
Not the subclass. In particular, this subclass is being removed
from post 1.0 libMesh, so this actually doesn't even compile.