### PR TITLE
Rayfire start_elem fix

### DIFF
--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -163,6 +163,16 @@ namespace GRINS
     //! Ensure the supplied origin is on a boundary of the mesh
     void check_origin_on_boundary(const libMesh::Elem* start_elem);
 
+    //! Get the correct starting elem corresponding to _origin
+    /*!
+    @return NULL Origin is not on the mesh
+    @return Elem* First elem on the rayfire
+    */
+    const libMesh::Elem* get_start_elem(const libMesh::MeshBase& mesh_base);
+
+    //! Walks a short distance along the rayfire and checks if elem contains that point
+    bool rayfire_in_elem(const libMesh::Point& end_point, const libMesh::Elem* elem);
+
     //! Iterative solver for calculating the intersection point of the rayfire on the side of an elem
     /*!
     The rayfire line can be represented in point-slope form:

--- a/test/unit/rayfire_test.C
+++ b/test/unit/rayfire_test.C
@@ -62,6 +62,7 @@ namespace GRINSTesting
     CPPUNIT_TEST( test_quad4_2D );
     CPPUNIT_TEST( test_quad9_2D );
     CPPUNIT_TEST( fire_through_vertex );
+    CPPUNIT_TEST( origin_between_elems );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -95,7 +96,6 @@ namespace GRINSTesting
       run_test_on_all_point_combinations(pts,mesh);
 
     }
-
 
     void quad9_all_sides()
     {
@@ -254,8 +254,6 @@ namespace GRINSTesting
       this->run_test(origin,-1.0,calc_end_node_large_neg_angle,9,0,"quad9",2);
     }
 
-
-
     void fire_through_vertex()
     {
       libMesh::Point origin = libMesh::Point(0.0,0.0);
@@ -269,6 +267,15 @@ namespace GRINSTesting
       this->run_test(origin,45.0*GRINS::Constants::pi/180.0,calc_end_node_straight,9,8,"quad9",2);
     }
 
+    void origin_between_elems()
+    {
+      libMesh::Point origin = libMesh::Point(0.0,1.0);
+      libMesh::Node calc_end_node = libMesh::Node(3.0,3.0);
+      libMesh::Real theta = calc_theta(origin,calc_end_node);
+
+      this->run_test(origin,theta,calc_end_node,9,8,"quad4",2);
+      this->run_test(origin,theta,calc_end_node,9,8,"quad9",2);
+    }
 
 
   private:


### PR DESCRIPTION
The `libMesh::PointLocatorBase` is used to find the elem of the mesh that contains the `origin` point of the rayfire.

However, the `PLB` returns the first elem it finds that contains the given `origin` point. When the origin is on an elem boundary, then multiple elems contain that point. Since PLB only returns the first elem it finds, it may not be the correct `start_elem` for the rayfire.

An additional check is added to find the correct starting elem. We walk a short distance along the rayfire, and check if we are still within the elem returned from the `PLB`. If not, then we do the same check with all neighbors of that elem to determine if any of them are along the rayfire. Since the origin must be on a mesh boundary, only the elem from the `PLB` and its neighbors would be valid possibilities for being the `start_elem`.

The added `CPPUnit` test demonstrates the issue, and verifies that the bugfix works correctly.

`make check` passes with `GCC 6.1` with `dbg` & `devel`