### PR TITLE
new input option for Simulation to skip refinement calls in libMesh::EuqationSystems::reinit

### DIFF
--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -173,6 +173,9 @@ namespace GRINS
     // This *must* be done after equation_system->init in order to get variable indices
     // Set any extra quadrature order the user requested. By default, is 0.
     _multiphysics_system->extra_quadrature_order = StrategiesParsing::extra_quadrature_order(input);
+
+    if (input("Strategies/MeshAdaptivity/disable_two_step_refinement",false))
+      _equation_system->disable_refine_in_reinit();
   }
 
   void Simulation::init_qois( const GetPot& input, SimulationBuilder& sim_builder )


### PR DESCRIPTION
Follows [libMesh PR](https://github.com/libMesh/libmesh/pull/1233) to add an input option to disable coarsen/refine calls within `libMesh::EquationSystems::reinit`. Correct refinement flags are required for proper `RayfireMesh::reinit`. New option is `Strategies/MeshAdaptivity/disable_two_step_refinement`.

Tested with SpectroscopicAbsorption AMR run.

Do not merge until libMesh PR goes through.