### PR TITLE
Fix memory leak in SpectroscopicAbsorption QoI

### DIFF
--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -55,18 +55,24 @@ namespace GRINS
   public:
     //! Constructor
     /*!
-      @param p_level The desired Gauss Quadrature level
-      @param f A FunctionBase or FEMFunctionBase object for evaluting the QoI
-      @param rayfire A RayfireMesh object (will be initialized in init())
-      @param qoi_name Passed to the QoIBase
+    @param p_level The desired Gauss Quadrature level
+    @param f A FunctionBase or FEMFunctionBase object for evaluting the QoI
+    @param rayfire A RayfireMesh object (will be initialized in init()) <b>Ownership will be taken by an internal libMesh::UniquePtr</b>
+    @param qoi_name Passed to the QoIBase
     */
-    IntegratedFunction(unsigned int p_level, SharedPtr<Function> f, SharedPtr<RayfireMesh> rayfire, const std::string& qoi_name);
+    IntegratedFunction(unsigned int p_level,SharedPtr<Function> f,RayfireMesh * rayfire,const std::string& qoi_name);
 
     //! Constructor
     /*!
     Used by the QoIFactory. Passes GetPot through to RayfireMesh for construction
     */
     IntegratedFunction(const GetPot & input,unsigned int p_level,SharedPtr<Function> f,const std::string & input_qoi_string,const std::string& qoi_name);
+
+    //! Copy Constructor
+    /*!
+    Required to deep-copy the UniquePtr RayfireMesh object
+    */
+    IntegratedFunction(const IntegratedFunction & original);
 
     //! Required to provide clone (deep-copy) for adding QoI object to libMesh objects.
     virtual QoIBase* clone() const;
@@ -101,10 +107,7 @@ namespace GRINS
     SharedPtr<Function> _f;
 
     //! Pointer to RayfireMesh object
-    SharedPtr<RayfireMesh> _rayfire;
-
-    //! QBase object for adding quadrature to rayfire elements
-    SharedPtr<libMesh::QBase> _qbase;
+    libMesh::UniquePtr<RayfireMesh> _rayfire;
 
     //! Compute the value of a QoI at a QP
     libMesh::Real qoi_value(Function& f,AssemblyContext& context,const libMesh::Point& xyz);

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -99,6 +99,11 @@ namespace GRINS
     //! Reinitialize the rayfire
     virtual void reinit(MultiphysicsSystem & system);
 
+    const RayfireMesh & get_rayfire()
+    {
+      return *(_rayfire.get());
+    }
+
   private:
     //! Quadrature order
     unsigned int _p_level;

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -62,6 +62,12 @@ namespace GRINS
     */
     IntegratedFunction(unsigned int p_level, SharedPtr<Function> f, SharedPtr<RayfireMesh> rayfire, const std::string& qoi_name);
 
+    //! Constructor
+    /*!
+    Used by the QoIFactory. Passes GetPot through to RayfireMesh for construction
+    */
+    IntegratedFunction(const GetPot & input,unsigned int p_level,SharedPtr<Function> f,const std::string & input_qoi_string,const std::string& qoi_name);
+
     //! Required to provide clone (deep-copy) for adding QoI object to libMesh objects.
     virtual QoIBase* clone() const;
 

--- a/src/qoi/include/grins/qoi_factory.h
+++ b/src/qoi/include/grins/qoi_factory.h
@@ -65,8 +65,6 @@ namespace GRINS
     void consistency_error_msg( const std::string& qoi_name, const std::set<std::string>& required_physics );
 
   private:
-    SharedPtr<RayfireMesh> construct_rayfire( const GetPot& input, const std::string qoi_string );
-
     //! Helper function to read a required value from the input file, or error if value is missing
     template<typename T>
     void get_var_value( const GetPot & input, T & value, std::string input_var, T default_value);

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -117,7 +117,7 @@ namespace GRINS
     /*!
       Returns a vector of elem IDs that are currently along the rayfire
     */
-    void elem_ids_in_rayfire(std::vector<libMesh::dof_id_type>& id_vector);
+    void elem_ids_in_rayfire(std::vector<libMesh::dof_id_type>& id_vector) const;
 
     /*!
       Checks for refined and coarsened main mesh elements along the rayfire path.

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -85,6 +85,12 @@ namespace GRINS
     */
     RayfireMesh(libMesh::Point& origin, libMesh::Real theta, libMesh::Real phi);
 
+    //! Input File Constructor
+    /*!
+    Creates rayfire from parameters specified in input file section: QoI/'qoi_string'/Rayfire/
+    */
+    RayfireMesh(const GetPot & input, const std::string & qoi_string);
+
     //! Initialization
     /*!
       This function performs the rayfire and assembles the 1D mesh.

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -91,6 +91,12 @@ namespace GRINS
     */
     RayfireMesh(const GetPot & input, const std::string & qoi_string);
 
+    //! Copy Constructor
+    /*!
+    Required to deep-copy _mesh and _elem_id_map
+    */
+    RayfireMesh(const RayfireMesh & original);
+
     //! Initialization
     /*!
       This function performs the rayfire and assembles the 1D mesh.
@@ -139,7 +145,7 @@ namespace GRINS
     libMesh::Real   _phi;
 
     //! Internal 1D mesh of EDGE2 elements
-    SharedPtr<libMesh::Mesh> _mesh;
+    libMesh::UniquePtr<libMesh::Mesh> _mesh;
 
     //! Map of main mesh elem_id to rayfire mesh elem_id
     std::map<libMesh::dof_id_type,libMesh::dof_id_type> _elem_id_map;

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -135,8 +135,8 @@ namespace GRINS
     //! Internal 1D mesh of EDGE2 elements
     SharedPtr<libMesh::Mesh> _mesh;
 
-    //! Map of main mesh elem_id to rayfire mesh elems
-    std::map<libMesh::dof_id_type,libMesh::Elem*> _elem_id_map;
+    //! Map of main mesh elem_id to rayfire mesh elem_id
+    std::map<libMesh::dof_id_type,libMesh::dof_id_type> _elem_id_map;
 
     //! User should never call the default constructor
     RayfireMesh();

--- a/src/qoi/include/grins/spectroscopic_absorption.h
+++ b/src/qoi/include/grins/spectroscopic_absorption.h
@@ -51,9 +51,8 @@ namespace GRINS
 
     /*!
       @param absorb AbsorptionCoeff object
-      @param rayfire Uninitialized RayfireMesh object
     */
-    SpectroscopicAbsorption( const std::string & qoi_name, SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb, SharedPtr<RayfireMesh> rayfire );
+    SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb);
 
     virtual QoIBase * clone() const;
 

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -56,6 +56,18 @@ namespace GRINS
   }
 
   template<typename Function>
+  IntegratedFunction<Function>::IntegratedFunction(const GetPot & input,unsigned int p_level,SharedPtr<Function> f,const std::string & input_qoi_string,const std::string& qoi_name) :
+    QoIBase(qoi_name),
+    _p_level(p_level),
+    _f(f)
+  {
+    _rayfire.reset(new RayfireMesh(input,input_qoi_string));
+
+    // use Gauss Quadrature
+    _qbase.reset(new libMesh::QGauss(1,libMesh::Order(_p_level)));
+  }
+
+  template<typename Function>
   QoIBase* IntegratedFunction<Function>::clone() const
   {
     return new IntegratedFunction<Function>( *this );

--- a/src/qoi/src/qoi_factory.C
+++ b/src/qoi/src/qoi_factory.C
@@ -126,8 +126,6 @@ namespace GRINS
 
     else if( qoi_name == integrated_function )
       {
-        SharedPtr<RayfireMesh> rayfire = this->construct_rayfire(input,"IntegratedFunction");
-
         std::string function;
         if (input.have_variable("QoI/IntegratedFunction/function"))
           function = input("QoI/IntegratedFunction/function", "");
@@ -138,7 +136,7 @@ namespace GRINS
 
         SharedPtr<libMesh::FunctionBase<libMesh::Real> > f = new libMesh::ParsedFunction<libMesh::Real>(function);
 
-        qoi =  new IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >(p_level,f,rayfire,integrated_function);
+        qoi =  new IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >(input,p_level,f,"IntegratedFunction",integrated_function);
       }
 
     else if ( qoi_name == spectroscopic_absorption )
@@ -202,9 +200,7 @@ namespace GRINS
         libmesh_error_msg("ERROR: GRINS must be built with either Antioch or Cantera to use the SpectroscopicAbsorption QoI");
 #endif
 
-        SharedPtr<RayfireMesh> rayfire( this->construct_rayfire(input,"SpectroscopicAbsorption") );
-
-        qoi = new SpectroscopicAbsorption(qoi_name,absorb,rayfire);
+        qoi = new SpectroscopicAbsorption(input,qoi_name,absorb);
       }
 
     else
@@ -301,37 +297,6 @@ namespace GRINS
     libMesh::err << "================================================================" << std::endl;
 
     libmesh_error();
-  }
-
-  SharedPtr<RayfireMesh> QoIFactory::construct_rayfire( const GetPot& input, const std::string qoi_string )
-  {
-    unsigned int rayfire_dim = input.vector_variable_size("QoI/"+qoi_string+"/Rayfire/origin");
-
-    if (rayfire_dim != 2)
-      libmesh_error_msg("ERROR: Only 2D Rayfires are currently supported");
-
-    if (!input.have_variable("QoI/"+qoi_string+"/Rayfire/origin"))
-      libmesh_error_msg("ERROR: No origin specified for Rayfire");
-
-    if (input.vector_variable_size("QoI/"+qoi_string+"/Rayfire/origin") != 2)
-      libmesh_error_msg("ERROR: Please specify a 2D point (x,y) for the rayfire origin");
-
-    libMesh::Point origin;
-    origin(0) = input("QoI/"+qoi_string+"/Rayfire/origin", 0.0, 0);
-    origin(1) = input("QoI/"+qoi_string+"/Rayfire/origin", 0.0, 1);
-
-    libMesh::Real theta;
-
-    if (input.have_variable("QoI/"+qoi_string+"/Rayfire/theta"))
-      theta = input("QoI/"+qoi_string+"/Rayfire/theta", -7.0);
-    else
-      libmesh_error_msg("ERROR: Spherical polar angle theta must be given for Rayfire");
-
-
-    if (input.have_variable("QoI/"+qoi_string+"/Rayfire/phi"))
-      libmesh_error_msg("ERROR: cannot specify spherical azimuthal angle phi for Rayfire, only 2D is currently supported");
-
-    return new RayfireMesh(origin,theta);
   }
 
   template<typename T>

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -119,7 +119,7 @@ namespace GRINS
           }
 
         // add new rayfire elem to the map
-        _elem_id_map[prev_elem->id()] = elem;
+        _elem_id_map[prev_elem->id()] = elem->id();
 
         start_point = end_point;
         start_node = end_node;
@@ -137,10 +137,10 @@ namespace GRINS
 
   void RayfireMesh::elem_ids_in_rayfire(std::vector<libMesh::dof_id_type>& id_vector)
   {
-    std::map<libMesh::dof_id_type,libMesh::Elem*>::iterator it = _elem_id_map.begin();
+    std::map<libMesh::dof_id_type,libMesh::dof_id_type>::iterator it = _elem_id_map.begin();
     for(; it != _elem_id_map.end(); it++)
       {
-        if (it->second->active())
+        if (_mesh->elem(it->second)->active())
           id_vector.push_back(it->first);
       }
   }
@@ -160,7 +160,7 @@ namespace GRINS
     // iterate over all main elems along the rayfire and look for
     // refinement: INACTIVE parent with JUST_REFINED children
     // coarsening: JUST_COARSENED parent
-    std::map<libMesh::dof_id_type,libMesh::Elem*>::iterator it = _elem_id_map.begin();
+    std::map<libMesh::dof_id_type,libMesh::dof_id_type>::iterator it = _elem_id_map.begin();
     for(; it != _elem_id_map.end(); it++)
       {
         const libMesh::Elem* main_elem = mesh_base.elem(it->first);
@@ -178,7 +178,7 @@ namespace GRINS
           {
             if (main_elem->has_children())
               if (main_elem->child(0)->refinement_flag() == libMesh::Elem::RefinementState::JUST_REFINED)
-                elems_to_refine.push_back(std::pair<const libMesh::Elem*, libMesh::Elem*>(main_elem,it->second));
+                elems_to_refine.push_back(std::pair<const libMesh::Elem*, libMesh::Elem*>(main_elem,_mesh->elem(it->second)));
           }
       }
 
@@ -261,11 +261,11 @@ namespace GRINS
     // return value; set if valid rayfire elem is found
     libMesh::Elem* retval = NULL;
 
-    std::map<libMesh::dof_id_type,libMesh::Elem*>::iterator it;
+    std::map<libMesh::dof_id_type,libMesh::dof_id_type>::iterator it;
     it = _elem_id_map.find(elem_id);
     if (it != _elem_id_map.end())
-      if (it->second->refinement_flag() != libMesh::Elem::RefinementState::INACTIVE)
-        retval = it->second;
+      if (_mesh->elem(it->second)->refinement_flag() != libMesh::Elem::RefinementState::INACTIVE)
+        retval = _mesh->elem(it->second);
 
     return retval;
   }
@@ -598,7 +598,7 @@ namespace GRINS
         elem->set_parent(rayfire_elem);
 
         // add new rayfire elem to the map
-        _elem_id_map[prev_elem->id()] = elem;
+        _elem_id_map[prev_elem->id()] = elem->id();
         start_point = end_point;
         prev_elem = next_elem;
         prev_node = new_node;
@@ -656,7 +656,7 @@ namespace GRINS
         libmesh_assert_less( (*(elem->get_node(0))-_origin).norm(),  (*(elem->get_node(1))-_origin).norm());
 
         // add new rayfire elem to the map
-        _elem_id_map[parent_elem->id()] = elem;
+        _elem_id_map[parent_elem->id()] = elem->id();
       }
 
   }

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -178,9 +178,9 @@ namespace GRINS
   }
 
 
-  void RayfireMesh::elem_ids_in_rayfire(std::vector<libMesh::dof_id_type>& id_vector)
+  void RayfireMesh::elem_ids_in_rayfire(std::vector<libMesh::dof_id_type>& id_vector) const
   {
-    std::map<libMesh::dof_id_type,libMesh::dof_id_type>::iterator it = _elem_id_map.begin();
+    std::map<libMesh::dof_id_type,libMesh::dof_id_type>::const_iterator it = _elem_id_map.begin();
     for(; it != _elem_id_map.end(); it++)
       {
         if (_mesh->elem(it->second)->active())

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -89,6 +89,18 @@ namespace GRINS
       libmesh_error_msg("ERROR: cannot specify spherical azimuthal angle phi for Rayfire, only 2D is currently supported");
   }
 
+  RayfireMesh::RayfireMesh(const RayfireMesh & original) :
+    _dim(original._dim),
+    _origin(original._origin),
+    _theta(original._theta),
+    _phi(original._phi)
+  {
+    if (original._mesh.get())
+      this->_mesh.reset( new libMesh::Mesh( *((original._mesh).get()) ) );
+      
+    this->_elem_id_map = original._elem_id_map;
+  }
+
   void RayfireMesh::init(const libMesh::MeshBase& mesh_base)
   {
     // consistency check

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -58,6 +58,37 @@ namespace GRINS
       libmesh_error_msg("Please supply a theta value between -2*pi and 2*pi");
   }
 
+  RayfireMesh::RayfireMesh(const GetPot & input, const std::string & qoi_string) :
+    _dim(2),
+    _phi(-7.0)
+  {
+    unsigned int rayfire_dim = input.vector_variable_size("QoI/"+qoi_string+"/Rayfire/origin");
+
+    if (rayfire_dim != 2)
+      libmesh_error_msg("ERROR: Only 2D Rayfires are currently supported");
+
+    if (!input.have_variable("QoI/"+qoi_string+"/Rayfire/origin"))
+      libmesh_error_msg("ERROR: No origin specified for Rayfire");
+
+    if (input.vector_variable_size("QoI/"+qoi_string+"/Rayfire/origin") != 2)
+      libmesh_error_msg("ERROR: Please specify a 2D point (x,y) for the rayfire origin");
+
+    libMesh::Point origin;
+    _origin(0) = input("QoI/"+qoi_string+"/Rayfire/origin", 0.0, 0);
+    _origin(1) = input("QoI/"+qoi_string+"/Rayfire/origin", 0.0, 1);
+
+    if (input.have_variable("QoI/"+qoi_string+"/Rayfire/theta"))
+        _theta = input("QoI/"+qoi_string+"/Rayfire/theta", -7.0);
+    else
+        libmesh_error_msg("ERROR: Spherical polar angle theta must be given for Rayfire");
+
+    if (std::abs(_theta) > 2.0*Constants::pi)
+      libmesh_error_msg("Please supply a theta value between -2*pi and 2*pi");
+
+    if (input.have_variable("QoI/"+qoi_string+"/Rayfire/phi"))
+      libmesh_error_msg("ERROR: cannot specify spherical azimuthal angle phi for Rayfire, only 2D is currently supported");
+  }
+
   void RayfireMesh::init(const libMesh::MeshBase& mesh_base)
   {
     // consistency check
@@ -71,7 +102,7 @@ namespace GRINS
         libmesh_error_msg(ss.str());
       }
 
-    _mesh = new libMesh::Mesh(mesh_base.comm(),(unsigned char)1);
+    _mesh.reset( new libMesh::Mesh(mesh_base.comm(),(unsigned char)1) );
 
     libMesh::Point start_point(_origin);
 

--- a/src/qoi/src/spectroscopic_absorption.C
+++ b/src/qoi/src/spectroscopic_absorption.C
@@ -42,8 +42,8 @@
 
 namespace GRINS
 {
-  SpectroscopicAbsorption::SpectroscopicAbsorption( const std::string & qoi_name, SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb, SharedPtr<RayfireMesh> rayfire)
-    : IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >(2 /* QGauss order */,absorb,rayfire,qoi_name)
+  SpectroscopicAbsorption::SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb)
+    : IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >(input,2 /* QGauss order */,absorb,"SpectroscopicAbsorption",qoi_name)
   {}
 
   QoIBase * SpectroscopicAbsorption::clone() const


### PR DESCRIPTION
This PR fixes a memory leak. The internal `_mesh` in `RayfireMesh` was not getting properly destroyed because there seemed to be 3 copies of the `IntegratedFunction` class floating around, so the destructor wasn't ever called. I wasn't able to find the root cause, but this PR fixes the issue and is probably better design-wise.

674f3ac changes the internal `_elem_id_map` to not store raw `Elem*` for rayfire elems.

91c362c new constructor that passes the GetPot object through to the `RayfireMesh` class to allow it to construct itself. This is not strictly necessary I guess; we can just pass a `RayfireMesh*` to the `IntegratedFunction` constructor, which would then take control of the object. But I added this so that the rayfire would not have to be created outside `IntegratedFunction` and leave a dead pointer hanging around. 

d8c536a we use `UniquePtr`'s internally instead of `SharedPtr`'s, and add proper copy-constructors to deep-copy objects on `clone()`. We also don't need to have the `QGauss` object as a class variable, we can just create it within `element_qoi()` each time.

The final 3 commits update the IntegratedFunction test to work with the new API.