### PR TITLE
Integrated Function QoI

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -198,6 +198,7 @@ libgrins_la_SOURCES += qoi/src/parsed_boundary_qoi.C
 libgrins_la_SOURCES += qoi/src/parsed_interior_qoi.C
 libgrins_la_SOURCES += qoi/src/weighted_flux_qoi.C
 libgrins_la_SOURCES += qoi/src/rayfire_mesh.C
+libgrins_la_SOURCES += qoi/src/integrated_function.C
 
 # src/solver files
 libgrins_la_SOURCES += solver/src/grins_solver.C
@@ -470,6 +471,7 @@ include_HEADERS += qoi/include/grins/parsed_boundary_qoi.h
 include_HEADERS += qoi/include/grins/parsed_interior_qoi.h
 include_HEADERS += qoi/include/grins/weighted_flux_qoi.h
 include_HEADERS += qoi/include/grins/rayfire_mesh.h
+include_HEADERS += qoi/include/grins/integrated_function.h
 
 # src/solver headers
 include_HEADERS += solver/include/grins/grins_solver.h

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -1,0 +1,123 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_INTEGRATED_FUNCTION_H
+#define GRINS_INTEGRATED_FUNCTION_H
+
+// libMesh
+#include "libmesh/quadrature.h"
+#include "libmesh/exact_solution.h"
+#include "libmesh/fem_function_base.h"
+
+// GRINS
+#include "grins/qoi_base.h"
+#include "grins/variable_name_defaults.h"
+#include "grins/rayfire_mesh.h"
+
+namespace GRINS
+{
+
+  //! IntegratedFunction
+  /*!
+  The purpose of this class is to integrate a function along a 1D line through a 2D mesh.
+  This class utilizes the RayfireMesh class to calculate the line and provide 1D elements for evaluating
+  the function.
+
+  The template parameter must be FunctionBase or FEMFunctionBase.
+
+  Currently, calculating element qoi derivatives is not supported.
+  */
+  template<typename Function>
+  class IntegratedFunction : public QoIBase
+  {
+  public:
+    //! Constructor
+    /*!
+    @param p_level The desired Gauss Quadrature level
+    @param f A FunctionBase or FEMFunctionBase object for evaluting the QoI
+    @param rayfire A RayfireMesh object (will be initialized in init())
+    @param qoi_name Passed to the QoIBase
+    */
+    IntegratedFunction(unsigned int p_level, SharedPtr<Function> f, SharedPtr<RayfireMesh> rayfire, const std::string& qoi_name);
+
+    //! Required to provide clone (deep-copy) for adding QoI object to libMesh objects.
+    virtual QoIBase* clone() const;
+
+    virtual bool assemble_on_interior() const;
+
+    virtual bool assemble_on_sides() const;
+
+    //! Compute the qoi value.
+    virtual void element_qoi( AssemblyContext& context,
+                              const unsigned int qoi_index );
+
+    //! Compute the qoi derivative with respect to the solution.
+    /*!
+    Currently not implemented
+    */
+    virtual void element_qoi_derivative( AssemblyContext& context,
+                                         const unsigned int qoi_index );
+    //! Initializes the rayfire with the mesh from system
+    virtual void init( const GetPot& input,
+                       const MultiphysicsSystem& system,
+                       unsigned int qoi_num );
+
+
+  private:
+    //! Quadrature order
+    unsigned int _p_level;
+
+    //! Pointer to the template class used for function evaluation
+    SharedPtr<Function> _f;
+
+    //! Pointer to RayfireMesh object
+    SharedPtr<RayfireMesh> _rayfire;
+
+    //! QBase object for adding quadrature to rayfire elements
+    SharedPtr<libMesh::QBase> _qbase;
+
+    //! Compute the value of a QoI at a QP
+    libMesh::Real qoi_value(Function& f,AssemblyContext& context,const libMesh::Point& xyz);
+
+    //! User cannot call empty constructor
+    IntegratedFunction();
+
+  };
+
+  template<typename Function>
+  inline
+  bool IntegratedFunction<Function>::assemble_on_interior() const
+  {
+    return true;
+  }
+
+  template<typename Function>
+  inline
+  bool IntegratedFunction<Function>::assemble_on_sides() const
+  {
+    return false;
+  }
+}
+#endif //GRINS_INTEGRATED_FUNCTION_H

--- a/src/qoi/include/grins/qoi_names.h
+++ b/src/qoi/include/grins/qoi_names.h
@@ -32,5 +32,6 @@ namespace GRINS
   const std::string parsed_boundary = "parsed_boundary";
   const std::string parsed_interior = "parsed_interior";
   const std::string weighted_flux = "weighted_flux";
+  const std::string integrated_function = "integrated_function";
 }
 #endif //GRINS_QOI_NAMES_H

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -103,6 +103,11 @@ namespace GRINS
     const libMesh::Elem* map_to_rayfire_elem(const libMesh::dof_id_type elem_id);
 
     /*!
+    Returns a vector of elem IDs that are currently along the rayfire
+    */
+    void elem_ids_in_rayfire(std::vector<libMesh::dof_id_type>& id_vector);
+
+    /*!
     Checks for refined and coarsened main mesh elements along the rayfire path.
     They are then passed to refine() and coarsen(), respectively, to update the rayfire mesh.
 

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -1,0 +1,133 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+// This class
+#include "grins/integrated_function.h"
+
+// GRINS
+#include "grins/multiphysics_sys.h"
+#include "grins/assembly_context.h"
+#include "grins/materials_parsing.h"
+#include "grins/rayfire_mesh.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+#include "libmesh/fem_system.h"
+#include "libmesh/quadrature_gauss.h"
+#include "libmesh/elem.h"
+#include "libmesh/fe.h"
+#include "libmesh/fe_type.h"
+#include "libmesh/function_base.h"
+#include "libmesh/fem_function_base.h"
+
+namespace GRINS
+{
+  template<typename Function>
+  IntegratedFunction<Function>::IntegratedFunction(unsigned int p_level, SharedPtr<Function> f, SharedPtr<RayfireMesh> rayfire, const std::string& qoi_name) :
+    QoIBase(qoi_name),
+    _p_level(p_level),
+    _f(f),
+    _rayfire(rayfire)
+  {
+    // use Gauss Quadrature
+    _qbase.reset(new libMesh::QGauss(1,libMesh::Order(_p_level)));
+  }
+
+  template<typename Function>
+  QoIBase* IntegratedFunction<Function>::clone() const
+  {
+    return new IntegratedFunction<Function>( *this );
+  }
+
+  template<typename Function>
+  void IntegratedFunction<Function>::init
+    (const GetPot& /*input*/,
+     const MultiphysicsSystem& system,
+     unsigned int /*qoi_num*/ )
+  {
+    _rayfire->init(system.get_mesh());
+  }
+
+  template<typename Function>
+  void IntegratedFunction<Function>::element_qoi( AssemblyContext& context,
+                                       const unsigned int qoi_index )
+  {
+    const libMesh::Elem& original_elem = context.get_elem();
+    const libMesh::Elem* rayfire_elem = _rayfire->map_to_rayfire_elem(original_elem.id());
+
+    // rayfire_elem will be NULL if the main_elem
+    // is not in the rayfire
+    if (rayfire_elem)
+      {
+        // init the quadrature base on the rayfire elem
+        _qbase->init(rayfire_elem->type(),_p_level);
+
+        // need the QP coordinates and JxW
+        libMesh::UniquePtr< libMesh::FEBase > fe = libMesh::FEBase::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
+
+        fe->attach_quadrature_rule( _qbase.get() );
+        fe->get_xyz();
+        fe->get_JxW();
+
+        fe->reinit(rayfire_elem);
+
+        const std::vector<libMesh::Real>& JxW = fe->get_JxW();
+        const std::vector<libMesh::Point>& xyz = fe->get_xyz();
+
+        const unsigned int n_qpoints = fe->n_quadrature_points();
+
+        libMesh::Number& qoi = context.get_qois()[qoi_index];
+
+        for (unsigned int qp = 0; qp != n_qpoints; ++qp)
+            qoi += this->qoi_value((*_f),context,xyz[qp])*JxW[qp];
+
+      }
+  }
+
+  template<typename Function>
+  void IntegratedFunction<Function>::element_qoi_derivative( AssemblyContext& /*context*/,
+                                       const unsigned int /*qoi_index*/ )
+  {
+    //TODO
+    libmesh_not_implemented();
+  }
+
+  // speciaizations of the qoi_value() function
+  template<>
+  libMesh::Real IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >::qoi_value(libMesh::FEMFunctionBase<libMesh::Real>& f,AssemblyContext& context,const libMesh::Point& xyz)
+  {
+    return f(context,xyz);
+  }
+
+  template<>
+  libMesh::Real IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >::qoi_value(libMesh::FunctionBase<libMesh::Real>& f,AssemblyContext& /*context*/,const libMesh::Point& xyz)
+  {
+    return f(xyz);
+  }
+
+template class IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >;
+template class IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >;
+
+} //namespace GRINS

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -124,6 +124,17 @@ namespace GRINS
   }
 
 
+  void RayfireMesh::elem_ids_in_rayfire(std::vector<libMesh::dof_id_type>& id_vector)
+  {
+    std::map<libMesh::dof_id_type,libMesh::Elem*>::iterator it = _elem_id_map.begin();
+    for(; it != _elem_id_map.end(); it++)
+      {
+        if (it->second->active())
+          id_vector.push_back(it->first);
+      }
+  }
+
+
   void RayfireMesh::reinit(const libMesh::MeshBase& mesh_base)
   {
     // store the elems to be refined until later

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -111,7 +111,8 @@ unit_driver_SOURCES = unit/unit_driver.C \
                       unit/builder_helper.C \
                       unit/default_bc_builder.C \
                       unit/rayfire_test.C \
-                      unit/rayfireAMR_test.C
+                      unit/rayfireAMR_test.C \
+                      unit/integrated_function_test.C
 
 antioch_mixture_SOURCES = unit/antioch_mixture.C
 arrhenius_catalycity_SOURCES = unit/arrhenius_catalycity.C

--- a/test/common/regression_helper.h
+++ b/test/common/regression_helper.h
@@ -1,0 +1,139 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_REGRESSION_HELPER_H
+#define GRINS_REGRESSION_HELPER_H
+
+// C++
+#include <limits>
+
+// libMesh
+#include "libmesh/libmesh_common.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+
+  #include <cppunit/extensions/HelperMacros.h>
+
+#endif // GRINS_HAVE_CPPUNIT
+
+
+namespace GRINSTesting
+{
+  //! Provides helper functions for fitting data to a curve.
+  //!
+  //! Currently supports linear regression \f$ Y = m X + b \f$
+  class RegressionHelper
+  {
+  protected:
+
+  //! Slope \f$ m \f$ for linear regression
+  libMesh::Real linear_slope(std::vector<libMesh::Real> x, std::vector<libMesh::Real> y, unsigned int start_index, unsigned int end_index)
+    {
+      libmesh_assert(x.size() == y.size());
+      libmesh_assert(start_index < end_index);
+          
+      unsigned int n = x.size(); 
+      libmesh_assert(end_index < n);
+          
+      libMesh::Real sum_y = 0.0,
+                    sum_x2 = 0.0,
+                    sum_x = 0.0,
+                    sum_xy = 0.0;
+      
+      for (unsigned int i=start_index; i<=end_index; i++)
+        {
+          libMesh::Real xi = x[i];
+          libMesh::Real yi = y[i];
+          
+          sum_y  += yi;
+          sum_x2 += xi*xi;
+          sum_x  += xi;
+          sum_xy += xi*yi;
+        }
+      
+       
+      libMesh::Real slope = ( n*sum_xy - sum_x*sum_y )/( n*sum_x2 - (sum_x*sum_x) );
+      return slope;
+    }
+
+  //! y-intercept \f$ b \f$ for linear regression  
+  libMesh::Real linear_intercept(std::vector<libMesh::Real> x, std::vector<libMesh::Real> y, unsigned int start_index, unsigned int end_index)
+    {
+      libmesh_assert(x.size() == y.size());
+      libmesh_assert(start_index < end_index);
+          
+      unsigned int n = x.size(); 
+      libmesh_assert(end_index < n);
+          
+      libMesh::Real sum_y = 0.0,
+                    sum_x2 = 0.0,
+                    sum_x = 0.0,
+                    sum_xy = 0.0;
+      
+      for (unsigned int i=start_index; i<=end_index; i++)
+        {
+          libMesh::Real xi = x[i];
+          libMesh::Real yi = y[i];
+          
+          sum_y  += yi;
+          sum_x2 += xi*xi;
+          sum_x  += xi;
+          sum_xy += xi*yi;
+        }
+      
+      libMesh::Real intercept = ( sum_y*sum_x2 - sum_x*sum_xy )/( n*sum_x2 - (sum_x*sum_x) );
+      return intercept;
+    }
+
+  //! Check the convergence rate of the supplied data to within the given absolute tolerance
+  void check_convergence_rate(std::vector<libMesh::Real> x, std::vector<libMesh::Real> y, unsigned int start_index, unsigned int end_index, libMesh::Real convergence_rate, libMesh::Real tol)
+    {
+      libmesh_assert(tol > 0.0);
+      libmesh_assert(x.size() == y.size());
+      libmesh_assert(start_index < end_index);
+      libmesh_assert(end_index < x.size());
+      
+      libMesh::Real calculated_rate = linear_slope(x,y,start_index,end_index);
+      
+#ifdef GRINS_HAVE_CPPUNIT
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(convergence_rate,calculated_rate,tol);
+#else
+      if (std::abs(convergence_rate - calculated_rate) > tol)
+        {
+          std::stringstream ss;
+          ss <<"ERROR" <<std::endl
+             <<"calculated convergence rate: " <<calculated_rate <<std::endl
+             <<"desired convergence rate: " <<convergence_rate <<std::endl
+             <<"tolerance: " <<tol <<std::endl;
+
+          libmesh_error_msg(ss.str());
+        }
+#endif // GRINS_HAVE_CPPUNIT
+    }
+
+  };
+}
+
+#endif // GRINS_REGRESSION_HELPER_H

--- a/test/unit/input_files/integrated_function_qoi_quad9.in
+++ b/test/unit/input_files/integrated_function_qoi_quad9.in
@@ -1,0 +1,94 @@
+# Materials
+[Materials]
+   [./TestMaterial]
+      [./ThermalConductivity]
+          model = 'constant'
+          value = '1.0'
+      [../Density]
+         value = '1.0'
+      [../SpecificHeat]
+         model = 'constant'
+         value = '1.0'
+[]
+
+# Options related to all Physics
+[Physics]
+
+   enabled_physics = 'HeatConduction'
+
+   [./HeatConduction]
+
+      material = 'TestMaterial'
+[]
+
+[BoundaryConditions]
+
+   bc_ids = '0 1:2:3'
+   bc_id_name_map = 'Dirichlet Neumann'
+
+   [./Dirichlet]
+      [./Temperature]
+         type = 'parsed_dirichlet'
+         T = '0.0'
+      [../]
+   [../]
+
+   [./Neumann]
+      [./Temperature]
+         type = 'adiabatic'
+      [../]
+   [../]
+
+[]
+
+
+[Variables]
+   [./Temperature]
+      names = 'T'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+[]
+
+# Mesh related options
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      n_elems_x = '10'
+      n_elems_y = '10'
+      x_min = '0.0'
+      x_max = '10.0'
+      y_min = '0.0'
+      y_max = '10.0'
+      element_type = 'QUAD9'
+[]
+
+[QoI]
+
+  enabled_qois = 'integrated_function'
+
+  [./IntegratedFunction]
+
+    function = '(4/3)*(x^3)+10'
+    quadrature_level = '3'
+
+    [./Rayfire]
+      origin = '0.0 2.5'
+      theta = '0.25'
+    [../]
+  [../]
+
+[]
+
+#Linear and nonlinear solver options
+[linear-nonlinear-solver]
+   max_nonlinear_iterations =  25
+   max_linear_iterations = 2500
+   relative_residual_tolerance = '1.0e-14'
+   relative_step_tolerance = '1.0e-12'
+[]
+
+# Options for print info to the screen
+[screen-options]
+   print_qoi = 'true'
+   print_mesh_info = 'true'
+[]

--- a/test/unit/input_files/integrated_function_quad9.in
+++ b/test/unit/input_files/integrated_function_quad9.in
@@ -1,0 +1,88 @@
+# Materials
+[Materials]
+   [./TestMaterial]
+      [./ThermalConductivity]
+          model = 'constant'
+          value = '1.0'
+      [../Density]
+         value = '1.0'
+      [../SpecificHeat]
+         model = 'constant'
+         value = '1.0'
+[]
+
+# Options related to all Physics
+[Physics]
+
+   enabled_physics = 'HeatConduction'
+
+   [./HeatConduction]
+
+      material = 'TestMaterial'
+[]
+
+[BoundaryConditions]
+
+   bc_ids = '0 1:2:3'
+   bc_id_name_map = 'Dirichlet Neumann'
+
+   [./Dirichlet]
+      [./Temperature]
+         type = 'parsed_dirichlet'
+         T = '0.0'
+      [../]
+   [../]
+
+   [./Neumann]
+      [./Temperature]
+         type = 'adiabatic'
+      [../]
+   [../]
+
+[]
+
+
+[Variables]
+   [./Temperature]
+      names = 'T'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+[]
+
+# Mesh related options
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      n_elems_x = '3'
+      n_elems_y = '3'
+      x_min = '0.0'
+      x_max = '3.0'
+      y_min = '0.0'
+      y_max = '3.0'
+      element_type = 'QUAD9'
+[]
+
+#Linear and nonlinear solver options
+[linear-nonlinear-solver]
+   max_nonlinear_iterations =  25
+   max_linear_iterations = 2500
+   relative_residual_tolerance = '1.0e-14'
+   relative_step_tolerance = '1.0e-12'
+[]
+
+# Visualization options
+[vis-options]
+   output_vis = false
+   vis_output_file_prefix = 'laplace'
+   output_format = 'ExodusII xdr'
+[]
+
+# Options for print info to the screen
+[screen-options]
+   system_name = 'Laplace'
+   print_equation_system_info = 'true'
+   print_mesh_info = 'true'
+   print_log_info = 'true'
+   solver_verbose = 'true'
+   solver_quiet = 'false'
+[]

--- a/test/unit/integrated_function_test.C
+++ b/test/unit/integrated_function_test.C
@@ -1,0 +1,313 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include "test_comm.h"
+#include "grins_test_paths.h"
+#include "regression_helper.h"
+
+// GRINS
+#include "grins/math_constants.h"
+#include "grins/grins_enums.h"
+#include "grins/integrated_function.h"
+#include "grins/composite_qoi.h"
+#include "grins/simulation_builder.h"
+#include "grins/simulation.h"
+#include "grins/variable_warehouse.h"
+
+// libMesh
+#include "libmesh/parsed_function.h"
+#include "libmesh/qoi_set.h"
+#include "libmesh/steady_solver.h"
+#include "libmesh/mesh_refinement.h"
+#include "libmesh/elem.h"
+
+namespace GRINSTesting
+{
+  class IntegratedFunctionTest : public CppUnit::TestCase,
+                                 public RegressionHelper
+  {
+  public:
+    CPPUNIT_TEST_SUITE( IntegratedFunctionTest );
+
+    CPPUNIT_TEST( test_exact_answer );
+    CPPUNIT_TEST( test_convergence );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+
+    void tearDown()
+      {
+        // Clear out the VariableWarehouse so it doesn't interfere with other tests.
+        GRINS::GRINSPrivate::VariableWarehouse::clear();
+      }
+
+    //! Functions that can be integrated exactly using Gauss Quadrature
+    void test_exact_answer()
+    {
+      const std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/integrated_function_quad9.in";
+      this->init_sim(filename);
+
+      libMesh::Point origin(0.0,0.0);
+
+      // angles for rayfire
+      std::vector<libMesh::Real> theta;
+      theta.push_back(0.0);
+      theta.push_back(0.25);
+
+      for (unsigned int t=0; t<theta.size(); t++)
+        {
+          libMesh::Real L = 3.0/std::cos(theta[t]);
+          libMesh::Real sintheta = std::sin(theta[t]);
+          libMesh::Real costheta = std::cos(theta[t]);
+
+          std::vector<std::string> functions;
+          std::vector<libMesh::Real> calc_answers;
+
+          // constant
+          functions.push_back("1");
+          calc_answers.push_back(L);
+
+          // linear
+          functions.push_back("x");
+          calc_answers.push_back(0.5/costheta*3.0*3.0);
+          functions.push_back("y");
+          calc_answers.push_back( sintheta/2.0*L*L );
+
+          // polynomial
+          functions.push_back("x*(y^2)");
+          calc_answers.push_back(0.25*std::pow(L,4)*std::pow(sintheta,2)*costheta);
+          functions.push_back("(4/3)*(x^3)+10");
+          calc_answers.push_back( (4.0/12.0)*pow(costheta,3)*std::pow(L,4)+10*L );
+
+          GRINS::MultiphysicsSystem* system = _sim->get_multiphysics_system();
+
+          // build rayfire
+          GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta[t]);
+
+          CPPUNIT_ASSERT_EQUAL(functions.size(), calc_answers.size());
+
+          // and now the CompositeQoI to do the evalutaion
+          GRINS::CompositeQoI comp_qoi;
+
+          for (unsigned int i=0; i<functions.size(); i++)
+            {
+              GRINS::IntegratedFunction<libMesh::FunctionBase<libMesh::Real> > integ_func((unsigned int)2,new libMesh::ParsedFunction<libMesh::Real>(functions[i]),rayfire,"integrated_function");
+              comp_qoi.add_qoi(integ_func);
+            }
+
+          comp_qoi.init(*_input,*system);
+          system->attach_qoi(&comp_qoi);
+          system->assemble_qoi();
+
+          for (unsigned int i=0; i<calc_answers.size(); i++)
+              CPPUNIT_ASSERT_DOUBLES_EQUAL( calc_answers[i], _sim->get_qoi_value(i),libMesh::TOLERANCE  );
+
+        } // for t
+    }
+
+    //! These functions cannot be integrated exactly wih Gauss Quadrature,
+    //! and so we look for quartic convergence to the analytical solution
+    /*!
+        A quartic convergence rate is identified by graphing log(error) vs. log(h),
+        where h is the length of the longest rayfire elem.
+        Linear regression is then used to fit a line to that data.
+        For quartic convergence, this line should have a slope of 4.
+        A 2% tolerance for the slope value is allowed in order to keep
+        the test runtime from becoming excessive.
+    */
+    void test_convergence()
+    {
+      const std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/integrated_function_quad9.in";
+      this->init_sim(filename);
+
+      libMesh::Point origin(0.0,0.0);
+
+      // angles for rayfire
+      std::vector<libMesh::Real> theta;
+      theta.push_back(0.0);
+      theta.push_back(0.25);
+
+      for (unsigned int t=0; t<theta.size(); t++)
+        {
+          libMesh::Real costheta = std::cos(theta[t]);
+          libMesh::Real sintheta = std::sin(theta[t]);
+          libMesh::Real L = 3.0/costheta;
+
+          std::vector<std::string> functions; // parsed functions
+          std::vector<libMesh::Real> calc_answers; // analytical solutions
+          std::vector<libMesh::Real> tolerance; // absolute error tolerance
+          std::vector<bool> converged;
+
+          // trig
+          functions.push_back("sin(x)+cos(y)");
+
+          if (theta[t] == 0.0)
+            calc_answers.push_back( L-std::cos(L)+1.0 );
+          else
+            calc_answers.push_back( ( (std::sin(L*sintheta))/sintheta ) - ( (std::cos(L*costheta)-1.0)/costheta ) );
+
+          tolerance.push_back(1e-9);
+          converged.push_back(false);
+
+          // exponential
+          functions.push_back("exp(x)");
+          calc_answers.push_back( (std::exp(3.0) - 1.0) / costheta);
+          tolerance.push_back(1e-8);
+          converged.push_back(false);
+
+          std::vector<std::vector<libMesh::Real> > errors(functions.size());
+          std::vector<std::vector<libMesh::Real> > h_vals(functions.size());
+
+          GRINS::MultiphysicsSystem* system = _sim->get_multiphysics_system();
+          GRINS::SharedPtr<libMesh::EquationSystems> es = _sim->get_equation_system();
+
+          // build rayfire
+          GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta[t]);
+
+          CPPUNIT_ASSERT_EQUAL(functions.size(), calc_answers.size());
+
+          // and now the CompositeQoI to do the evalutaion
+          GRINS::CompositeQoI comp_qoi;
+
+          for (unsigned int i=0; i<functions.size(); i++)
+            {
+              GRINS::IntegratedFunction<libMesh::FunctionBase<libMesh::Real> > integ_func((unsigned int)3,new libMesh::ParsedFunction<libMesh::Real>(functions[i]),rayfire,"integrated_function");
+              comp_qoi.add_qoi(integ_func);
+            }
+
+          comp_qoi.init(*_input,*system);
+          system->attach_qoi(&comp_qoi);
+
+          libMesh::MeshRefinement mr(system->get_mesh());
+
+          unsigned int num_converged = 0;
+          unsigned int iter = 0;
+
+          // limit iterations to prevent excessive runtime
+          unsigned int max_iter = 7;
+
+          // calculate qoi's, check error
+          // refine until all qoi's converge within their tolerance
+          do
+            {
+              std::vector<libMesh::dof_id_type> elems_in_rayfire;
+              rayfire->elem_ids_in_rayfire(elems_in_rayfire);
+
+              system->assemble_qoi();
+
+              // get the length of the longest rayfire elem
+              libMesh::Real h = -1.0;
+              for (unsigned int i=0; i<elems_in_rayfire.size(); i++)
+                {
+                  libMesh::Real l = (rayfire->map_to_rayfire_elem(elems_in_rayfire[i]))->length(0,1);
+                  if (l>h)
+                      h=l;
+                }
+
+              CPPUNIT_ASSERT(h > 0.0);
+
+              // check for convergence
+              for (unsigned int i=0; i<calc_answers.size(); i++)
+                {
+                  if (!converged[i])
+                    {
+                      libMesh::Real err = std::abs( _sim->get_qoi_value(i) - calc_answers[i] );
+                      if (err < tolerance[i])
+                        {
+                          num_converged++;
+                          converged[i] = true;
+                          h_vals[i].push_back(std::log10(h));
+                          errors[i].push_back(std::log10(err));
+                        }
+                      else
+                        {
+                          h_vals[i].push_back(std::log10(h));
+                          errors[i].push_back(std::log10(err));
+                        }
+                    }
+                }
+
+              // if all functions have not yet converged, refine along the rayfire
+              if (num_converged < calc_answers.size())
+                {
+                  if (iter++ > max_iter+1 )
+                    libmesh_error_msg("Exceeded maximum iterations");
+
+                  for (unsigned int i=0; i<elems_in_rayfire.size(); i++)
+                    system->get_mesh().elem(elems_in_rayfire[i])->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+
+                  mr.refine_elements();
+
+                  // ensure all elems marked for refinement were actually refined
+                  for (unsigned int i=0; i<elems_in_rayfire.size(); i++)
+                    CPPUNIT_ASSERT( !( system->get_mesh().elem(elems_in_rayfire[i])->active() ) );
+
+                  // post-refinement reinit
+                  rayfire->reinit(system->get_mesh());
+                  es->reinit();
+                }
+
+            } while(num_converged < calc_answers.size());
+
+            // verify that all functions had quartic convergence within 2%
+            for (unsigned int i=0; i<functions.size(); i++)
+                this->check_convergence_rate(h_vals[i],errors[i],0,errors[i].size()-1,4.0,0.08);
+
+        } //for t
+    }
+
+  private:
+    GRINS::SharedPtr<GRINS::Simulation> _sim;
+    GRINS::SharedPtr<GetPot> _input;
+
+    //! Initialize the GetPot and Simulation class objects
+    void init_sim(const std::string& filename)
+    {
+      _input.reset(new GetPot(filename));
+
+      const char* const argv = "unit_driver";
+      GetPot empty_command_line( (const int)1,&argv );
+      GRINS::SimulationBuilder sim_builder;
+
+      _sim = new GRINS::Simulation(*_input,
+                                    empty_command_line,
+                                    sim_builder,
+                                   *TestCommWorld );
+    }
+
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( IntegratedFunctionTest );
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_CPPUNIT

--- a/test/unit/integrated_function_test.C
+++ b/test/unit/integrated_function_test.C
@@ -59,6 +59,7 @@ namespace GRINSTesting
 
     CPPUNIT_TEST( test_exact_answer );
     CPPUNIT_TEST( test_convergence );
+    CPPUNIT_TEST( qoi_from_input_file );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -284,6 +285,27 @@ namespace GRINSTesting
 
         } //for t
     }
+
+    //! Tests that an IntegratedFunction can be initialized and computed
+    //! directly from the input file
+    void qoi_from_input_file()
+    {
+      const std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/integrated_function_qoi_quad9.in";
+      this->init_sim(filename);
+
+      libMesh::Real theta = 0.25;
+      libMesh::Real L = 10.0/std::cos(theta);
+      libMesh::Real costheta = std::cos(theta);
+
+      // function: "(4/3)*(x^3)+10"
+
+      libMesh::Real calc_answer = (4.0/12.0)*pow(costheta,3)*std::pow(L,4)+10*L;
+
+      _sim->run();
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( calc_answer, _sim->get_qoi_value(0),libMesh::TOLERANCE  );
+    }
+
 
   private:
     GRINS::SharedPtr<GRINS::Simulation> _sim;


### PR DESCRIPTION
The `IntegratedFunction` class builds upon `RayfireMesh` to evaluate a given function along a 1D rayfire. Integration is done with Gauss Quadrature (`QGauss`).

The template parameter can be `FunctionBase` or `FEMFunctionBase`, depending on whether or not the `context` is needed to evaluate the function. An object of the templated type is then passed in to the constructor, and will be used to evaluate the function at the given quadrature points along the rayfire.

`IntegratedFunction` was then added to the `QoIFactory`, which allows us to run everything directly from an input file. User adds a `[QoI]` section with `integrated_function`, and must specify:

1. Rayfire origin coordinates (currently restricted to 2D)
2. Rayfire polar angle, theta
3. Function to be evaluated
4. Quadrature order (default order is 2 if omitted)

`element_qoi_derivative()` is currently not implemented, as there are no readily-available hooks in the templated classes for derivative evaluation. This will be addressed in an upcoming PR.

Also, mesh refinement through the input file is not yet supported, but will be in a future PR.
However, the convergence test in `integrated_function_test` does refinement manually, so the functionality is there and works, just not yet integrated with the refinement using an input file.

The first 2 commits address Valgrind complaints.

`make check` passes on GCC 6.1 in dbg, devel, and opt