### PR TITLE
Ignore third party library code in compiler warnings

### DIFF
--- a/examples/cavity_benchmark/cavity.C
+++ b/examples/cavity_benchmark/cavity.C
@@ -32,7 +32,9 @@
 
 // GRVY
 #ifdef GRINS_HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 // libMesh

--- a/examples/elastic_sheet/stretching_sheet.C
+++ b/examples/elastic_sheet/stretching_sheet.C
@@ -33,7 +33,9 @@
 
 // GRVY
 #ifdef GRINS_HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 // libMesh

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -39,7 +39,9 @@
 
 #ifdef GRINS_HAVE_GRVY
 // GRVY timers
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 // libMesh forward declartions

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -47,7 +47,9 @@
 
 // GRVY
 #ifdef GRINS_HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h" // GRVY timers
+#include "libmesh/restore_warnings.h"
 #endif
 
 // libMesh forward declarations

--- a/src/solver/include/grins/grins_solver.h
+++ b/src/solver/include/grins/grins_solver.h
@@ -33,7 +33,9 @@
 #include "libmesh/equation_systems.h"
 
 #ifdef GRINS_HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h" // GRVY timers
+#include "libmesh/restore_warnings.h"
 #endif
 
 // libMesh forward declarations

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -48,7 +48,9 @@
 
 // GRVY
 #ifdef GRINS_HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 // libMesh forward declarations

--- a/src/solver/src/grins.C
+++ b/src/solver/src/grins.C
@@ -33,7 +33,9 @@
 
 // GRVY
 #ifdef GRINS_HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 // libMesh

--- a/test/exact_soln/vorticity_qoi.C
+++ b/test/exact_soln/vorticity_qoi.C
@@ -37,7 +37,9 @@
 
 // GRVY
 #ifdef GRINS_HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 int main(int argc, char* argv[]) 

--- a/test/regression/3d_low_mach_jacobians.C
+++ b/test/regression/3d_low_mach_jacobians.C
@@ -32,7 +32,9 @@
 
 // GRVY
 #ifdef GRINS_HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 // libMesh

--- a/test/regression/elastic_sheet_regression.C
+++ b/test/regression/elastic_sheet_regression.C
@@ -32,7 +32,9 @@
 
 // GRVY
 #ifdef HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 // libMesh

--- a/test/regression/test_turbulent_channel.C
+++ b/test/regression/test_turbulent_channel.C
@@ -53,7 +53,9 @@
 
 // GRVY
 #ifdef GRINS_HAVE_GRVY
+#include "libmesh/ignore_warnings.h" // avoid auto_ptr deprecated warnings
 #include "grvy.h"
+#include "libmesh/restore_warnings.h"
 #endif
 
 namespace GRINS

--- a/test/unit/builder_helper.C
+++ b/test/unit/builder_helper.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 // Testing headers
 #include "test_comm.h"
@@ -37,6 +39,8 @@
 // GRINS
 #include "grins/builder_helper.h"
 
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {

--- a/test/unit/default_bc_builder.C
+++ b/test/unit/default_bc_builder.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 // Testing headers
 #include "test_comm.h"
@@ -37,6 +39,9 @@
 // GRINS
 #include "grins/default_bc_builder.h"
 #include "grins/boundary_condition_names.h"
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {

--- a/test/unit/hitran_test.C
+++ b/test/unit/hitran_test.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 // Testing headers
 #include "test_comm.h"
@@ -36,6 +38,8 @@
 // GRINS
 #include "grins/hitran.h"
 
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {

--- a/test/unit/integrated_function_test.C
+++ b/test/unit/integrated_function_test.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 #include "test_comm.h"
 #include "grins_test_paths.h"
@@ -48,6 +50,9 @@
 #include "libmesh/steady_solver.h"
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/elem.h"
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {

--- a/test/unit/mesh_builder.C
+++ b/test/unit/mesh_builder.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 #include "test_comm.h"
 #include "grins_test_paths.h"
@@ -38,6 +40,9 @@
 
 // libMesh
 #include "libmesh/elem.h"
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {

--- a/test/unit/rayfireAMR_test.C
+++ b/test/unit/rayfireAMR_test.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 #include "test_comm.h"
 #include "grins_test_paths.h"
@@ -46,6 +48,9 @@
 #include "libmesh/fe_interface.h"
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/serial_mesh.h"
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {

--- a/test/unit/rayfire_test.C
+++ b/test/unit/rayfire_test.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 #include "test_comm.h"
 #include "grins_test_paths.h"
@@ -45,6 +47,9 @@
 #include "libmesh/face_quad9.h"
 #include "libmesh/fe_interface.h"
 #include "libmesh/serial_mesh.h"
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {

--- a/test/unit/spectroscopic_absorption_test.C
+++ b/test/unit/spectroscopic_absorption_test.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 #include "test_comm.h"
 #include "grins_test_paths.h"
@@ -41,6 +43,9 @@
 
 // libMesh
 #include "libmesh/parsed_function.h"
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {

--- a/test/unit/string_utils.C
+++ b/test/unit/string_utils.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 #include <string>
 #include <vector>
@@ -35,6 +37,9 @@
 #include <limits>
 
 #include "grins/string_utils.h"
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {

--- a/test/unit/unit_driver.C
+++ b/test/unit/unit_driver.C
@@ -25,8 +25,10 @@
 #include "grins_config.h"
 
 #ifdef GRINS_HAVE_CPPUNIT
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 #include <cppunit/ui/text/TestRunner.h>
+#include <libmesh/restore_warnings.h>
 #endif // GRINS_HAVE_CPPUNIT
 
 #include <libmesh/libmesh.h>

--- a/test/unit/variables.C
+++ b/test/unit/variables.C
@@ -26,8 +26,10 @@
 
 #ifdef GRINS_HAVE_CPPUNIT
 
+#include <libmesh/ignore_warnings.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
 
 // Testing headers
 #include "test_comm.h"
@@ -42,6 +44,9 @@
 #include "grins/variable_warehouse.h"
 #include "grins/variable_builder.h"
 #include "grins/variables_parsing.h"
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
 
 namespace GRINSTesting
 {


### PR DESCRIPTION
GRVY and CPPUnit use auto_ptr, and probably will for the foreseeable future.  But with the thousands of lines of "auto_ptr!  I saw an auto_ptr!  Did you know that's deprecated!?" disabled, I can actually read GCC warnings about our *own* code again.