### PR TITLE
Update QoI Output and Corresponding Options

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -199,6 +199,7 @@ libgrins_la_SOURCES += qoi/src/parsed_interior_qoi.C
 libgrins_la_SOURCES += qoi/src/weighted_flux_qoi.C
 libgrins_la_SOURCES += qoi/src/rayfire_mesh.C
 libgrins_la_SOURCES += qoi/src/integrated_function.C
+libgrins_la_SOURCES += qoi/src/qoi_output.C
 
 # src/solver files
 libgrins_la_SOURCES += solver/src/grins_solver.C
@@ -472,6 +473,7 @@ include_HEADERS += qoi/include/grins/parsed_interior_qoi.h
 include_HEADERS += qoi/include/grins/weighted_flux_qoi.h
 include_HEADERS += qoi/include/grins/rayfire_mesh.h
 include_HEADERS += qoi/include/grins/integrated_function.h
+include_HEADERS += qoi/include/grins/qoi_output.h
 include_HEADERS += qoi/include/grins/qoi_options.h
 
 # src/solver headers

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -525,6 +525,7 @@ include_HEADERS += utilities/include/grins/cached_quantities_enum.h
 include_HEADERS += utilities/include/grins/string_utils.h
 include_HEADERS += utilities/include/grins/distance_function.h
 include_HEADERS += utilities/include/grins/parameter_antioch_reset.h
+include_HEADERS += utilities/include/grins/output_parsing.h
 
 # src/visualization headers
 include_HEADERS += visualization/include/grins/steady_visualization.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -472,6 +472,7 @@ include_HEADERS += qoi/include/grins/parsed_interior_qoi.h
 include_HEADERS += qoi/include/grins/weighted_flux_qoi.h
 include_HEADERS += qoi/include/grins/rayfire_mesh.h
 include_HEADERS += qoi/include/grins/integrated_function.h
+include_HEADERS += qoi/include/grins/qoi_options.h
 
 # src/solver headers
 include_HEADERS += solver/include/grins/grins_solver.h

--- a/src/qoi/include/grins/qoi_base.h
+++ b/src/qoi/include/grins/qoi_base.h
@@ -51,7 +51,7 @@ namespace GRINS
 
     QoIBase( const std::string& qoi_name );
 
-    virtual ~QoIBase();
+    virtual ~QoIBase(){}
 
     //! Clone this QoI
     /*!
@@ -72,30 +72,30 @@ namespace GRINS
      * Method to allow QoI to cache any system information needed for QoI calculation,
      * for example, solution variable indices.
      */
-    virtual void init( const GetPot& input,
-                       const MultiphysicsSystem& system,
-                       unsigned int qoi_num );
+    virtual void init( const GetPot& /*input*/,
+                       const MultiphysicsSystem & /*system*/,
+                       unsigned int /*qoi_num*/ ){}
 
-    virtual void init_context( AssemblyContext& context );
+    virtual void init_context( AssemblyContext& /*context*/ ){}
 
     //! Compute the qoi value for element interiors.
     /*! Override this method if your QoI is defined on element interiors */
-    virtual void element_qoi( AssemblyContext& context,
-                              const unsigned int qoi_index );
+    virtual void element_qoi( AssemblyContext& /*context*/,
+                              const unsigned int /*qoi_index*/ ){}
 
     //! Compute the qoi derivative with respect to the solution on element interiors.
     /*! Override this method if your QoI is defined on element interiors */
-    virtual void element_qoi_derivative( AssemblyContext &context,
-                                         const unsigned int qoi_index );
+    virtual void element_qoi_derivative( AssemblyContext & /*context*/,
+                                         const unsigned int /*qoi_index*/ ){}
 
     //! Compute the qoi value on the domain boundary
     /*! Override this method if your QoI is defined on the domain boundary */
-    virtual void side_qoi( AssemblyContext& context, const unsigned int qoi_index );
+    virtual void side_qoi( AssemblyContext & /*context*/, const unsigned int /*qoi_index*/ ){}
 
     //! Compute the qoi derivative with respect to the solution on the domain boundary
     /*! Override this method if your QoI is defined on the domain boundary */
-    virtual void side_qoi_derivative( AssemblyContext& context,
-                                      const unsigned int qoi_index );
+    virtual void side_qoi_derivative( AssemblyContext & /*context*/,
+                                      const unsigned int /*qoi_index*/ ){}
 
     //! Call the parallel operation for this QoI and cache the value.
     /*!

--- a/src/qoi/include/grins/qoi_options.h
+++ b/src/qoi/include/grins/qoi_options.h
@@ -40,8 +40,8 @@ namespace GRINS
     static const std::string output_to_display()
     { return "print_qoi"; }
 
-    static const std::string file_prefix()
-    { return "file_prefix"; }
+    static const std::string default_file_prefix()
+    { return "default_file_prefix"; }
   };
 } // end namespace GRINS
 

--- a/src/qoi/include/grins/qoi_options.h
+++ b/src/qoi/include/grins/qoi_options.h
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_QOI_OPTIONS_H
+#define GRINS_QOI_OPTIONS_H
+
+// GRINS
+#include "grins/output_parsing.h"
+
+namespace GRINS
+{
+  class QoIOptions
+  {
+  public:
+
+    static const std::string qoi_section()
+    { return "QoI"; }
+
+    static const std::string output_to_display()
+    { return "print_qoi"; }
+
+    static const std::string file_prefix()
+    { return "file_prefix"; }
+  };
+} // end namespace GRINS
+
+#endif // GRINS_QOI_OPTIONS_H

--- a/src/qoi/include/grins/qoi_output.h
+++ b/src/qoi/include/grins/qoi_output.h
@@ -1,0 +1,83 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_QOI_OUTPUT_H
+#define GRINS_QOI_OUTPUT_H
+
+#include <string>
+
+// libMesh forward declarations
+class GetPot;
+namespace libMesh
+{
+  namespace Parallel
+  {
+    class Communicator;
+  }
+}
+
+namespace GRINS
+{
+  // Forward declarations
+  class CompositeQoI;
+
+  //! Encapsulate QoI output flags and functionality
+  /*! This class handles both the parsing of the options for triggering
+      QoI output and implements the functionality for outputting the QoIs
+      (which is really just a wrapper around calling output from QoI classes).
+      Currently, the user can enable printing the QoI info to the display
+      (std::cout) and to a file by specifing the filename in the corresponding
+      input option. */
+  class QoIOutput
+  {
+  public:
+
+    QoIOutput( const GetPot & input );
+
+    ~QoIOutput(){}
+
+    //! Function to query whether any input options set to output qoi
+    /*! Returns true if user requested to output QoI in any one of the avaiable
+        modes, false otherwise. */
+    bool output_qoi_set() const
+    { return (_output_to_display || _output_to_file ); }
+
+    //! Output the QoI values for all triggered output modes
+    /*! This function assumes that the qoi values have been assembled by
+        the System. */
+    void output_qois( const CompositeQoI & qois, const libMesh::Parallel::Communicator & comm ) const;
+
+  protected:
+
+    bool _output_to_display;
+
+    bool _output_to_file;
+
+    std::string _file_prefix;
+
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_QOI_OUTPUT_H

--- a/src/qoi/src/qoi_base.C
+++ b/src/qoi/src/qoi_base.C
@@ -107,14 +107,10 @@ namespace GRINS
 
   void QoIBase::output_qoi( std::ostream& out ) const
   {
-    out << "==========================================================" << std::endl;
-
     out << _qoi_name+" = "
         << std::setprecision(16)
         << std::scientific
         << _qoi_value << std::endl;
-
-    out << "==========================================================" << std::endl;
 
     return;
   }

--- a/src/qoi/src/qoi_base.C
+++ b/src/qoi/src/qoi_base.C
@@ -40,50 +40,7 @@ namespace GRINS
     : ParameterUser(qoi_name),
       _qoi_name(qoi_name),
       _qoi_value(0.0)
-  {
-    return;
-  }
-
-  QoIBase::~QoIBase()
-  {
-    return;
-  }
-
-  void QoIBase::init
-    (const GetPot& /*input*/,
-     const MultiphysicsSystem& /*system*/,
-     unsigned int /*qoi_num*/ )
-  {
-  }
-
-  void QoIBase::init_context( AssemblyContext& /*context*/ )
-  {
-    return;
-  }
-
-  void QoIBase::element_qoi( AssemblyContext& /*context*/,
-                             const unsigned int /*qoi_index*/ )
-  {
-    return;
-  }
-
-  void QoIBase::element_qoi_derivative( AssemblyContext& /*context*/,
-                                        const unsigned int /*qoi_index*/ )
-  {
-    return;
-  }
-
-  void QoIBase::side_qoi( AssemblyContext& /*context*/,
-                          const unsigned int /*qoi_index*/ )
-  {
-    return;
-  }
-
-  void QoIBase::side_qoi_derivative( AssemblyContext& /*context*/,
-                                     const unsigned int /*qoi_index*/ )
-  {
-    return;
-  }
+  {}
 
   void QoIBase::parallel_op( const libMesh::Parallel::Communicator& communicator,
                              libMesh::Number& sys_qoi,
@@ -94,15 +51,11 @@ namespace GRINS
     sys_qoi = local_qoi;
 
     _qoi_value = sys_qoi;
-
-    return;
   }
 
   void QoIBase::thread_join( libMesh::Number& qoi, const libMesh::Number& other_qoi )
   {
     qoi += other_qoi;
-
-    return;
   }
 
   void QoIBase::output_qoi( std::ostream& out ) const
@@ -111,8 +64,6 @@ namespace GRINS
         << std::setprecision(16)
         << std::scientific
         << _qoi_value << std::endl;
-
-    return;
   }
-  
+
 } // namespace GRINS

--- a/src/qoi/src/qoi_output.C
+++ b/src/qoi/src/qoi_output.C
@@ -42,8 +42,8 @@ namespace GRINS
 {
   QoIOutput::QoIOutput( const GetPot & input )
     : _output_to_display( input(OutputParsing::output_section()+"/"+OutputParsing::display_section()+"/"+QoIOptions::output_to_display(), false) ),
-      _output_to_file( input.have_variable(OutputParsing::output_section()+"/"+QoIOptions::qoi_section()+"/"+QoIOptions::file_prefix()) ),
-      _file_prefix( input(OutputParsing::output_section()+"/"+QoIOptions::qoi_section()+"/"+QoIOptions::file_prefix(), "nofile") )
+      _output_to_file( input.have_variable(OutputParsing::output_section()+"/"+QoIOptions::qoi_section()+"/"+QoIOptions::default_file_prefix()) ),
+      _file_prefix( input(OutputParsing::output_section()+"/"+QoIOptions::qoi_section()+"/"+QoIOptions::default_file_prefix(), "nofile") )
   {
     if( input.have_variable("screen-options/print_qoi") )
       {

--- a/src/qoi/src/qoi_output.C
+++ b/src/qoi/src/qoi_output.C
@@ -1,0 +1,82 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/qoi_output.h"
+
+// GRINS
+#include "grins/common.h"
+#include "grins/qoi_options.h"
+#include "grins/composite_qoi.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+
+// C++
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+namespace GRINS
+{
+  QoIOutput::QoIOutput( const GetPot & input )
+    : _output_to_display( input(OutputParsing::output_section()+"/"+OutputParsing::display_section()+"/"+QoIOptions::output_to_display(), false) ),
+      _output_to_file( input.have_variable(OutputParsing::output_section()+"/"+QoIOptions::qoi_section()+"/"+QoIOptions::file_prefix()) ),
+      _file_prefix( input(OutputParsing::output_section()+"/"+QoIOptions::qoi_section()+"/"+QoIOptions::file_prefix(), "nofile") )
+  {
+    if( input.have_variable("screen-options/print_qoi") )
+      {
+        std::string warning;
+        warning = "WARNING: Option screen-options/print_qoi is DEPRECATED!\n";
+        warning += "         Please update input to use ";
+        warning += OutputParsing::output_section()+"/"+OutputParsing::display_section()+"/"+QoIOptions::output_to_display()+"\n";
+        grins_warning(warning);
+
+        _output_to_display = input("screen-options/print_qoi", false);
+      }
+  }
+
+  void QoIOutput::output_qois( const CompositeQoI & qois, const libMesh::Parallel::Communicator & comm ) const
+  {
+    if( _output_to_display )
+      {
+        std::cout << "==========================================================" << std::endl;
+        qois.output_qoi( std::cout );
+        std::cout << "==========================================================" << std::endl;
+      }
+
+    if( _output_to_file )
+      {
+        if( comm.rank() == 0 )
+          {
+            std::ofstream output;
+            output.open( _file_prefix+".dat" );
+
+            qois.output_qoi(output);
+
+            output.close();
+          }
+      }
+  }
+} // end namespace GRINS

--- a/src/solver/include/grins/grins_solver.h
+++ b/src/solver/include/grins/grins_solver.h
@@ -87,7 +87,7 @@ namespace GRINS
 
     void print_scalar_vars( SolverContext& context );
 
-    void print_qoi( SolverContext& context, std::ostream& output );
+    void print_qoi( SolverContext& context );
 
   protected:
 

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -39,6 +39,7 @@
 #include "grins/parameter_manager.h"
 #include "grins/postprocessed_quantities.h"
 #include "grins/error_estimator_options.h"
+#include "grins/qoi_output.h"
 
 // libMesh
 #include "libmesh/error_estimator.h"
@@ -142,8 +143,10 @@ namespace GRINS
     bool _print_log_info;
     bool _print_equation_system_info;
     bool _print_perflog;
-    bool _print_qoi;
     bool _print_scalars;
+
+    // QoI output options and functionality
+    SharedPtr<QoIOutput> _qoi_output;
 
     // Visualization options
     bool _output_vis;

--- a/src/solver/include/grins/solver_context.h
+++ b/src/solver/include/grins/solver_context.h
@@ -32,6 +32,7 @@
 #include "grins/shared_ptr.h"
 #include "grins/visualization.h"
 #include "grins/postprocessed_quantities.h"
+#include "grins/qoi_output.h"
 
 // libMesh
 #include "libmesh/error_estimator.h"
@@ -66,8 +67,9 @@ namespace GRINS
     bool output_solution_sensitivities;
     bool print_perflog;
     bool print_scalars;
-    bool print_qoi;
     bool do_adjoint_solve;
+
+    SharedPtr<QoIOutput> qoi_output;
 
     SharedPtr<PostProcessedQuantities<libMesh::Real> > postprocessing;
 

--- a/src/solver/src/grins_solver.C
+++ b/src/solver/src/grins_solver.C
@@ -152,13 +152,11 @@ namespace GRINS
         }
   }
 
-  void Solver::print_qoi( SolverContext& context, std::ostream& output )
+  void Solver::print_qoi( SolverContext & context )
   {
     context.system->assemble_qoi();
     const CompositeQoI* my_qoi = libMesh::cast_ptr<const CompositeQoI*>(context.system->get_qoi());
-
-    my_qoi->output_qoi( output );
-    output << std::endl;
+    context.qoi_output->output_qois(*my_qoi, context.system->comm());
   }
 
 } // namespace GRINS

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -59,8 +59,8 @@ namespace GRINS
        _print_mesh_info( input("screen-options/print_mesh_info", false ) ),
        _print_log_info( input("screen-options/print_log_info", false ) ),
        _print_equation_system_info( input("screen-options/print_equation_system_info", false ) ),
-       _print_qoi( input("screen-options/print_qoi", false ) ),
        _print_scalars( input("screen-options/print_scalars", false ) ),
+       _qoi_output( new QoIOutput(input) ),
        _output_vis( input("vis-options/output_vis", false ) ),
        _output_adjoint( input("vis-options/output_adjoint", false ) ),
        _output_residual( input( "vis-options/output_residual", false ) ),
@@ -107,8 +107,8 @@ namespace GRINS
        _print_mesh_info( input("screen-options/print_mesh_info", false ) ),
        _print_log_info( input("screen-options/print_log_info", false ) ),
        _print_equation_system_info( input("screen-options/print_equation_system_info", false ) ),
-       _print_qoi( input("screen-options/print_qoi", false ) ),
        _print_scalars( input("screen-options/print_scalars", false ) ),
+       _qoi_output( new QoIOutput(input) ),
        _output_vis( input("vis-options/output_vis", false ) ),
        _output_adjoint( input("vis-options/output_adjoint", false ) ),
        _output_residual( input( "vis-options/output_residual", false ) ),
@@ -186,7 +186,7 @@ namespace GRINS
            it will be cloned in _multiphysics_system and all the calculations are done there. */
         _multiphysics_system->attach_qoi( qois.get() );
       }
-    else if (_print_qoi)
+    else if (_qoi_output->output_qoi_set())
       {
         std::cout << "Error: print_qoi is specified but\n" <<
           "no QoIs have been specified.\n" << std::endl;
@@ -341,7 +341,7 @@ namespace GRINS
     context.print_perflog = _print_log_info;
     context.postprocessing = _postprocessing;
     context.error_estimator = _error_estimator;
-    context.print_qoi = _print_qoi;
+    context.qoi_output = _qoi_output;
     context.do_adjoint_solve = _do_adjoint_solve;
     context.have_restart = _have_restart;
 
@@ -367,11 +367,11 @@ namespace GRINS
 
     _solver->solve( context );
 
-    if ( this->_print_qoi )
+    if (_qoi_output->output_qoi_set())
       {
         _multiphysics_system->assemble_qoi();
-        const CompositeQoI* my_qoi = libMesh::cast_ptr<const CompositeQoI*>(this->_multiphysics_system->get_qoi());
-        my_qoi->output_qoi( std::cout );
+        const CompositeQoI * my_qoi = libMesh::cast_ptr<const CompositeQoI*>(this->_multiphysics_system->get_qoi());
+        _qoi_output->output_qois(*my_qoi, this->_multiphysics_system->comm() );
       }
 
     if ( _adjoint_parameters.parameter_vector.size() )

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -151,8 +151,8 @@ namespace GRINS
 
                 // It's helpful to print the qoi along the way, but only do it if the user
                 // asks for it
-                if( context.print_qoi )
-                  this->print_qoi(context,std::cout);
+                if( context.qoi_output->output_qoi_set() )
+                  this->print_qoi(context);
               }
           }
 

--- a/src/solver/src/unsteady_mesh_adaptive_solver.C
+++ b/src/solver/src/unsteady_mesh_adaptive_solver.C
@@ -144,8 +144,8 @@ namespace GRINS
               << "==========================================================" << std::endl;
 
     // Print out the QoI, but only do it if the user asks for it
-    if( context.print_qoi )
-      this->print_qoi(context,std::cout);
+    if(context.qoi_output->output_qoi_set())
+      this->print_qoi(context);
   }
 
 } // namespace GRINS

--- a/src/utilities/include/grins/output_parsing.h
+++ b/src/utilities/include/grins/output_parsing.h
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_OUTPUT_PARSING_H
+#define GRINS_OUTPUT_PARSING_H
+
+#include <string>
+
+namespace GRINS
+{
+  //! Functions for naming input sections/variables related to output
+  class OutputParsing
+  {
+  public:
+
+    //! Outer output section in input file
+    static const std::string output_section()
+    { return "Output"; }
+
+    //! Displace section in input file
+    static const std::string display_section()
+    { return "Display"; }
+
+  };
+} // end namespace GRINS
+
+#endif // GRINS_OUTPUT_PARSING_H

--- a/test/input_files/3d_low_mach_jacobians_xy.in
+++ b/test/input_files/3d_low_mach_jacobians_xy.in
@@ -126,6 +126,12 @@ output_residual = 'false'
 
 output_format = 'ExodusII'
 
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]
+
 # Options for print info to the screen
 [screen-options]
 
@@ -137,8 +143,6 @@ print_log_info = true
 solver_verbose = true
 solver_quiet = false
 
-
-print_qoi = 'true'
 echo_qoi = 'true'
 
 print_element_jacobians = 'false'

--- a/test/input_files/3d_low_mach_jacobians_xz.in
+++ b/test/input_files/3d_low_mach_jacobians_xz.in
@@ -123,6 +123,12 @@ output_residual = 'false'
 
 output_format = 'ExodusII'
 
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]
+
 # Options for print info to the screen
 [screen-options]
 
@@ -134,8 +140,6 @@ print_log_info = true
 solver_verbose = true
 solver_quiet = false
 
-
-print_qoi = 'true'
 echo_qoi = 'true'
 
 print_element_jacobians = 'false'

--- a/test/input_files/3d_low_mach_jacobians_yz.in
+++ b/test/input_files/3d_low_mach_jacobians_yz.in
@@ -124,6 +124,14 @@ output_residual = 'false'
 
 output_format = 'ExodusII'
 
+[]
+
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]
+
 # Options for print info to the screen
 [screen-options]
 
@@ -135,8 +143,6 @@ print_log_info = true
 solver_verbose = true
 solver_quiet = false
 
-
-print_qoi = 'true'
 echo_qoi = 'true'
 
 print_element_jacobians = 'false'

--- a/test/input_files/extra_quadrature_order_laplace_arefee_amr_regression.in
+++ b/test/input_files/extra_quadrature_order_laplace_arefee_amr_regression.in
@@ -60,6 +60,12 @@
          value = '1.0'
 []
 
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]
+
 # Options for print info to the screen
 [screen-options]
    print_equation_system_info = 'true'
@@ -70,7 +76,6 @@
 
    echo_physics = 'true'
    echo_qoi = 'true' # which QoIs activated
-   print_qoi = 'true' # print numerical values of QoIs
 []
 
 [Physics]

--- a/test/input_files/low_mach_cavity_benchmark_regression_input.in
+++ b/test/input_files/low_mach_cavity_benchmark_regression_input.in
@@ -163,6 +163,14 @@ vis_output_file_prefix = 'cavity'
 output_residual = 'false'
 
 output_format = 'ExodusII xdr'
+[]
+
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]
+
 
 # Options for print info to the screen
 [screen-options]
@@ -175,8 +183,6 @@ print_log_info = true
 solver_verbose = true
 solver_quiet = false
 
-
-print_qoi = 'true'
 echo_qoi = 'true'
 
 print_element_jacobians = 'false'

--- a/test/input_files/parsed_qoi.in
+++ b/test/input_files/parsed_qoi.in
@@ -29,6 +29,12 @@ output_solution_sensitivities = 'false'
 vis_output_file_prefix = 'parsed_qoi_vis'
 output_format = 'ExodusII'
 
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]
+
 # Options for print info to the screen
 [screen-options]
 print_equation_system_info = 'false'
@@ -39,7 +45,6 @@ solver_quiet = 'true'
 
 echo_physics = 'true'
 echo_qoi = 'true' # which QoIs activated
-print_qoi = 'true' # print numerical values of QoIs
 
 [Materials]
    [./TestMaterial]

--- a/test/input_files/poisson_weighted_flux_regression.in
+++ b/test/input_files/poisson_weighted_flux_regression.in
@@ -105,13 +105,18 @@ weights = 'y*(1-y)' # This 'fixes' the spill
    output_format = 'ExodusII xdr'
 []
 
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]
+
 # Options for print info to the screen
 [screen-options]
    system_name = 'Laplace'
    print_equation_system_info = 'true'
    print_mesh_info = 'true'
    print_log_info = 'true'
-   print_qoi = 'true'
    solver_verbose = 'true'
    solver_quiet = 'false'
 []

--- a/test/input_files/vorticity_qoi.in
+++ b/test/input_files/vorticity_qoi.in
@@ -22,6 +22,13 @@ verify_analytic_jacobians = 1.e-6
 output_vis = 'false'
 vis_output_file_prefix = temp
 output_format = 'ExodusII'
+[]
+
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]
 
 # Options for print info to the screen
 [screen-options]
@@ -33,7 +40,6 @@ solver_quiet = 'true'
 
 echo_physics = 'true'
 echo_qoi = 'true' # which QoIs activated
-print_qoi = 'true' # print numerical values of QoIs
 []
 
 [Materials]

--- a/test/unit/input_files/integrated_function_qoi_quad9.in
+++ b/test/unit/input_files/integrated_function_qoi_quad9.in
@@ -87,8 +87,13 @@
    relative_step_tolerance = '1.0e-12'
 []
 
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]
+
 # Options for print info to the screen
 [screen-options]
-   print_qoi = 'true'
    print_mesh_info = 'true'
 []


### PR DESCRIPTION
Long overdue, this PR adds the capability to output the QoI(s) to a text file as well as the terminal. The `QoIOutput` class handles parsing the options and deciding what modes to output - the actual QoI printing is still delegated to the QoI.

This will be used in refactoring the regression tests so that, for those tests with a QoI, we can just read in the QoI text files output from the grins run and compare to the gold values. Thus, right now, only the `print_qoi` option is actually tested in the test suite, but I've manually verified the file output in the `sa_airfoil` example.

Implicit in here is starting down the resectioning of output options in the input; hence the new `OutputParsing` class. Right now only the `[Output/QoI]` parts are there, but we might as well discuss this now so that I can change the QoI parts if needed. Here is what I was thinking.

<pre>
[Output]
   [./Display]
      ...all options relevant to terminal output...
   [../]
   [./QoI]
       #Outputs qoi values to file_prefix.dat txt file. If no file_prefix value is specified, QoIs not output to file.
       file_prefix = 'myqoi'
   [../]
   [./Visualization]
      file_prefix = ''
      formats = ''
      output_residual = ''
      output_adjoint = ''
      ...etc...
   [../]
   [./Mesh]
      file_prefix = ''
      formats = ''
   [../]
   [./Restart]
      file_prefix = ''
      formats = ''
   [../]
[]
</pre>

Thoughts @roystgnr?