### PR TITLE
RayfireMesh fixes to handle special cases

### DIFF
--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -157,13 +157,13 @@ namespace GRINS
     @return Elem* if intersection is found
     @return NULL  if no intersection point found (i.e. start_point is on a boundary)
     */
-    const libMesh::Elem* get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point& start_point, libMesh::Point& end_point);
+    const libMesh::Elem* get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point& start_point, libMesh::Point& end_point, bool same_parent = false);
 
     //! Ensure the calculated intersection point is on the edge_elem and is not the start_point
     bool check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, libMesh::Elem& edge_elem, libMesh::Point& next_point);
 
     //! Knowing the end_point, get the appropraite next elem along the path
-    const libMesh::Elem* get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side);
+    const libMesh::Elem* get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side, bool same_parent);
 
     //! Ensure the supplied origin is on a boundary of the mesh
     void check_origin_on_boundary(const libMesh::Elem* start_elem);

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -58,7 +58,6 @@ namespace GRINS
       libmesh_error_msg("Please supply a theta value between -2*pi and 2*pi");
   }
 
-
   void RayfireMesh::init(const libMesh::MeshBase& mesh_base)
   {
     // consistency check
@@ -74,8 +73,6 @@ namespace GRINS
 
     _mesh = new libMesh::Mesh(mesh_base.comm(),(unsigned char)1);
 
-    unsigned int node_id = 0;
-
     libMesh::Point start_point(_origin);
 
     // get first element
@@ -89,7 +86,8 @@ namespace GRINS
     this->check_origin_on_boundary(start_elem);
 
     // add the origin point to the point list
-    _mesh->add_point(start_point,node_id++);
+    libMesh::Node * start_node = _mesh->add_point(start_point);
+    libMesh::Node * end_node = NULL;
 
     libMesh::Point end_point;
 
@@ -103,15 +101,16 @@ namespace GRINS
         next_elem = this->get_next_elem(prev_elem,start_point,end_point);
 
         // add end point as node on the rayfire mesh
-        _mesh->add_point(end_point,node_id);
+        end_node = _mesh->add_point(end_point);
         libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
-        elem->set_node(0) = _mesh->node_ptr(node_id-1);
-        elem->set_node(1) = _mesh->node_ptr(node_id++);
+        elem->set_node(0) = start_node;
+        elem->set_node(1) = end_node;
 
         // add new rayfire elem to the map
         _elem_id_map[prev_elem->id()] = elem;
 
         start_point = end_point;
+        start_node = end_node;
         prev_elem = next_elem;
       } while(next_elem);
 
@@ -178,6 +177,7 @@ namespace GRINS
     // coarsen the elements that need it
     for (unsigned int i=0; i<elems_to_coarsen.size(); i++)
       this->coarsen(elems_to_coarsen[i]);
+
   }
 
 
@@ -185,6 +185,8 @@ namespace GRINS
 
   void RayfireMesh::check_origin_on_boundary(const libMesh::Elem* start_elem)
   {
+    libmesh_assert(start_elem);
+
     // first, make sure the elem is on a boundary
     if ( !(start_elem->on_boundary()) )
       libmesh_error_msg("The supplied origin point is not on a boundary element");
@@ -195,8 +197,8 @@ namespace GRINS
 
     for (unsigned int s=0; s<start_elem->n_sides(); s++)
       {
-        // neighbor() returns NULL on boundary elems
-        if ( start_elem->neighbor(s) )
+        // neighbor_ptr() returns NULL on boundary elems
+        if ( start_elem->neighbor_ptr(s) )
           continue;
 
         // we found a boundary elem, so make an edge and see if it contains the origin
@@ -225,7 +227,7 @@ namespace GRINS
           {
             for (unsigned int i=0; i<elem->n_neighbors(); i++)
               {
-                const libMesh::Elem* neighbor_elem = elem->neighbor(i);
+                const libMesh::Elem* neighbor_elem = elem->neighbor_ptr(i);
                 if (!neighbor_elem)
                   continue;
 
@@ -257,8 +259,10 @@ namespace GRINS
   }
 
 
-  const libMesh::Elem* RayfireMesh::get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point& start_point, libMesh::Point& next_point)
+  const libMesh::Elem* RayfireMesh::get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point& start_point, libMesh::Point& next_point, bool same_parent)
   {
+    libmesh_assert(cur_elem);
+
     libMesh::Point intersection_point;
 
     // loop over all sides of the elem and check each one for intersection
@@ -273,7 +277,7 @@ namespace GRINS
         if (converged)
           {
             if ( this->check_valid_point(intersection_point,start_point,*edge_elem,next_point) )
-              return this->get_correct_neighbor(intersection_point,cur_elem,s);
+              return this->get_correct_neighbor(intersection_point,cur_elem,s,same_parent);
           }
         else
           continue;
@@ -318,11 +322,9 @@ namespace GRINS
   }
 
 
-  const libMesh::Elem* RayfireMesh::get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side)
+  const libMesh::Elem* RayfireMesh::get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side, bool same_parent)
   {
-    // check if side is a boundary
-    if( !(cur_elem->neighbor(side)) )
-      return NULL;
+    libmesh_assert(cur_elem);
 
     // check if the intersection point is a vertex
     bool is_vertex = false;
@@ -333,7 +335,37 @@ namespace GRINS
       {
         // rayfire goes through vertex
 
-        // get all elems that share this vertex
+        // check elem neighbors first
+        for (unsigned int s=0; s<cur_elem->n_sides(); s++)
+          {
+            libMesh::UniquePtr<libMesh::Elem> side_elem = cur_elem->build_side(s);
+            if (side_elem->contains_point(end_point))
+              {
+                const libMesh::Elem * neighbor = cur_elem->neighbor_ptr(s);
+                if (!neighbor)
+                  continue;
+
+                if (same_parent)
+                  {
+                    if (neighbor->parent())
+                      {
+                        if (neighbor->parent()->id() != cur_elem->parent()->id())
+                          continue;
+                        else
+                          if (this->rayfire_in_elem(end_point,neighbor))
+                            return neighbor;
+                      }
+                    else
+                      continue;
+                  }
+                else
+                  if (this->rayfire_in_elem(end_point,neighbor))
+                    return neighbor;
+              }
+          }
+
+        // next elem is not a neighbor,
+        // so get all elems that share this vertex
         std::set<const libMesh::Elem*> elem_set;
         cur_elem->find_point_neighbors(end_point,elem_set);
         std::set<const libMesh::Elem *>::const_iterator       it  = elem_set.begin();
@@ -354,8 +386,12 @@ namespace GRINS
       }
     else
       {
-        // not a vertex, so just get the elem on that side
-        return cur_elem->neighbor(side);
+        // check if side is a boundary
+        if( !(cur_elem->neighbor_ptr(side)) )
+          return NULL;
+
+        // not a vertex or boundary, so just get the elem on that side
+        return cur_elem->neighbor_ptr(side);
       }
 
     return NULL;
@@ -364,6 +400,8 @@ namespace GRINS
 
   bool RayfireMesh::newton_solve_intersection(libMesh::Point& initial_point, const libMesh::Elem* edge_elem, libMesh::Point& intersection_point)
   {
+    libmesh_assert(edge_elem);
+
     unsigned int iter_max = 20; // max iterations
 
     // the number of shape functions needed for the edge_elem
@@ -439,6 +477,9 @@ namespace GRINS
 
   void RayfireMesh::refine(const libMesh::Elem* main_elem, libMesh::Elem* rayfire_elem)
   {
+    libmesh_assert(main_elem);
+    libmesh_assert(rayfire_elem);
+
     libmesh_assert_equal_to(main_elem->refinement_flag(),libMesh::Elem::RefinementState::INACTIVE);
 
     // these nodes cannot change
@@ -500,24 +541,22 @@ namespace GRINS
     // break this
     libmesh_assert_equal_to( prev_elem->refinement_flag(), libMesh::Elem::RefinementState::JUST_REFINED );
 
-    // There are _mesh->n_nodes()-1 number of nodes already in _mesh
-    // so use n_nodes() as the ID of the next node to add
-    unsigned int end_node_id = _mesh->n_nodes();
-
-    unsigned int start_node_id = start_node->id();
-
-    // calculate the end point and
-    // get the second elem in the rayfire
-    next_elem = this->get_next_elem(prev_elem,start_point,end_point);
+    libMesh::Node * prev_node = start_node;
+    libMesh::Node * new_node = NULL;
 
     // iterate until we reach the stored end_node
-    while(!(end_point.absolute_fuzzy_equals(*end_node)))
+    do
       {
+        next_elem = this->get_next_elem(prev_elem,start_point,end_point,true);
+
         // add end point as node on the rayfire mesh
-        _mesh->add_point(end_point,end_node_id);
+        new_node = _mesh->add_point(end_point);
         libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
-        elem->set_node(0) = _mesh->node_ptr(start_node_id);
-        elem->set_node(1) = _mesh->node_ptr(end_node_id);
+
+        elem->set_node(0) = prev_node;
+        elem->set_node(1) = new_node;
+
+        libmesh_assert_less( (*(elem->get_node(0))-_origin).norm(),  (*(elem->get_node(1))-_origin).norm());
 
         // set rayfire_elem as the parent of this new elem
         // in case it gets coarsened
@@ -527,25 +566,17 @@ namespace GRINS
         _elem_id_map[prev_elem->id()] = elem;
         start_point = end_point;
         prev_elem = next_elem;
-        start_node_id = end_node_id++;
+        prev_node = new_node;
 
-        next_elem = this->get_next_elem(prev_elem,start_point,end_point);
-      }
+      } while(!(new_node->absolute_fuzzy_equals(*end_node)));
 
-    // need to manually assign the end_node to the final edge elem
-    libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
-    elem->set_node(0) = _mesh->node_ptr(start_node_id);
-    elem->set_node(1) = _mesh->node_ptr(end_node->id());
-
-    elem->set_parent(rayfire_elem);
-
-    // add new rayfire elem to the map
-    _elem_id_map[prev_elem->id()] = elem;
   }
 
 
   void RayfireMesh::coarsen(const libMesh::Elem* child_elem)
   {
+    libmesh_assert(child_elem);
+
     if (this->get_rayfire_elem(child_elem->id()))
       {
         const libMesh::Elem* parent_elem = child_elem->parent();
@@ -587,9 +618,12 @@ namespace GRINS
         elem->set_node(0) = _mesh->node_ptr(start_node->id());
         elem->set_node(1) = _mesh->node_ptr(end_node->id());
 
+        libmesh_assert_less( (*(elem->get_node(0))-_origin).norm(),  (*(elem->get_node(1))-_origin).norm());
+
         // add new rayfire elem to the map
         _elem_id_map[parent_elem->id()] = elem;
       }
+
   }
 
 } //namespace GRINS

--- a/test/unit/rayfireAMR_test.C
+++ b/test/unit/rayfireAMR_test.C
@@ -70,6 +70,8 @@ namespace GRINSTesting
     CPPUNIT_TEST( mixed_type_mesh );
     CPPUNIT_TEST( start_with_refined_mesh );
     CPPUNIT_TEST( refined_above_unrefined );
+    CPPUNIT_TEST( refine_deformed_elem );
+    CPPUNIT_TEST( refine_deformed_elem_near_tolerance );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -377,6 +379,83 @@ namespace GRINSTesting
       CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem0->child(2)->id()) );
       CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem0->child(3)->id()) );
     }
+
+    //! QUAD4 elem is deformed, rayfire goes within libMesh::TOLERANCE central node
+    void refine_deformed_elem()
+    {
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.0,0.0),0 );
+      mesh->add_point( libMesh::Point(1.0,0.0),1 );
+      mesh->add_point( libMesh::Point(1.1,1.1),2 );
+      mesh->add_point( libMesh::Point(0.2,1.0),3 );
+
+      libMesh::Elem* e = mesh->add_elem( new libMesh::Quad4 );
+      for (unsigned int n=0; n<4; n++)
+        e->set_node(n) = mesh->node_ptr(n);
+
+      mesh->prepare_for_use();
+
+      CPPUNIT_ASSERT_EQUAL( mesh->n_elem(), (libMesh::dof_id_type)1 );
+
+      libMesh::Real y = 0.5250005;
+      libMesh::Real x = y/5.0;
+
+      libMesh::Point origin(x,y); // within libMesh::TOLERANCE of node 8
+      libMesh::Real theta = 0.0;
+
+      std::vector<unsigned int> children_in_rayfire;
+      children_in_rayfire.push_back(1);
+      children_in_rayfire.push_back(2);
+      children_in_rayfire.push_back(3);
+
+      std::vector<unsigned int> children_not_in_rayfire;
+      children_not_in_rayfire.push_back(0);
+      
+      this->test_deformed_elem(mesh,origin,theta,children_in_rayfire,children_not_in_rayfire);
+    }
+
+    //! QUAD4 elem is slightly deformed, rayfire starts and ends very neay boundary of refined children.
+    //!
+    //! Based on an element from a larger mesh, hence the seemingly arbitrary coordinates
+    void refine_deformed_elem_near_tolerance()
+    {
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.26591876082146976,0.016285303166482301),2 );
+      mesh->add_point( libMesh::Point(0.26539426622418877,0.016285726631637167),3 );
+      mesh->add_point( libMesh::Point(0.26538091506882988,0.015714299294800886),0 );
+      mesh->add_point( libMesh::Point(0.26590538328042834,0.015713833483130532),1 );
+
+      libMesh::Elem* e = mesh->add_elem( new libMesh::Quad4 );
+      for (unsigned int n=0; n<4; n++)
+        e->set_node(n) = mesh->node_ptr(n);
+
+      mesh->prepare_for_use();
+
+      CPPUNIT_ASSERT_EQUAL( mesh->n_elem(), (libMesh::dof_id_type)1 );
+
+      libMesh::Real x = 0.26538759034362924;
+      libMesh::Real y = 0.01600000000000000;
+
+      libMesh::Point origin(x,y);
+      libMesh::Real theta = 0.0;
+
+      std::vector<unsigned int> children_in_rayfire;
+      children_in_rayfire.push_back(0);
+      children_in_rayfire.push_back(2);
+      children_in_rayfire.push_back(3);
+
+      std::vector<unsigned int> children_not_in_rayfire;
+      children_not_in_rayfire.push_back(1);
+      
+      this->test_deformed_elem(mesh,origin,theta,children_in_rayfire,children_not_in_rayfire);
+    }
+
 
   private:
 
@@ -700,6 +779,32 @@ namespace GRINSTesting
           CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(26)->child(c)->id())) );
           CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(9)->child(c)->id())) );
         }
+    }
+
+    void test_deformed_elem(  GRINS::SharedPtr<libMesh::UnstructuredMesh> & mesh,
+                              libMesh::Point & origin, libMesh::Real theta,
+                              std::vector<unsigned int> & children_in_rayfire,
+                              std::vector<unsigned int> & children_not_in_rayfire )
+    {
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+
+      libMesh::Elem* elem = mesh->elem(0);
+      CPPUNIT_ASSERT(elem);
+
+      elem->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+
+      libMesh::MeshRefinement mr(*mesh);
+      mr.refine_elements();
+
+      rayfire->reinit(*mesh);
+
+      for (unsigned int c=0; c<children_in_rayfire.size(); c++)
+        CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(children_in_rayfire[c])->id()) );
+
+      for (unsigned int c=0; c<children_not_in_rayfire.size(); c++)
+        CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(mesh->elem(0)->child(children_not_in_rayfire[c])->id()) );
+
     }
 
   };

--- a/test/unit/rayfireAMR_test.C
+++ b/test/unit/rayfireAMR_test.C
@@ -69,6 +69,7 @@ namespace GRINSTesting
     CPPUNIT_TEST( refine_and_coarsen );
     CPPUNIT_TEST( mixed_type_mesh );
     CPPUNIT_TEST( start_with_refined_mesh );
+    CPPUNIT_TEST( refined_above_unrefined );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -324,6 +325,57 @@ namespace GRINSTesting
       // and no other elem
       for (unsigned int e=1; e<mesh->n_elem(); e++)
         CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(e)) );
+    }
+
+    //! 2 QUAD4 elems, one is refined, one if not, rayfire travels boundary between them
+    void refined_above_unrefined() {
+      GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh = new libMesh::SerialMesh(*TestCommWorld);
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.0,0.0),0 );
+      mesh->add_point( libMesh::Point(1.0,0.0),1 );
+      mesh->add_point( libMesh::Point(1.0,1.0),2 );
+      mesh->add_point( libMesh::Point(0.0,1.0),3 );
+      mesh->add_point( libMesh::Point(1.0,2.0),4 );
+      mesh->add_point( libMesh::Point(0.0,2.0),5 );
+
+      libMesh::Elem* elem0 = mesh->add_elem( new libMesh::Quad4 );
+      elem0->set_node(0) = mesh->node_ptr(0);
+      elem0->set_node(1) = mesh->node_ptr(1);
+      elem0->set_node(2) = mesh->node_ptr(2);
+      elem0->set_node(3) = mesh->node_ptr(3);
+
+      libMesh::Elem* elem1 = mesh->add_elem( new libMesh::Quad4 );
+      elem1->set_node(0) = mesh->node_ptr(3);
+      elem1->set_node(1) = mesh->node_ptr(2);
+      elem1->set_node(2) = mesh->node_ptr(4);
+      elem1->set_node(3) = mesh->node_ptr(5);
+
+      mesh->prepare_for_use();
+
+      libMesh::Point origin(0.0,1.0);
+      libMesh::Real theta = 0.0;
+
+      GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
+      rayfire->init(*mesh);
+
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem0->id()) );
+      CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(elem1->id()) );
+
+      elem0->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+
+      libMesh::MeshRefinement mr(*mesh);
+      mr.refine_elements();
+
+      rayfire->reinit(*mesh);
+
+      CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(elem1->id()) );
+
+      CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(elem0->child(0)->id()) );
+      CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(elem0->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem0->child(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem0->child(3)->id()) );
     }
 
   private:


### PR DESCRIPTION
Recent work uncovered 2 bugs in the RayfireMesh class with non-square QUAD elements.

The first fix is for the case where the rayfire travels the boundary between 2 elements, one of which is to be refined. When updating the rayfire to reflect the refinement, it was possible for `RayfireMesh::refine()` to incorrectly identify elements along the rayfire due to the rayfire being along an element boundary. This caused the rayfire to wander into other elements, creating a hole in the rayfire that ultimately led to null pointer exceptions. This is fixed by adding a flag to certain private class functions to enforce when elements must have the same parent, as is the case when the rayfire is refined.

The second issue arises when the rayfire passes very close to vertices or element boundaries (within `libMesh::TOLERANCE`) after refinement. In certain instances, the correct `next_elem` would not be identified due to the default tolerances used in various functions. These issues are fixed by tightening the tolerance on `Elem::contains_point()` and `RayfireMesh::rayfire_in_elem()`. Two test cases are added to identify these issues, with the second one (`refine_deformed_elem_near_tolerance()`) coming from a larger mesh that originally demonstrated the issue. The coordinates given were obtained from the DDT debugger, and attempts to remove digits resulted in failures in `libMesh::Elem::contains_point()` and `PointLocatorBase::operator()`, used in verifying the validity of the supplied origin point.

`make check` passes in `dbg`,`devel`, & `opt` with `GCC 6.1.0`. Fixes were also verified on the original mesh that uncovered these issues, and 6 AMR steps were performed with no issues. Originally, the run failed at AMR step 3.