### PR TITLE
QoI reinit hooks in MultiphysicsSystem

### DIFF
--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -32,6 +32,7 @@
 #include "grins/variable_warehouse.h"
 #include "grins/bc_builder.h"
 #include "grins/constraint_builder.h"
+#include "grins/composite_qoi.h"
 
 // libMesh
 #include "libmesh/composite_function.h"
@@ -286,6 +287,14 @@ namespace GRINS
          physics_iter != _physics_list.end();
          physics_iter++ )
       (physics_iter->second)->reinit(*this);
+
+    // And now reinit the QoI
+    if (this->qoi.size() > 0)
+      {
+        libMesh::DifferentiableQoI* diff_qoi = this->get_qoi();
+        CompositeQoI* qoi = libMesh::cast_ptr<CompositeQoI*>(diff_qoi);
+        qoi->reinit(*this);
+      }
   }
 
   bool MultiphysicsSystem::_general_residual( bool request_jacobian,

--- a/src/qoi/include/grins/composite_qoi.h
+++ b/src/qoi/include/grins/composite_qoi.h
@@ -89,6 +89,9 @@ namespace GRINS
 
     virtual void init_context( libMesh::DiffContext& context );
 
+    //! Reinitialize qoi
+    virtual void reinit(MultiphysicsSystem & system);
+
     //! Compute the qoi value for element interiors.
     virtual void element_qoi( libMesh::DiffContext& context,
                               const libMesh::QoISet& qoi_indices );
@@ -128,6 +131,9 @@ namespace GRINS
 
     const QoIBase& get_qoi( unsigned int qoi_index ) const;
 
+    //! Non-const version needed for reinit()
+    QoIBase& get_qoi( unsigned int qoi_index );
+
   protected:
     
     std::vector<QoIBase*> _qois;
@@ -142,6 +148,14 @@ namespace GRINS
 
   inline
   const QoIBase& CompositeQoI::get_qoi( unsigned int qoi_index ) const
+  {
+    libmesh_assert_less( qoi_index, this->n_qois() );
+
+    return (*_qois[qoi_index]);
+  }
+
+  inline
+  QoIBase& CompositeQoI::get_qoi( unsigned int qoi_index )
   {
     libmesh_assert_less( qoi_index, this->n_qois() );
 

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -84,6 +84,8 @@ namespace GRINS
                        const MultiphysicsSystem& system,
                        unsigned int qoi_num );
 
+    //! Reinitialize the rayfire
+    virtual void reinit(MultiphysicsSystem & system);
 
   private:
     //! Quadrature order

--- a/src/qoi/include/grins/qoi_base.h
+++ b/src/qoi/include/grins/qoi_base.h
@@ -78,6 +78,9 @@ namespace GRINS
 
     virtual void init_context( AssemblyContext& /*context*/ ){}
 
+    //! Reinitialize QoI
+    virtual void reinit(MultiphysicsSystem & /*system*/) {}
+
     //! Compute the qoi value for element interiors.
     /*! Override this method if your QoI is defined on element interiors */
     virtual void element_qoi( AssemblyContext& /*context*/,

--- a/src/qoi/src/composite_qoi.C
+++ b/src/qoi/src/composite_qoi.C
@@ -119,6 +119,13 @@ namespace GRINS
       (*_qois[q]).register_parameter(param_name, param_pointer);
   }
 
+  void CompositeQoI::reinit(MultiphysicsSystem & system)
+  {
+    // call reinit() on each qoi
+    for (unsigned int i=0; i<this->n_qois(); i++)
+      (this->get_qoi(i)).reinit(system);
+  }
+
   void CompositeQoI::element_qoi( libMesh::DiffContext& context,
                                   const libMesh::QoISet& /*qoi_indices*/ )
   {

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -71,6 +71,12 @@ namespace GRINS
   }
 
   template<typename Function>
+  void IntegratedFunction<Function>::reinit(MultiphysicsSystem & system)
+  {
+    _rayfire->reinit(system.get_mesh());
+  }
+
+  template<typename Function>
   void IntegratedFunction<Function>::element_qoi( AssemblyContext& context,
                                        const unsigned int qoi_index )
   {

--- a/test/unit/input_files/integrated_function_quad9.in
+++ b/test/unit/input_files/integrated_function_quad9.in
@@ -62,6 +62,14 @@
       element_type = 'QUAD9'
 []
 
+[Strategies]
+
+  [./MeshAdaptivity]
+    disable_two_step_refinement = 'true'
+  [../]
+
+[]
+
 #Linear and nonlinear solver options
 [linear-nonlinear-solver]
    max_nonlinear_iterations =  25


### PR DESCRIPTION
Hooks into `MultiphysicsSystem::reinit()` to also call `reinit()` on an attached `CompositeQoI`.

Included CPPUNIT tests fails without this, as the rayfire would not get refined along with the main mesh since `rayfire->reinit()` is not explicitly called in the test.

Also tests `libMesh::EquationSystems::reinit` flag from #478, without which this test will also fail because `es->reinit()` will clear the refinement flags on the main mesh and the rayfire will not get refined.