### PR TITLE
Provide Physics::reinit() Hooks

### DIFF
--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -130,6 +130,11 @@ namespace GRINS
                            bool get_jacobian,
                            bool apply_heterogeneous_constraints = false );
 
+    //! Override FEMSystem::reinit
+    /*! This will allow each Physics to reinit things internally that need it,
+        such as point locators. */
+    virtual void reinit();
+
     // residual and jacobian calculations
     // element_*, side_* as *time_derivative, *constraint, *mass_residual
 

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -165,6 +165,12 @@ namespace GRINS
     //! Perform any necessary setup before element assembly begins
     virtual void preassembly( MultiphysicsSystem & /*system*/ ){};
 
+    //! Any reinitialization that needs to be done
+    /*! This is called through libMesh::FEMSystem::reinit, which is called e.g.
+        after adaptive mesh refinement/coarsening. So, for Physics that need to
+        reinit internally, then this method should be overridden. */
+    virtual void reinit( MultiphysicsSystem & /*system*/ ){};
+
     // residual and jacobian calculations
     // element_*, side_* as *time_derivative, *constraint, *mass_residual
 

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -270,6 +270,18 @@ namespace GRINS
     libMesh::FEMSystem::assembly(get_residual,get_jacobian,apply_heterogeneous_constraints);
   }
 
+  void MultiphysicsSystem::reinit()
+  {
+    // First call Parent
+    FEMSystem::reinit();
+
+    // Now do per Physics reinit (which by default is none)
+    for( PhysicsListIter physics_iter = _physics_list.begin();
+         physics_iter != _physics_list.end();
+         physics_iter++ )
+      (physics_iter->second)->reinit(*this);
+  }
+
   bool MultiphysicsSystem::_general_residual( bool request_jacobian,
 					      libMesh::DiffContext& context,
                                               ResFuncType resfunc,


### PR DESCRIPTION
Some Physics may, internally, need to reinit things after AMR/C. This
provides the hook for them to be able to do so. Physics::reinit()
is called through MultiphysicsSystem::reinit() (and override of
FEMSystem reinit).