### PR TITLE
Skip SpectrscopicAbsorption test if not configured with Antioch

### DIFF
--- a/test/unit/spectroscopic_absorption_test.C
+++ b/test/unit/spectroscopic_absorption_test.C
@@ -53,10 +53,10 @@ namespace GRINSTesting
   {
   public:
     CPPUNIT_TEST_SUITE( SpectroscopicAbsorptionTest );
-
+#if GRINS_HAVE_ANTIOCH
     CPPUNIT_TEST( single_elem_mesh );
     CPPUNIT_TEST( multi_elem_mesh );
-
+#endif
     CPPUNIT_TEST_SUITE_END();
 
   public:


### PR DESCRIPTION
These tests require Antioch to calculate the QoI, so if GRINS was not configured with Antioch, these tests need to be skipped.