### PR TITLE
Add Instantiations for Antioch::IdealGasMicroThermo/NASA9

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ an external chemistry library. While [Cantera](http://code.google.com/p/cantera/
 partially supported, [Antioch](https://github.com/libantioch/antioch) is fully
 supported.
 
+The current required minimum hash for using Antioch is libantioch/antioch@ad78595 (libantioch/antioch#240).
+
+
 Building GRINS 
 ================
 

--- a/src/physics/include/grins/antioch_instantiation_macro.h
+++ b/src/physics/include/grins/antioch_instantiation_macro.h
@@ -37,6 +37,14 @@
   template class GRINS::class_name<Antioch::StatMechThermodynamics<libMesh::Real>, \
                                    Antioch::BlottnerViscosity<libMesh::Real>, \
                                    Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
+                                   Antioch::ConstantLewisDiffusivity<libMesh::Real> >; \
+  template class GRINS::class_name<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>, \
+                                   Antioch::SutherlandViscosity<libMesh::Real>, \
+                                   Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> >, \
+                                   Antioch::ConstantLewisDiffusivity<libMesh::Real> >; \
+  template class GRINS::class_name<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>, \
+                                   Antioch::BlottnerViscosity<libMesh::Real>, \
+                                   Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> >, \
                                    Antioch::ConstantLewisDiffusivity<libMesh::Real> >
 
 

--- a/src/physics/include/grins/antioch_instantiation_macro.h
+++ b/src/physics/include/grins/antioch_instantiation_macro.h
@@ -53,6 +53,10 @@
   template class GRINS::class_name<Antioch::StatMechThermodynamics<libMesh::Real>, \
                                    Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
                                    Antioch::KineticsTheoryThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real>,libMesh::Real>, \
+                                   Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> >; \
+  template class GRINS::class_name<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>, \
+                                   Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
+                                   Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > >,libMesh::Real>, \
                                    Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> >
 #endif // ANTIOCH_HAVE_GSL
 

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_macro.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_macro.h
@@ -17,50 +17,50 @@ template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<A
                                                                                Antioch::ConstantLewisDiffusivity<libMesh::Real> >, \
                                  GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>, \
                                                                                  Antioch::SutherlandViscosity<libMesh::Real>, \
-                                 Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
-                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> > >;\
-                                 /*
-                                  *MixtureAveraged: StatMech thermo, Blottner viscosity, Eucken conductivity, constant Lewis diffusivity
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
-                                 Antioch::BlottnerViscosity<libMesh::Real>, \
-                                 Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
-                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> >, \
-                                 GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>, \
-                                 Antioch::BlottnerViscosity<libMesh::Real>, \
-                                 Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
-                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> > >; \
-                                 /*
-                                  *MixtureAveraged: StatMech thermo, Kinetic theory viscosity, Kinetic theory  conductivity, Molecular binary diffusivity
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
-                                 Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
-                                 Antioch::KineticsTheoryThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real>,libMesh::Real>, \
-                                 Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> >, \
-                                 GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>, \
-                                 Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
-                                 Antioch::KineticsTheoryThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real>,libMesh::Real>, \
-                                 Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >; \
-                                 /*
-                                  *Constant viscosity, constant Lewis diffusivity, constant conductivity, StatMech thermo
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity>, \
-                                 GRINS::AntiochConstantTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>, GRINS::ConstantConductivity> >; \
-                                 /*
-                                  *Constant viscosity, constant Lewis diffusivity, constant Prandtl conductivity, StatMech thermo
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantPrandtlConductivity>,\
-                                 GRINS::AntiochConstantTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>, GRINS::ConstantPrandtlConductivity> >; \
-                                 /*
-                                  *Constant viscosity, constant Lewis diffusivity, constant conductivity, CEA thermo
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity>,\
-                                 GRINS::AntiochConstantTransportEvaluator<Antioch::CEAEvaluator<libMesh::Real>, GRINS::ConstantConductivity> >; \
-                                 /*
-                                  *Constant viscosity, constant Lewis diffusivity, constant Prandtl conductivity, CEA thermo
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantPrandtlConductivity>, \
-                                 GRINS::AntiochConstantTransportEvaluator<Antioch::CEAEvaluator<libMesh::Real>, GRINS::ConstantPrandtlConductivity> >
+                                                                                 Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
+                                                                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> > >; \
+  /*
+   *MixtureAveraged: StatMech thermo, Blottner viscosity, Eucken conductivity, constant Lewis diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
+                                                                                 Antioch::BlottnerViscosity<libMesh::Real>, \
+                                                                                 Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
+                                                                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> >, \
+                                   GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>, \
+                                                                                   Antioch::BlottnerViscosity<libMesh::Real>, \
+                                                                                   Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
+                                                                                   Antioch::ConstantLewisDiffusivity<libMesh::Real> > >; \
+  /*
+   *MixtureAveraged: StatMech thermo, Kinetic theory viscosity, Kinetic theory  conductivity, Molecular binary diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
+                                                                                 Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
+                                                                                 Antioch::KineticsTheoryThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real>,libMesh::Real>, \
+                                                                                 Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> >, \
+                                   GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>, \
+                                                                                   Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
+                                                                                   Antioch::KineticsTheoryThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real>,libMesh::Real>, \
+                                                                                   Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >; \
+  /*
+   *Constant viscosity, constant Lewis diffusivity, constant conductivity, StatMech thermo
+   */ \
+  template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity>, \
+                                   GRINS::AntiochConstantTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>, GRINS::ConstantConductivity> >; \
+  /*
+   *Constant viscosity, constant Lewis diffusivity, constant Prandtl conductivity, StatMech thermo
+   */ \
+  template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantPrandtlConductivity>,\
+                                   GRINS::AntiochConstantTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>, GRINS::ConstantPrandtlConductivity> >; \
+  /*
+   *Constant viscosity, constant Lewis diffusivity, constant conductivity, CEA thermo
+   */ \
+  template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity>,\
+                                   GRINS::AntiochConstantTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>, GRINS::ConstantConductivity> >; \
+  /*
+   *Constant viscosity, constant Lewis diffusivity, constant Prandtl conductivity, CEA thermo
+   */ \
+  template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantPrandtlConductivity>, \
+                                   GRINS::AntiochConstantTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>, GRINS::ConstantPrandtlConductivity> >
 
 
 #define INSTANTIATE_REACTING_LOW_MACH_SUBCLASS_MIXTURE_ONLY(class_name) \

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_macro.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_macro.h
@@ -64,6 +64,17 @@ template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<A
                                                                                    Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >, \
                                                                                    Antioch::ConstantLewisDiffusivity<libMesh::Real> > >; \
   /*
+   *MixtureAveraged: IdealGasMicroThermo/CEA thermo, Kinetic theory viscosity, Kinetic theory  conductivity, Molecular binary diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >, \
+                                                                                 Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
+                                                                                 Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,libMesh::Real>, \
+                                                                                 Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> >, \
+                                   GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >, \
+                                                                                   Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
+                                                                                   Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,libMesh::Real>, \
+                                                                                   Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >; \
+  /*
    *Constant viscosity, constant Lewis diffusivity, constant conductivity, StatMech thermo
    */ \
   template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity>, \
@@ -121,6 +132,13 @@ template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<A
                                                                                  Antioch::BlottnerViscosity<libMesh::Real>, \
                                                                                  Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >, \
                                                                                  Antioch::ConstantLewisDiffusivity<libMesh::Real> > >;\
+  /*
+   *MixtureAveraged: StatMech thermo, Kinetic theory viscosity, Kinetic theory  conductivity, Molecular binary diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >, \
+                                                                                 Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
+                                                                                 Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,libMesh::Real>, \
+                                                                                 Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >; \
   /*
    *Constant transport: constant conductivity
    */ \

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_macro.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_macro.h
@@ -42,6 +42,28 @@ template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<A
                                                                                    Antioch::KineticsTheoryThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real>,libMesh::Real>, \
                                                                                    Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >; \
   /*
+   *MixtureAveraged: IdealGasMicroThermo/CEA thermo, Sutherland viscosity, Eucken conductivity, constant Lewis diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >, \
+                                                                                 Antioch::SutherlandViscosity<libMesh::Real>, \
+                                                                                 Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >, \
+                                                                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> >, \
+                                   GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >, \
+                                                                                   Antioch::SutherlandViscosity<libMesh::Real>, \
+                                                                                   Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >, \
+                                                                                   Antioch::ConstantLewisDiffusivity<libMesh::Real> > >; \
+  /*
+   *MixtureAveraged: IdealGasMicroThermo/CEA thermo, Blottner viscosity, Eucken conductivity, constant Lewis diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >, \
+                                                                                 Antioch::BlottnerViscosity<libMesh::Real>, \
+                                                                                 Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >, \
+                                                                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> >, \
+                                   GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >, \
+                                                                                   Antioch::BlottnerViscosity<libMesh::Real>, \
+                                                                                   Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >, \
+                                                                                   Antioch::ConstantLewisDiffusivity<libMesh::Real> > >; \
+  /*
    *Constant viscosity, constant Lewis diffusivity, constant conductivity, StatMech thermo
    */ \
   template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity>, \
@@ -64,34 +86,48 @@ template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<A
 
 
 #define INSTANTIATE_REACTING_LOW_MACH_SUBCLASS_MIXTURE_ONLY(class_name) \
-                                 /*
-                                  *MixtureAveraged: StatMech thermo, Sutherland viscosity, Eucken conductivity, constant Lewis diffusivity
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
-                                 Antioch::SutherlandViscosity<libMesh::Real>, \
-                                 Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
-                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> > >;\
-                                 /*
-                                  *MixtureAveraged: StatMech thermo, Blottner viscosity, Eucken conductivity, constant Lewis diffusivity
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
-                                 Antioch::BlottnerViscosity<libMesh::Real>, \
-                                 Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
-                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> > >; \
-                                 /*
-                                  *MixtureAveraged: StatMech thermo, Kinetic theory viscosity, Kinetic theory  conductivity, Molecular binary diffusivity
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
-                                 Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
-                                 Antioch::KineticsTheoryThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real>,libMesh::Real>, \
-                                 Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >; \
-                                 /*
-                                  *Constant transport: constant conductivity
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity> >; \
-                                 /*
-                                  *Constant transport: constant Prandtl conductivity
-                                  */ \
-                                 template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantPrandtlConductivity> >
+  /*
+   *MixtureAveraged: StatMech thermo, Sutherland viscosity, Eucken conductivity, constant Lewis diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
+                                                                                 Antioch::SutherlandViscosity<libMesh::Real>, \
+                                                                                 Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
+                                                                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> > >;\
+  /*
+   *MixtureAveraged: StatMech thermo, Blottner viscosity, Eucken conductivity, constant Lewis diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
+                                                                                 Antioch::BlottnerViscosity<libMesh::Real>, \
+                                                                                 Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >, \
+                                                                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> > >; \
+  /*
+   *MixtureAveraged: StatMech thermo, Kinetic theory viscosity, Kinetic theory  conductivity, Molecular binary diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::StatMechThermodynamics<libMesh::Real>, \
+                                                                                 Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>, \
+                                                                                 Antioch::KineticsTheoryThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real>,libMesh::Real>, \
+                                                                                 Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >; \
+  /*
+   *MixtureAveraged: IdealGasMicroThermo/CEA thermo, Sutherland viscosity, Eucken conductivity, constant Lewis diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >, \
+                                                                                 Antioch::SutherlandViscosity<libMesh::Real>, \
+                                                                                 Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >, \
+                                                                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> > >;\
+  /*
+   *MixtureAveraged: IdealGasMicroThermo/CEA thermo, Blottner viscosity, Eucken conductivity, constant Lewis diffusivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >, \
+                                                                                 Antioch::BlottnerViscosity<libMesh::Real>, \
+                                                                                 Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >, \
+                                                                                 Antioch::ConstantLewisDiffusivity<libMesh::Real> > >;\
+  /*
+   *Constant transport: constant conductivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity> >; \
+  /*
+   *Constant transport: constant Prandtl conductivity
+   */ \
+  template class GRINS::class_name<GRINS::AntiochConstantTransportMixture<GRINS::ConstantPrandtlConductivity> >
 
 #endif // GRINS_REACTING_LOW_MACH_NAVIER_STOKES_MACRO_H

--- a/src/physics/src/physics_factory_reacting_flows.C
+++ b/src/physics/src/physics_factory_reacting_flows.C
@@ -140,7 +140,7 @@ namespace GRINS
                      (conductivity_model == std::string("constant")) )
               {
                 new_physics.reset(new DerivedPhysics<GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity>,
-                                  GRINS::AntiochConstantTransportEvaluator<Antioch::CEAEvaluator<libMesh::Real>, GRINS::ConstantConductivity> >
+                                                     GRINS::AntiochConstantTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > >, GRINS::ConstantConductivity> >
                                   (physics_name,input) );
               }
             else if( (thermo_model == std::string("stat_mech")) &&
@@ -154,7 +154,7 @@ namespace GRINS
                      (conductivity_model == std::string("constant_prandtl")) )
               {
                 new_physics.reset(new DerivedPhysics<GRINS::AntiochConstantTransportMixture<GRINS::ConstantPrandtlConductivity>,
-                                  GRINS::AntiochConstantTransportEvaluator<Antioch::CEAEvaluator<libMesh::Real>, GRINS::ConstantPrandtlConductivity> >
+                                                     GRINS::AntiochConstantTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > >, GRINS::ConstantPrandtlConductivity> >
                                   (physics_name,input) );
               }
             else

--- a/src/physics/src/physics_factory_reacting_flows.C
+++ b/src/physics/src/physics_factory_reacting_flows.C
@@ -117,6 +117,36 @@ namespace GRINS
                 libmesh_error_msg("ERROR: Antioch requires GSL in order to use kinetics theory based models!");
 #endif // ANTIOCH_HAVE_GSL
               }
+            else if( (thermo_model == std::string("cea")) &&
+                     (diffusivity_model == std::string("constant_lewis")) &&
+                     (conductivity_model == std::string("eucken")) &&
+                     (viscosity_model == std::string("sutherland")) )
+              {
+                new_physics.reset(new DerivedPhysics<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,
+                                                                                                   Antioch::SutherlandViscosity<libMesh::Real>,
+                                                                                                   Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >,
+                                                                                                   Antioch::ConstantLewisDiffusivity<libMesh::Real> >,
+                                                     GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,
+                                                                                                     Antioch::SutherlandViscosity<libMesh::Real>,
+                                                                                                     Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >,
+                                                                                                     Antioch::ConstantLewisDiffusivity<libMesh::Real> > >
+                                  (physics_name,input) );
+              }
+            else if( (thermo_model == std::string("cea")) &&
+                     (diffusivity_model == std::string("constant_lewis")) &&
+                     (conductivity_model == std::string("eucken")) &&
+                     (viscosity_model == std::string("blottner")) )
+              {
+                new_physics.reset(new DerivedPhysics<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,
+                                                                                                   Antioch::BlottnerViscosity<libMesh::Real>,
+                                                                                                   Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >,
+                                                                                                   Antioch::ConstantLewisDiffusivity<libMesh::Real> >,
+                                                     GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,
+                                                                                                     Antioch::BlottnerViscosity<libMesh::Real>,
+                                                                                                     Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real > >,
+                                                                                                     Antioch::ConstantLewisDiffusivity<libMesh::Real> > >
+                                  (physics_name,input) );
+              }
             else
               this->grins_antioch_model_error_msg(viscosity_model,conductivity_model,diffusivity_model,thermo_model);
           }

--- a/src/physics/src/physics_factory_reacting_flows.C
+++ b/src/physics/src/physics_factory_reacting_flows.C
@@ -147,6 +147,24 @@ namespace GRINS
                                                                                                      Antioch::ConstantLewisDiffusivity<libMesh::Real> > >
                                   (physics_name,input) );
               }
+            else if( (thermo_model == std::string("cea")) &&
+                     (diffusivity_model == std::string("kinetics_theory")) &&
+                     (conductivity_model == std::string("kinetics_theory")) &&
+                     (viscosity_model == std::string("kinetics_theory")) )
+              {
+#ifdef ANTIOCH_HAVE_GSL
+                new_physics.reset(new DerivedPhysics<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,
+                                                                                                   Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,
+                                                                                                   Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,libMesh::Real>,
+                                                                                                   Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> >,
+                                                     GRINS::AntiochMixtureAveragedTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,
+                                                                                                     Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,
+                                                                                                     Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real >,libMesh::Real>,
+                                                                                                     Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >(physics_name,input) );
+#else
+                libmesh_error_msg("ERROR: Antioch requires GSL in order to use kinetics theory based models!");
+#endif // ANTIOCH_HAVE_GSL
+              }
             else
               this->grins_antioch_model_error_msg(viscosity_model,conductivity_model,diffusivity_model,thermo_model);
           }

--- a/src/properties/include/grins/antioch_kinetics.h
+++ b/src/properties/include/grins/antioch_kinetics.h
@@ -78,7 +78,7 @@ namespace GRINS
 
     Antioch::KineticsEvaluator<libMesh::Real> _antioch_kinetics;
 
-    Antioch::CEAEvaluator<libMesh::Real> _antioch_cea_thermo;
+    Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > _antioch_cea_thermo;
 
   private:
 

--- a/src/properties/include/grins/antioch_mixture.h
+++ b/src/properties/include/grins/antioch_mixture.h
@@ -41,7 +41,8 @@
 #include "antioch/vector_utils_decl.h"
 #include "antioch/vector_utils.h"
 #include "antioch/chemical_mixture.h"
-#include "antioch/cea_mixture.h"
+#include "antioch/nasa_mixture.h"
+#include "antioch/cea_curve_fit.h"
 #include "antioch/reaction_set.h"
 
 // libMesh forward declarations
@@ -74,7 +75,7 @@ namespace GRINS
 
     const Antioch::ReactionSet<libMesh::Real>& reaction_set() const;
 
-    const Antioch::CEAThermoMixture<libMesh::Real>& cea_mixture() const;
+    const Antioch::NASAThermoMixture<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > & cea_mixture() const;
 
     libMesh::Real h_stat_mech_ref_correction( unsigned int species ) const;
 
@@ -90,7 +91,7 @@ namespace GRINS
 
     libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > _reaction_set;
 
-    libMesh::UniquePtr<Antioch::CEAThermoMixture<libMesh::Real> > _cea_mixture;
+    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > > _cea_mixture;
 
     std::vector<libMesh::Real> _h_stat_mech_ref_correction;
 
@@ -128,7 +129,7 @@ namespace GRINS
   }
 
   inline
-  const Antioch::CEAThermoMixture<libMesh::Real>& AntiochMixture::cea_mixture() const
+  const Antioch::NASAThermoMixture<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > & AntiochMixture::cea_mixture() const
   {
     return *_cea_mixture.get();
   }

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
@@ -140,14 +140,6 @@ namespace GRINS
       return;
     }
 
-    void specialized_build_thermo( const GetPot& /*input*/,
-                                   libMesh::UniquePtr<Antioch::CEAEvaluator<libMesh::Real> >& thermo,
-                                   thermo_type<Antioch::CEAEvaluator<libMesh::Real> > )
-    {
-      thermo.reset( new Antioch::CEAEvaluator<libMesh::Real>( this->cea_mixture() ) );
-      return;
-    }
-
     void specialized_build_viscosity( const GetPot& input,
                                       const std::string& material,
                                       libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> >& viscosity,

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
@@ -42,7 +42,9 @@
 // Antioch
 #include "antioch/vector_utils_decl.h"
 #include "antioch/vector_utils.h"
-#include "antioch/cea_evaluator.h"
+#include "antioch/cea_curve_fit.h"
+#include "antioch/nasa_evaluator.h"
+#include "antioch/ideal_gas_micro_thermo.h"
 #include "antioch/stat_mech_thermo.h"
 #include "antioch/mixture_averaged_transport_mixture.h"
 #include "antioch/mixture_viscosity.h"
@@ -106,6 +108,9 @@ namespace GRINS
 
     libMesh::UniquePtr<Thermo> _thermo;
 
+    //! For some Thermo types, we also need to cache a NASAEvaluator.
+    libMesh::UniquePtr<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > > _cea_evaluator;
+
     libMesh::UniquePtr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> > _viscosity;
 
     libMesh::UniquePtr<Antioch::MixtureConductivity<Conductivity,libMesh::Real> > _conductivity;
@@ -137,7 +142,14 @@ namespace GRINS
                                    thermo_type<Antioch::StatMechThermodynamics<libMesh::Real> > )
     {
       thermo.reset( new Antioch::StatMechThermodynamics<libMesh::Real>( *(this->_antioch_gas.get()) ) );
-      return;
+    }
+
+    void specialized_build_thermo( const GetPot& /*input*/,
+                                   libMesh::UniquePtr<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> >& thermo,
+                                   thermo_type<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> > )
+    {
+      _cea_evaluator.reset( new Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >(this->cea_mixture()) );
+      thermo.reset( new Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>( *_cea_evaluator, *(this->_antioch_gas.get()) ) );
     }
 
     void specialized_build_viscosity( const GetPot& input,

--- a/src/properties/src/antioch_constant_transport_instantiate.C
+++ b/src/properties/src/antioch_constant_transport_instantiate.C
@@ -44,9 +44,9 @@
 template class GRINS::AntiochConstantTransportMixture<GRINS::ConstantConductivity>;
 template class GRINS::AntiochConstantTransportMixture<GRINS::ConstantPrandtlConductivity>;
 
-template class GRINS::AntiochConstantTransportEvaluator<Antioch::CEAEvaluator<libMesh::Real>,
+template class GRINS::AntiochConstantTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
                                                         GRINS::ConstantConductivity>;
-template class GRINS::AntiochConstantTransportEvaluator<Antioch::CEAEvaluator<libMesh::Real>,
+template class GRINS::AntiochConstantTransportEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
                                                         GRINS::ConstantPrandtlConductivity>;
 
 template class GRINS::AntiochConstantTransportEvaluator<Antioch::StatMechThermodynamics<libMesh::Real>,

--- a/src/properties/src/antioch_evaluator.C
+++ b/src/properties/src/antioch_evaluator.C
@@ -60,12 +60,33 @@ namespace GRINS
   }
 
   template<>
-  libMesh::Real AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::cp( const libMesh::Real& T,
-                                                                             const libMesh::Real /*P*/,
-                                                                             const std::vector<libMesh::Real>& Y )
+  libMesh::Real
+  AntiochEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> >::
+  cp( const libMesh::Real& T,
+      const libMesh::Real /*P*/,
+      const std::vector<libMesh::Real>& Y )
   {
     this->check_and_reset_temp_cache(T);
-    return _thermo->cp( *(_temp_cache.get()), Y );
+    return this->_cea_evaluator->cp( *(_temp_cache.get()), Y );
+  }
+
+  template<>
+  libMesh::Real AntiochEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> >::
+  cv( const libMesh::Real& T,
+      const libMesh::Real /*P*/,
+      const std::vector<libMesh::Real>& Y )
+  {
+    this->check_and_reset_temp_cache(T);
+    return this->_cea_evaluator->cv( *(_temp_cache.get()), Y );
+  }
+
+  template<>
+  libMesh::Real AntiochEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> >::
+  h_s( const libMesh::Real& T, unsigned int species )
+  {
+    this->check_and_reset_temp_cache(T);
+
+    return this->_cea_evaluator->h( *(_temp_cache.get()), species );;
   }
 
   template<>
@@ -73,16 +94,7 @@ namespace GRINS
                                                                                        const libMesh::Real /*P*/,
                                                                                        const std::vector<libMesh::Real>& Y )
   {
-    return _thermo->cp( T, T, Y );
-  }
-
-  template<>
-  libMesh::Real AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::cv( const libMesh::Real& T,
-                                                                             const libMesh::Real /*P*/,
-                                                                             const std::vector<libMesh::Real>& Y )
-  {
-    this->check_and_reset_temp_cache(T);
-    return _thermo->cv( *(_temp_cache.get()), Y );
+    return this->_thermo->cp( T, T, Y );
   }
 
   template<>
@@ -90,21 +102,13 @@ namespace GRINS
                                                                                        const libMesh::Real /*P*/,
                                                                                        const std::vector<libMesh::Real>& Y )
   {
-    return _thermo->cv( T, T, Y );
-  }
-
-  template<>
-  libMesh::Real AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >::h_s( const libMesh::Real& T, unsigned int species )
-  {
-    this->check_and_reset_temp_cache(T);
-
-    return _thermo->h( *(_temp_cache.get()), species );;
+    return this->_thermo->cv( T, T, Y );
   }
 
   template<>
   libMesh::Real AntiochEvaluator<Antioch::StatMechThermodynamics<libMesh::Real> >::h_s( const libMesh::Real& T, unsigned int species )
   {
-    return _thermo->h_tot( species, T ) + _chem.h_stat_mech_ref_correction(species);
+    return this->_thermo->h_tot( species, T ) + _chem.h_stat_mech_ref_correction(species);
   }
 
 } // end namespace GRINS

--- a/src/properties/src/antioch_evaluator_instantiate.C
+++ b/src/properties/src/antioch_evaluator_instantiate.C
@@ -33,11 +33,12 @@
 // Antioch
 #include "antioch/cea_evaluator.h"
 #include "antioch/stat_mech_thermo.h"
+#include "antioch/ideal_gas_micro_thermo.h"
 
 // This class
 #include "antioch_evaluator.C"
 
-template class GRINS::AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> >;
 template class GRINS::AntiochEvaluator<Antioch::StatMechThermodynamics<libMesh::Real> >;
+template class GRINS::AntiochEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real, Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> >;
 
 #endif //GRINS_HAVE_ANTIOCH

--- a/src/properties/src/antioch_mixture.C
+++ b/src/properties/src/antioch_mixture.C
@@ -40,7 +40,7 @@
 
 // Antioch
 #include "antioch/read_reaction_set_data.h"
-#include "antioch/cea_mixture_ascii_parsing.h"
+#include "antioch/nasa_mixture_parsing.h"
 #include "antioch/stat_mech_thermo.h"
 
 namespace GRINS
@@ -49,7 +49,7 @@ namespace GRINS
                                   const std::string& material )
     : AntiochChemistry(input,material),
       _reaction_set( new Antioch::ReactionSet<libMesh::Real>( (*_antioch_gas.get()) ) ),
-      _cea_mixture( new Antioch::CEAThermoMixture<libMesh::Real>( (*_antioch_gas.get()) ) ),
+      _cea_mixture( new Antioch::NASAThermoMixture<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >( (*_antioch_gas.get()) ) ),
       _minimum_T( input( "Materials/"+material+"/GasMixture/Antioch/minimum_T", -std::numeric_limits<libMesh::Real>::max() ) ),
       _clip_negative_rho( input( "Materials/"+material+"/GasMixture/Antioch/clip_negative_rho", false) )
   {
@@ -63,7 +63,7 @@ namespace GRINS
     if( cea_data_filename == std::string("default") )
       cea_data_filename = Antioch::DefaultInstallFilename::thermo_data();
 
-    Antioch::read_cea_mixture_data_ascii( *_cea_mixture.get(), cea_data_filename );
+    Antioch::read_nasa_mixture_data( *_cea_mixture.get(), cea_data_filename, Antioch::ASCII, true );
 
     this->build_stat_mech_ref_correction();
   }

--- a/test/interface/air_5sp.C
+++ b/test/interface/air_5sp.C
@@ -217,13 +217,13 @@ namespace GRINSTesting
       Y[_O_idx] = 0.2;
       Y[_N_idx] = 0.05;
 
-      this->test_cp_common<GRINS::AntiochMixture,GRINS::AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> > >
+      this->test_cp_common<GRINS::AntiochMixture,GRINS::AntiochEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> > >
         ( *_antioch_mixture, Y, TestingUtils::epsilon()*100 );
     }
 
     void test_hs()
     {
-      this->test_h_common<GRINS::AntiochMixture,GRINS::AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> > >
+      this->test_h_common<GRINS::AntiochMixture,GRINS::AntiochEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> > >
         ( *_antioch_mixture, TestingUtils::epsilon()*100 );
     }
   };
@@ -262,7 +262,7 @@ namespace GRINSTesting
 
       AirNASA9Thermo thermo;
 
-      this->test_omega_dot_common<GRINS::AntiochMixture,GRINS::AntiochEvaluator<Antioch::CEAEvaluator<libMesh::Real> > >
+      this->test_omega_dot_common<GRINS::AntiochMixture,GRINS::AntiochEvaluator<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> > >
         ( *_antioch_mixture, thermo, Y, TestingUtils::epsilon()*1e3 );
     }
   };


### PR DESCRIPTION
This adds in support for using `Antioch::IdealGasMicroThermo`, with NASA9, for reacting Low Mach physics kernels. Instead of trying to compute vibrational and electronic energies directly, this uses the NASA9 curve fits to get the total cv, etc., and then subtracts off `cv_trans` and `cv_rot` to get `cv_vib`, which is needed for some transport models.

I've done a little bit of testing in examples and seems to work OK, but I haven't been able to encapsulate as a regression test yet. So we can wait to merge until that time.

Future PRs will add NASA7 versions of this (which will require some tweaks to input parsing).

This should not be merged before libantioch/antioch#240 as this PR depends on that.

Actually, we shouldn't merge this until the README is updated with the commit on the Antioch branch that's required.