### PR TITLE
Command line overrides

### DIFF
--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -25,6 +25,13 @@
 # an error. This is to reduce the chance of errors in the input
 # file specification.
 #
+# In the default grins binary, as well as in any libgrins.so
+# application that so chooses, it is possible to override input-file
+# options using command-line options.  For example, running
+# $ grins input.in Mesh/class=parallel
+# will try to use a DistributedMesh regardless of what the value of
+# Mesh/class is in input.in
+#
 # The primary sections are:
 #    [Mesh] - all options related to the mesh used in the simulation
 #    [Materials] - all material property specifications

--- a/src/solver/src/grins.C
+++ b/src/solver/src/grins.C
@@ -76,9 +76,14 @@ int main(int argc, char* argv[])
   // Initialize libMesh library.
   libMesh::LibMeshInit libmesh_init(argc, argv);
 
-  // Create our GetPot object.
+  // Create our GetPot object from the input file
   GetPot libMesh_inputfile( libMesh_input_filename );
 
+  // But allow command line options to override the file
+  libMesh_inputfile.parse_command_line(argc, argv);
+
+  // And create a command_line only GetPot object for command line
+  // specific arguments
   GetPot command_line(argc,argv);
 
   // GetPot doesn't throw an error for a nonexistent file?

--- a/test/exact_soln/generic_exact_solution_testing_app.C
+++ b/test/exact_soln/generic_exact_solution_testing_app.C
@@ -154,6 +154,16 @@ int main(int argc, char* argv[])
   // Create our GetPot object.
   GetPot input( input_filename );
 
+  // But allow command line options to override the file
+  input.parse_command_line(argc, argv);
+
+  // Don't flag our command-line-specific variables as UFOs later
+  input.have_variable("input");
+  input.have_variable("test_data");
+  input.have_variable("vars");
+  input.have_variable("norms");
+  input.have_variable("tol");
+ 
   // Initialize libMesh library
   libMesh::LibMeshInit libmesh_init(argc, argv);
 

--- a/test/exact_soln/poisson_periodic_2d_x.sh
+++ b/test/exact_soln/poisson_periodic_2d_x.sh
@@ -7,11 +7,22 @@ TESTDATA="./poisson_periodic_2d_x.xda"
 
 PETSC_OPTIONS="-ksp_type cg -pc_type bjacobi -sub_pc_type icc"
 
-# First run the case with grins
-${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT $PETSC_OPTIONS
+# First run the case with grins.  We'll override part of the input
+# file on the command line, too, to test that feature.
+${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins \
+  $INPUT \
+  Mesh/Generation/n_elems_x=20 \
+  Mesh/Generation/n_elems_y=20 \
+  $PETSC_OPTIONS
 
 # Now run the test part to make sure we're getting the correct thing
-${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app input=$INPUT vars='u' norms='L2' tol='1.0e-8' u_L2_error='0.00349104' u_exact_soln='sin(pi*y)*cos(2*pi*x)' test_data=$TESTDATA
+${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app \
+  input=$INPUT \
+  Mesh/Generation/n_elems_x=20 \
+  Mesh/Generation/n_elems_y=20 \
+  vars='u' norms='L2' tol='1.0e-8' \
+  u_L2_error='0.00349104' u_exact_soln='sin(pi*y)*cos(2*pi*x)' \
+  test_data=$TESTDATA
 
 # Now remove the test turd
 rm $TESTDATA

--- a/test/input_files/poisson_periodic_2d_x.in
+++ b/test/input_files/poisson_periodic_2d_x.in
@@ -63,8 +63,15 @@
 
    [./Generation]
       dimension = '2'
+
+      # We actually need to generate a 20x20 solution to match our
+      # gold standard, so we'll override these variables via the
+      # command line in our regression test script; that way this test
+      # doubles as a function test for command line variable
+      # overriding.
       n_elems_x = '10'
       n_elems_y = '10'
+
       x_min = '0.0'
       x_max = '1.0'
       y_min = '0.0'

--- a/test/input_files/poisson_periodic_2d_x.in
+++ b/test/input_files/poisson_periodic_2d_x.in
@@ -63,8 +63,8 @@
 
    [./Generation]
       dimension = '2'
-      n_elems_x = '20'
-      n_elems_y = '20'
+      n_elems_x = '10'
+      n_elems_y = '10'
       x_min = '0.0'
       x_max = '1.0'
       y_min = '0.0'

--- a/test/regression/3d_low_mach_jacobians.C
+++ b/test/regression/3d_low_mach_jacobians.C
@@ -66,6 +66,9 @@ int main(int argc, char* argv[])
   // Create our GetPot object.
   GetPot libMesh_inputfile( libMesh_input_filename );
 
+  // But allow command line options to override the file
+  libMesh_inputfile.parse_command_line(argc, argv);
+
 #ifdef GRINS_USE_GRVY_TIMERS
   grvy_timer.BeginTimer("Initialize Solver");
 #endif

--- a/test/regression/elastic_sheet_regression.C
+++ b/test/regression/elastic_sheet_regression.C
@@ -69,6 +69,9 @@ int main(int argc, char* argv[])
   // Create our GetPot object.
   GetPot libMesh_inputfile( libMesh_input_filename );
 
+  // But allow command line options to override the file
+  libMesh_inputfile.parse_command_line(argc, argv);
+
   int return_flag = 0;
 
   return_flag = run( argc, argv, libMesh_inputfile );

--- a/test/regression/generic_solution_regression.C
+++ b/test/regression/generic_solution_regression.C
@@ -90,6 +90,17 @@ int main(int argc, char* argv[])
   // Create our GetPot object.
   GetPot libMesh_inputfile( libMesh_input_filename );
 
+  // But allow command line options to override the file
+  libMesh_inputfile.parse_command_line(argc, argv);
+
+  // Don't flag our command-line-specific variables as UFOs later
+  libMesh_inputfile.have_variable("input");
+  libMesh_inputfile.have_variable("soln-data");
+  libMesh_inputfile.have_variable("vars");
+  libMesh_inputfile.have_variable("norms");
+  libMesh_inputfile.have_variable("tol");
+  libMesh_inputfile.have_variable("qois");
+
   // Initialize libMesh library.
   libMesh::LibMeshInit libmesh_init(argc, argv);
 

--- a/test/regression/grins_flow_regression.C
+++ b/test/regression/grins_flow_regression.C
@@ -49,6 +49,9 @@ int main(int argc, char* argv[])
   // Create our GetPot object.
   GetPot libMesh_inputfile( libMesh_input_filename );
 
+  // But allow command line options to override the file
+  libMesh_inputfile.parse_command_line(argc, argv);
+
   // Initialize libMesh library.
   libMesh::LibMeshInit libmesh_init(argc, argv);
  

--- a/test/regression/low_mach_cavity_benchmark_regression.C
+++ b/test/regression/low_mach_cavity_benchmark_regression.C
@@ -51,6 +51,9 @@ int main(int argc, char* argv[])
   // Create our GetPot object.
   GetPot libMesh_inputfile( libMesh_input_filename );
 
+  // But allow command line options to override the file
+  libMesh_inputfile.parse_command_line(argc, argv);
+
   // Initialize libMesh library.
   libMesh::LibMeshInit libmesh_init(argc, argv);
  

--- a/test/regression/regression_testing_app.C
+++ b/test/regression/regression_testing_app.C
@@ -166,6 +166,20 @@ int main(int argc, char* argv[])
   // Create our GetPot object.
   GetPot input( input_filename );
 
+  // But allow command line options to override the file
+  input.parse_command_line(argc, argv);
+
+  // Don't flag our command-line-specific variables as UFOs later
+  input.have_variable("input");
+  input.have_variable("soln-data");
+  input.have_variable("gold-data");
+  input.have_variable("vars");
+  input.have_variable("norms");
+  input.have_variable("tol");
+  input.have_variable("gold-qoi-names");
+  input.have_variable("qoi-data");
+  input.have_variable("gold-qoi-values");
+
   // Initialize libMesh library.
   libMesh::LibMeshInit libmesh_init(argc, argv);
 

--- a/test/regression/test_turbulent_channel.C
+++ b/test/regression/test_turbulent_channel.C
@@ -262,6 +262,17 @@ int main(int argc, char* argv[])
   // Create our GetPot object.
   GetPot libMesh_inputfile( libMesh_input_filename );
 
+  // But allow command line options to override the file
+  libMesh_inputfile.parse_command_line(argc, argv);
+
+  // Don't flag our command-line-specific variables as UFOs later
+  libMesh_inputfile.have_variable("mesh-1d");
+  libMesh_inputfile.have_variable("data-1d");
+  libMesh_inputfile.have_variable("soln-data");
+  libMesh_inputfile.have_variable("vars");
+  libMesh_inputfile.have_variable("norms");
+  libMesh_inputfile.have_variable("tol");
+
 #ifdef GRINS_USE_GRVY_TIMERS
   grvy_timer.BeginTimer("Initialize Solver");
 #endif


### PR DESCRIPTION
Allow users to override input file arguments on the command line.

I'm making this the default behavior for bin/grins, which I think is safe because it still would need to be done explicitly by users of libgrins.so, so we don't have to worry that any of our input-file options will suddenly cause namespace collisions with users' apps' command-line options.