### PR TITLE
Update suspended_cable_test options

### DIFF
--- a/test/regression/suspended_cable_test.sh
+++ b/test/regression/suspended_cable_test.sh
@@ -5,6 +5,6 @@ PROG="${GRINS_TEST_DIR}/generic_solution_regression"
 INPUT="${GRINS_TEST_INPUT_DIR}/suspended_cable_test.in"
 DATA="${GRINS_TEST_DATA_DIR}/suspended_cable_test.xdr"
 
-PETSC_OPTIONS="-ksp_type cg -pc_type bjacobi -sub_pc_type icc -sub_pc_factor_shift_type nonzero -ksp_converged_reason"
+PETSC_OPTIONS="-ksp_type gmres -pc_type bjacobi -sub_pc_type lu -sub_pc_factor_shift_type nonzero -ksp_converged_reason"
 
 ${LIBMESH_RUN:-} $PROG input=$INPUT soln-data=$DATA vars='Ux Uy' norms='L2 H1' tol='1.0e-10' $PETSC_OPTIONS


### PR DESCRIPTION
Cholesky sub_pc is not robust in parallel as the PC dies due
to indefiniteness using pc bjacobi. So, be gross and just use
GMRES with LU. This runs on 1-16 processors for me.

Fixes #447 and I think replaces #452. @roystgnr please confirm and sorry I didn't do this sooner.