### PR TITLE
Fix for VariablePinning without a variable to pin

### DIFF
--- a/src/physics/src/variable_pinning.C
+++ b/src/physics/src/variable_pinning.C
@@ -74,8 +74,11 @@ namespace GRINS
     // We should prerequest all the data
     // we will need to build the linear system
     // or evaluate a quantity of interest.
-    context.get_element_fe(_variable_to_pin)->get_JxW();
-    context.get_element_fe(_variable_to_pin)->get_phi();
+    if ( _pin_variable )
+      {
+        context.get_element_fe(_variable_to_pin)->get_JxW();
+        context.get_element_fe(_variable_to_pin)->get_phi();
+      }
   }
 
   void VariablePinning::element_constraint( bool compute_jacobian,


### PR DESCRIPTION
My philosophy in this case was "continue running with pinning
disabled, because it would inconvenience users to just scream and
die", but my actual implementation was "pass a uninitialized variable
to libMesh and see what happens".  This fixes that.