### PR TITLE
Output Thermal Conductivity and Diffusion Coefficients

### DIFF
--- a/src/physics/include/grins/reacting_low_mach_navier_stokes.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes.h
@@ -104,6 +104,9 @@ namespace GRINS
     //! Index from registering this quantity. Each species will have it's own index.
     std::vector<unsigned int> _omega_dot_index;
 
+    //! Index from registering this quantity. Each species will have it's own index.
+    std::vector<unsigned int> _Ds_index;
+
   private:
 
     ReactingLowMachNavierStokes();

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -701,11 +701,22 @@ namespace GRINS
     else if( quantity_index == this->_k_index )
       {
         std::vector<libMesh::Real> Y( this->_n_species );
+
         libMesh::Real T = this->T(point,context);
         this->mass_fractions( point, context, Y );
         libMesh::Real p0 = this->get_p0_steady(context,point);
 
-        value = gas_evaluator.k( T, p0, Y );
+        libMesh::Real cp = gas_evaluator.cp( T, p0, Y );
+
+        libMesh::Real rho = this->rho( T, p0, gas_evaluator.R_mix(Y) );
+
+        libMesh::Real mu, k;
+        std::vector<libMesh::Real> D( this->_n_species );
+
+        gas_evaluator.mu_and_k_and_D( T, rho, cp, Y, mu, k, D );
+
+        value = k;
+        return;
       }
     else if( quantity_index == this->_cp_index )
       {


### PR DESCRIPTION
This uses a more inefficient way of computing these, but since we basically only want to do this for postprocessing/debugging/sanity-checking anyway, I'm not going to sweat the inefficiency of it at this point. I just wanted to capture this as it was/is part of debugging new thermo/transport models in reacting Low Mach.