### PR TITLE
Call MultiphysicSystem::read_input_options() in testing helper

### DIFF
--- a/test/common/system_helper.h
+++ b/test/common/system_helper.h
@@ -46,6 +46,10 @@ namespace GRINSTesting
       _mesh = mesh_builder.build( *_input, *TestCommWorld );
       _es.reset( new libMesh::EquationSystems(*_mesh) );
       _system = &_es->add_system<GRINS::MultiphysicsSystem>( "GRINS-TEST" );
+
+      // We may not need any of these options, but this does some setup work that's needed
+      // and all the options have sane defaults if they're not in the testing input file.
+      _system->read_input_options( (*_input) );
     }
 
     void reset_all()


### PR DESCRIPTION
For unit tests that may be using "raw" MultiphysicsSystem (i.e. outside
of the Simulation class), this is one of the necessary steps. In
particular, this function caches a pointer to the GetPot object
that will be subsequently passed to things like the boundary condition
factories. So, let's make sure and call it when the developer is
using this testing helper function.