### PR TITLE
Fix broken example input file

### DIFF
--- a/examples/transient_amr/convection_diffusion_unsteady_2d_amr.in
+++ b/examples/transient_amr/convection_diffusion_unsteady_2d_amr.in
@@ -38,13 +38,13 @@
    bc_id_name_map = 'WholeBoundary'
 
    [./WholeBoundary]
-      [./GenericVariable:ConvectionDiffusion]
+      [./SingleVariable]
          type = 'parsed_dirichlet'
          u = '${TestExactSolution/value}'
 []
 
 [Variables]
-   [./GenericVariable:ConvectionDiffusion]
+   [./SingleVariable]
       names = 'u'
       fe_family = 'LAGRANGE'
       order = 'FIRST'


### PR DESCRIPTION
This breakage snuck in while I was refactoring `Variable` parsing. We really need to get example checking into CIVET.

Will merge this obvious fix once CIVET runs.