### PR TITLE
Enable AdaptiveTimeSolver with negative tolerance

### DIFF
--- a/src/strategies/src/adaptive_time_stepping_options.C
+++ b/src/strategies/src/adaptive_time_stepping_options.C
@@ -47,7 +47,7 @@ namespace GRINS
     else
       this->parse_new_style(input);
 
-    if( _target_tolerance > 0 )
+    if( _target_tolerance != 0.0 )
       _is_time_adaptive = true;
   }
 


### PR DESCRIPTION
libMesh uses a negative value here to signal "base my tolerance on the
time discretization error from the first successful time step", and we
should pass that along to enable that feature.