### PR TITLE
RayfireMesh GCC warnings fix

### DIFF
--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -501,10 +501,8 @@ namespace GRINS
         const libMesh::Elem* parent_elem = child_elem->parent();
         libmesh_assert(parent_elem);
 
-        const libMesh::Node* start_node;
-        const libMesh::Node* end_node;
-
-        bool initial_nodes = false;
+        const libMesh::Node* start_node = NULL;
+        const libMesh::Node* end_node = NULL;
 
         for (unsigned int c=0; c<parent_elem->n_children(); c++)
           {
@@ -512,11 +510,10 @@ namespace GRINS
 
             if (rayfire_child)
               {
-                if (!initial_nodes)
+                if (!start_node)
                   {
                     start_node = rayfire_child->get_node(0);
                     end_node = rayfire_child->get_node(1);
-                    initial_nodes = true;
                   }
                 else
                   {
@@ -530,6 +527,10 @@ namespace GRINS
                 rayfire_child->set_refinement_flag(libMesh::Elem::RefinementState::INACTIVE);
               }
           } // for c
+
+        // make sure we found nodes
+        libmesh_assert(start_node);
+        libmesh_assert(end_node);
 
         // add a new rayfire elem
         libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);


### PR DESCRIPTION
This fixes warnings from GCC6.1 pointed out by @pbauman in #441.

For some context, on coarsening, we know the coarsened rayfire elem has to travel across the entire `parent_elem`. But since we have already calculated the intersection points for all the child elems, we can coarsen by just finding the node closest to the origin and farthest from it. So we iterate over all the child elems of our parent, and keep track of the start and end nodes, which later become the 2 nodes of the coarsened EDGE2 rayfire elem