### PR TITLE
Moved CachedValues to AssemblyContext

### DIFF
--- a/src/physics/include/grins/assembly_context.h
+++ b/src/physics/include/grins/assembly_context.h
@@ -29,6 +29,9 @@
 // libMesh
 #include "libmesh/fem_context.h"
 
+// GRINS
+#include "grins/cached_values.h"
+
 namespace GRINS
 {
   class AssemblyContext : public libMesh::FEMContext
@@ -38,7 +41,15 @@ namespace GRINS
     AssemblyContext( const libMesh::System& system );
     ~AssemblyContext();
 
+    CachedValues & get_cached_values()
+    { return _cached_values; }
+
+    const CachedValues & get_cached_values() const
+    { return _cached_values; }
+
   protected:
+
+    CachedValues _cached_values;
 
   };
 

--- a/src/physics/include/grins/averaged_fan.h
+++ b/src/physics/include/grins/averaged_fan.h
@@ -68,8 +68,7 @@ namespace GRINS
 
     // Constraint part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     //! Compute value of postprocessed quantities at libMesh::Point.
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,

--- a/src/physics/include/grins/averaged_fan_adjoint_stab.h
+++ b/src/physics/include/grins/averaged_fan_adjoint_stab.h
@@ -56,12 +56,10 @@ namespace GRINS
     virtual void init_context( AssemblyContext& context );
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/averaged_turbine.h
+++ b/src/physics/include/grins/averaged_turbine.h
@@ -57,25 +57,22 @@ namespace GRINS
 
     ~AveragedTurbine(){};
 
-    virtual void init_context( AssemblyContext& context );
+    virtual void init_context( AssemblyContext & context );
 
     // residual and jacobian calculations
     // element_*, side_* as *time_derivative, *constraint, *mass_residual
 
     // Constraint part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
     // Mass residual of the turbine itself
     virtual void nonlocal_mass_residual ( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
     // External torque powering the fan or loading the turbine
     virtual void nonlocal_time_derivative ( bool compute_jacobian,
-                                            AssemblyContext& context,
-                                            CachedValues& cache );
+                                            AssemblyContext & context );
 
   private:
 

--- a/src/physics/include/grins/averaged_turbine_adjoint_stab.h
+++ b/src/physics/include/grins/averaged_turbine_adjoint_stab.h
@@ -57,12 +57,10 @@ namespace GRINS
     virtual void init_context( AssemblyContext& context );
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/axisym_boussinesq_buoyancy.h
+++ b/src/physics/include/grins/axisym_boussinesq_buoyancy.h
@@ -69,8 +69,7 @@ namespace GRINS
       the AxisymmetricIncompNavierStokes class.
     */
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
   protected:
 

--- a/src/physics/include/grins/axisym_heat_transfer.h
+++ b/src/physics/include/grins/axisym_heat_transfer.h
@@ -64,13 +64,11 @@ namespace GRINS
 
     // Time dependent part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache  );
+                                          AssemblyContext & context );
 
     // Mass matrix part(s)
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
     // Registers all parameters in this physics and in its property
     // class

--- a/src/physics/include/grins/boussinesq_buoyancy.h
+++ b/src/physics/include/grins/boussinesq_buoyancy.h
@@ -58,8 +58,7 @@ namespace GRINS
       the IncompressibleNavierStokes class.
     */
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
   private:
 

--- a/src/physics/include/grins/boussinesq_buoyancy_adjoint_stab.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_adjoint_stab.h
@@ -47,15 +47,13 @@ namespace GRINS
 
     ~BoussinesqBuoyancyAdjointStabilization();
 
-    virtual void init_context( AssemblyContext& context );
+    virtual void init_context( AssemblyContext & context );
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
     // Registers all parameters in this physics and in its property
     // classes

--- a/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
@@ -53,16 +53,13 @@ namespace GRINS
     ~BoussinesqBuoyancySPGSMStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
     // Registers all parameters in this physics and in its property
     // classes

--- a/src/physics/include/grins/constant_source_term.h
+++ b/src/physics/include/grins/constant_source_term.h
@@ -38,11 +38,10 @@ namespace GRINS
 
     ConstantSourceTerm( const std::string& physics_name, const GetPot& input );
 
-    virtual ~ConstantSourceTerm();
+    virtual ~ConstantSourceTerm(){}
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/convection_diffusion.h
+++ b/src/physics/include/grins/convection_diffusion.h
@@ -51,12 +51,10 @@ namespace GRINS
     virtual void init_context( AssemblyContext& context );
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/elastic_cable.h
+++ b/src/physics/include/grins/elastic_cable.h
@@ -43,16 +43,14 @@ namespace GRINS
 
     //! Register postprocessing variables for ElasticCable
     virtual void register_postprocessing_vars( const GetPot& input,
-                                               PostProcessedQuantities<libMesh::Real>& postprocessing );
+                                               PostProcessedQuantities<libMesh::Real> & postprocessing );
 
     //! Time dependent part(s) of physics for element interiors
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& /*cache*/ )
+                                AssemblyContext & context )
     { this->mass_residual_impl(compute_jacobian,
                                context,
                                &libMesh::FEMContext::interior_accel,

--- a/src/physics/include/grins/elastic_cable_rayleigh_damping.h
+++ b/src/physics/include/grins/elastic_cable_rayleigh_damping.h
@@ -42,8 +42,7 @@ namespace GRINS
 
     //! Time dependent part(s) of physics for element interiors
     virtual void damping_residual( bool compute_jacobian,
-                                   AssemblyContext& context,
-                                   CachedValues& /*cache*/ );
+                                   AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/elastic_membrane.h
+++ b/src/physics/include/grins/elastic_membrane.h
@@ -42,20 +42,17 @@ namespace GRINS
 
     //! Register postprocessing variables for ElasticMembrane
     virtual void register_postprocessing_vars( const GetPot& input,
-                                               PostProcessedQuantities<libMesh::Real>& postprocessing );
+                                               PostProcessedQuantities<libMesh::Real> & postprocessing );
 
     //! Time dependent part(s) of physics for element interiors
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& /*cache*/ );
+                                          AssemblyContext & context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& /*cache*/ )
+                                AssemblyContext & context )
     { this->mass_residual_impl(compute_jacobian,
                                context,
                                &libMesh::FEMContext::interior_accel,

--- a/src/physics/include/grins/elastic_membrane_constant_pressure.h
+++ b/src/physics/include/grins/elastic_membrane_constant_pressure.h
@@ -41,8 +41,7 @@ namespace GRINS
 
     //! Time dependent part(s) of physics for element interiors
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     void reset_pressure( libMesh::Real pressure_in );
 

--- a/src/physics/include/grins/elastic_membrane_rayleigh_damping.h
+++ b/src/physics/include/grins/elastic_membrane_rayleigh_damping.h
@@ -42,8 +42,7 @@ namespace GRINS
 
     //! Time dependent part(s) of physics for element interiors
     virtual void damping_residual( bool compute_jacobian,
-                                   AssemblyContext& context,
-                                   CachedValues& cache );
+                                   AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/heat_conduction.h
+++ b/src/physics/include/grins/heat_conduction.h
@@ -51,12 +51,10 @@ namespace GRINS
 
     //! Time dependent part(s) of physics for element interiors
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
     // Registers all parameters in this physics and in its property
     // classes

--- a/src/physics/include/grins/heat_transfer.h
+++ b/src/physics/include/grins/heat_transfer.h
@@ -54,13 +54,11 @@ namespace GRINS
 
     // Time dependent part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     // Mass matrix part(s)
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
     //! Compute value of postprocessed quantities at libMesh::Point.
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,

--- a/src/physics/include/grins/heat_transfer_adjoint_stab.h
+++ b/src/physics/include/grins/heat_transfer_adjoint_stab.h
@@ -42,12 +42,10 @@ namespace GRINS
     virtual ~HeatTransferAdjointStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   private:
     HeatTransferAdjointStabilization();

--- a/src/physics/include/grins/heat_transfer_spgsm_stab.h
+++ b/src/physics/include/grins/heat_transfer_spgsm_stab.h
@@ -42,12 +42,10 @@ namespace GRINS
     virtual ~HeatTransferSPGSMStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   private:
     HeatTransferSPGSMStabilization();

--- a/src/physics/include/grins/inc_navier_stokes.h
+++ b/src/physics/include/grins/inc_navier_stokes.h
@@ -60,18 +60,15 @@ namespace GRINS
 
     // Time dependent part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     // Constraint part(s)
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
     // Mass matrix part(s)
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
     //! Compute value of postprocessed quantities at libMesh::Point.
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,

--- a/src/physics/include/grins/inc_navier_stokes_adjoint_stab.h
+++ b/src/physics/include/grins/inc_navier_stokes_adjoint_stab.h
@@ -41,17 +41,14 @@ namespace GRINS
     virtual ~IncompressibleNavierStokesAdjointStabilization(){};
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   private:
 

--- a/src/physics/include/grins/inc_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/inc_navier_stokes_spgsm_stab.h
@@ -41,16 +41,13 @@ namespace GRINS
     virtual ~IncompressibleNavierStokesSPGSMStabilization(){};
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   private:
 

--- a/src/physics/include/grins/low_mach_navier_stokes.h
+++ b/src/physics/include/grins/low_mach_navier_stokes.h
@@ -66,8 +66,7 @@ namespace GRINS
     virtual void mass_residual( bool compute_jacobian,
                                 AssemblyContext & context );
 
-    virtual void compute_element_time_derivative_cache( AssemblyContext & context,
-                                                        CachedValues & cache );
+    virtual void compute_element_time_derivative_cache( AssemblyContext & context );
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,

--- a/src/physics/include/grins/low_mach_navier_stokes.h
+++ b/src/physics/include/grins/low_mach_navier_stokes.h
@@ -53,24 +53,21 @@ namespace GRINS
                                                PostProcessedQuantities<libMesh::Real>& postprocessing );
 
     // Context initialization
-    virtual void init_context( AssemblyContext& context );
+    virtual void init_context( AssemblyContext & context );
 
     // Time dependent part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
     // Mass matrix part(s)
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
     virtual void compute_element_time_derivative_cache( AssemblyContext & context,
-                                                        CachedValues& cache );
+                                                        CachedValues & cache );
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,
@@ -90,38 +87,38 @@ namespace GRINS
     //! Helper function
     void assemble_mass_time_deriv( bool compute_jacobian,
                                    AssemblyContext& context,
-                                   CachedValues& cache );
+                                   const CachedValues & cache );
 
     //! Helper function
     void assemble_momentum_time_deriv( bool compute_jacobian,
                                        AssemblyContext& context,
-                                       CachedValues& cache );
+                                       const CachedValues & cache );
 
     //! Helper function
     void assemble_energy_time_deriv( bool compute_jacobian,
                                      AssemblyContext& context,
-                                     CachedValues& cache );
+                                     const CachedValues & cache );
 
     //! Helper function
     void assemble_continuity_mass_residual( bool compute_jacobian,
-                                            AssemblyContext& c );
+                                            AssemblyContext & context );
 
     //! Helper function
     void assemble_momentum_mass_residual( bool compute_jacobian,
-                                          AssemblyContext& c );
+                                          AssemblyContext & context );
 
     //! Helper function
     void assemble_energy_mass_residual( bool compute_jacobian,
-                                        AssemblyContext& c );
+                                        AssemblyContext & context );
 
     void assemble_thermo_press_elem_time_deriv( bool compute_jacobian,
-                                                AssemblyContext& c );
+                                                AssemblyContext & context );
 
     void assemble_thermo_press_side_time_deriv( bool compute_jacobian,
-                                                AssemblyContext& c );
+                                                AssemblyContext & context );
 
     void assemble_thermo_press_mass_residual( bool compute_jacobian,
-                                              AssemblyContext& c );
+                                              AssemblyContext & context );
 
   private:
 

--- a/src/physics/include/grins/low_mach_navier_stokes.h
+++ b/src/physics/include/grins/low_mach_navier_stokes.h
@@ -69,7 +69,7 @@ namespace GRINS
                                 AssemblyContext& context,
                                 CachedValues& cache );
 
-    virtual void compute_element_time_derivative_cache( const AssemblyContext& context,
+    virtual void compute_element_time_derivative_cache( AssemblyContext & context,
                                                         CachedValues& cache );
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,

--- a/src/physics/include/grins/low_mach_navier_stokes_braack_stab.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_braack_stab.h
@@ -42,12 +42,10 @@ namespace GRINS
     virtual ~LowMachNavierStokesBraackStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/low_mach_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_spgsm_stab.h
@@ -41,12 +41,10 @@ namespace GRINS
     virtual ~LowMachNavierStokesSPGSMStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/low_mach_navier_stokes_vms_stab.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_vms_stab.h
@@ -42,12 +42,10 @@ namespace GRINS
     virtual ~LowMachNavierStokesVMSStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -220,8 +220,9 @@ namespace GRINS
     //! Constraint application object
     libMesh::UniquePtr<libMesh::System::Constraint> _constraint;
 
-    // Useful typedef for refactoring
-    typedef void (GRINS::Physics::*ResFuncType) (bool, AssemblyContext &, CachedValues &);
+    // Useful typedef to pointer-to-member functions so we can call all
+    // residual and caching functions using a single function (_general_residual)
+    typedef void (GRINS::Physics::*ResFuncType) (bool, AssemblyContext &);
     typedef void (GRINS::Physics::*CacheFuncType) (AssemblyContext &, CachedValues &);
 
     // Refactored residual evaluation implementation

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -222,11 +222,11 @@ namespace GRINS
 
     // Useful typedef for refactoring
     typedef void (GRINS::Physics::*ResFuncType) (bool, AssemblyContext &, CachedValues &);
-    typedef void (GRINS::Physics::*CacheFuncType) (const AssemblyContext&, CachedValues &);
+    typedef void (GRINS::Physics::*CacheFuncType) (AssemblyContext &, CachedValues &);
 
     // Refactored residual evaluation implementation
     bool _general_residual( bool request_jacobian,
-                            libMesh::DiffContext& context,
+                            libMesh::DiffContext & context,
                             ResFuncType resfunc,
                             CacheFuncType cachefunc);
 

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -223,7 +223,7 @@ namespace GRINS
     // Useful typedef to pointer-to-member functions so we can call all
     // residual and caching functions using a single function (_general_residual)
     typedef void (GRINS::Physics::*ResFuncType) (bool, AssemblyContext &);
-    typedef void (GRINS::Physics::*CacheFuncType) (AssemblyContext &, CachedValues &);
+    typedef void (GRINS::Physics::*CacheFuncType) (AssemblyContext &);
 
     // Refactored residual evaluation implementation
     bool _general_residual( bool request_jacobian,

--- a/src/physics/include/grins/parsed_source_term.h
+++ b/src/physics/include/grins/parsed_source_term.h
@@ -40,13 +40,12 @@ namespace GRINS
 
     ParsedSourceTerm( const std::string& physics_name, const GetPot& input );
 
-    virtual ~ParsedSourceTerm();
+    virtual ~ParsedSourceTerm(){}
 
     virtual void init_context( AssemblyContext& context );
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/parsed_velocity_source.h
+++ b/src/physics/include/grins/parsed_velocity_source.h
@@ -66,8 +66,7 @@ namespace GRINS
 
     // Constraint part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,

--- a/src/physics/include/grins/parsed_velocity_source_adjoint_stab.h
+++ b/src/physics/include/grins/parsed_velocity_source_adjoint_stab.h
@@ -50,12 +50,10 @@ namespace GRINS
     virtual void init_context( AssemblyContext& context );
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -208,32 +208,23 @@ namespace GRINS
     void init_ics( libMesh::FEMSystem* system,
                    libMesh::CompositeFunction<libMesh::Number>& all_ics );
 
-    virtual void compute_element_time_derivative_cache( AssemblyContext & /*context*/,
-                                                        CachedValues & /*cache*/ ){}
+    virtual void compute_element_time_derivative_cache( AssemblyContext & /*context*/ ){}
 
-    virtual void compute_side_time_derivative_cache( AssemblyContext & /*context*/,
-                                                     CachedValues & /*cache*/ ){}
+    virtual void compute_side_time_derivative_cache( AssemblyContext & /*context*/ ){}
 
-    virtual void compute_nonlocal_time_derivative_cache( AssemblyContext & /*context*/,
-                                                         CachedValues & /*cache*/ ){}
+    virtual void compute_nonlocal_time_derivative_cache( AssemblyContext & /*context*/ ){}
 
-    virtual void compute_element_constraint_cache( AssemblyContext & /*context*/,
-                                                   CachedValues & /*cache*/ ){}
+    virtual void compute_element_constraint_cache( AssemblyContext & /*context*/ ){}
 
-    virtual void compute_side_constraint_cache( AssemblyContext & /*context*/,
-                                                CachedValues & /*cache*/ ){}
+    virtual void compute_side_constraint_cache( AssemblyContext & /*context*/ ){}
 
-    virtual void compute_nonlocal_constraint_cache( AssemblyContext & /*context*/,
-                                                    CachedValues & /*cache*/ ){}
+    virtual void compute_nonlocal_constraint_cache( AssemblyContext & /*context*/ ){}
 
-    virtual void compute_damping_residual_cache( AssemblyContext & /*context*/,
-                                                 CachedValues & /*cache*/ ){}
+    virtual void compute_damping_residual_cache( AssemblyContext & /*context*/ ){}
 
-    virtual void compute_mass_residual_cache( AssemblyContext & /*context*/,
-                                              CachedValues & /*cache*/ ){}
+    virtual void compute_mass_residual_cache( AssemblyContext & /*context*/ ){}
 
-    virtual void compute_nonlocal_mass_residual_cache( AssemblyContext & /*context*/,
-                                                       CachedValues & /*cache*/ ){}
+    virtual void compute_nonlocal_mass_residual_cache( AssemblyContext & /*context*/ ){}
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -170,49 +170,40 @@ namespace GRINS
     // element_*, side_* as *time_derivative, *constraint, *mass_residual
 
     //! Time dependent part(s) of physics for element interiors
-    virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+    virtual void element_time_derivative( bool /*compute_jacobian*/,
+                                          AssemblyContext & /*context*/ ){}
 
     //! Time dependent part(s) of physics for boundaries of elements on the domain boundary
-    virtual void side_time_derivative( bool compute_jacobian,
-                                       AssemblyContext& context,
-                                       CachedValues& cache );
+    virtual void side_time_derivative( bool /*compute_jacobian*/,
+                                       AssemblyContext & /*context*/ ){}
 
     //! Time dependent part(s) of physics for scalar variables
-    virtual void nonlocal_time_derivative( bool compute_jacobian,
-                                           AssemblyContext& context,
-                                           CachedValues& cache );
+    virtual void nonlocal_time_derivative( bool /*compute_jacobian*/,
+                                           AssemblyContext & /*context*/ ){}
 
     //! Constraint part(s) of physics for element interiors
-    virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+    virtual void element_constraint( bool /*compute_jacobian*/,
+                                     AssemblyContext & /*context*/ ){}
 
     //! Constraint part(s) of physics for boundaries of elements on the domain boundary
-    virtual void side_constraint( bool compute_jacobian,
-                                  AssemblyContext& context,
-                                  CachedValues& cache );
+    virtual void side_constraint( bool /*compute_jacobian*/,
+                                  AssemblyContext & /*context*/ ){}
 
     //! Constraint part(s) of physics for scalar variables
-    virtual void nonlocal_constraint( bool compute_jacobian,
-                                      AssemblyContext& context,
-                                      CachedValues& cache );
+    virtual void nonlocal_constraint( bool /*compute_jacobian*/,
+                                      AssemblyContext & /*context*/ ){}
 
     //! Damping matrix part(s) for element interiors. All boundary terms lie within the time_derivative part
-    virtual void damping_residual( bool compute_jacobian,
-                                   AssemblyContext& context,
-                                   CachedValues& cache );
+    virtual void damping_residual( bool /*compute_jacobian*/,
+                                   AssemblyContext & /*context*/ ){}
 
     //! Mass matrix part(s) for element interiors. All boundary terms lie within the time_derivative part
-    virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+    virtual void mass_residual( bool /*compute_jacobian*/,
+                                AssemblyContext & /*context*/ ){}
 
     //! Mass matrix part(s) for scalar variables.
-    virtual void nonlocal_mass_residual( bool compute_jacobian,
-                                         AssemblyContext& context,
-                                         CachedValues& cache );
+    virtual void nonlocal_mass_residual( bool /*compute_jacobian*/,
+                                         AssemblyContext & /*context*/ ){}
 
     void init_ics( libMesh::FEMSystem* system,
                    libMesh::CompositeFunction<libMesh::Number>& all_ics );

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -217,32 +217,32 @@ namespace GRINS
     void init_ics( libMesh::FEMSystem* system,
                    libMesh::CompositeFunction<libMesh::Number>& all_ics );
 
-    virtual void compute_element_time_derivative_cache( const AssemblyContext& context,
-                                                        CachedValues& cache );
+    virtual void compute_element_time_derivative_cache( AssemblyContext & /*context*/,
+                                                        CachedValues & /*cache*/ ){}
 
-    virtual void compute_side_time_derivative_cache( const AssemblyContext& context,
-                                                     CachedValues& cache );
+    virtual void compute_side_time_derivative_cache( AssemblyContext & /*context*/,
+                                                     CachedValues & /*cache*/ ){}
 
-    virtual void compute_nonlocal_time_derivative_cache( const AssemblyContext& context,
-                                                         CachedValues& cache );
+    virtual void compute_nonlocal_time_derivative_cache( AssemblyContext & /*context*/,
+                                                         CachedValues & /*cache*/ ){}
 
-    virtual void compute_element_constraint_cache( const AssemblyContext& context,
-                                                   CachedValues& cache );
+    virtual void compute_element_constraint_cache( AssemblyContext & /*context*/,
+                                                   CachedValues & /*cache*/ ){}
 
-    virtual void compute_side_constraint_cache( const AssemblyContext& context,
-                                                CachedValues& cache );
+    virtual void compute_side_constraint_cache( AssemblyContext & /*context*/,
+                                                CachedValues & /*cache*/ ){}
 
-    virtual void compute_nonlocal_constraint_cache( const AssemblyContext& context,
-                                                    CachedValues& cache );
+    virtual void compute_nonlocal_constraint_cache( AssemblyContext & /*context*/,
+                                                    CachedValues & /*cache*/ ){}
 
-    virtual void compute_damping_residual_cache( const AssemblyContext& context,
-                                                 CachedValues& cache );
+    virtual void compute_damping_residual_cache( AssemblyContext & /*context*/,
+                                                 CachedValues & /*cache*/ ){}
 
-    virtual void compute_mass_residual_cache( const AssemblyContext& context,
-                                              CachedValues& cache );
+    virtual void compute_mass_residual_cache( AssemblyContext & /*context*/,
+                                              CachedValues & /*cache*/ ){}
 
-    virtual void compute_nonlocal_mass_residual_cache( const AssemblyContext& context,
-                                                       CachedValues& cache );
+    virtual void compute_nonlocal_mass_residual_cache( AssemblyContext & /*context*/,
+                                                       CachedValues & /*cache*/ ){}
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes.h
@@ -51,20 +51,17 @@ namespace GRINS
 
     // Time dependent part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
     // Mass matrix part(s)
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
     virtual void compute_element_time_derivative_cache( AssemblyContext & context,
-                                                        CachedValues& cache );
+                                                        CachedValues & cache );
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes.h
@@ -60,8 +60,7 @@ namespace GRINS
     virtual void mass_residual( bool compute_jacobian,
                                 AssemblyContext & context );
 
-    virtual void compute_element_time_derivative_cache( AssemblyContext & context,
-                                                        CachedValues & cache );
+    virtual void compute_element_time_derivative_cache( AssemblyContext & context );
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes.h
@@ -63,7 +63,7 @@ namespace GRINS
                                 AssemblyContext& context,
                                 CachedValues& cache );
 
-    virtual void compute_element_time_derivative_cache( const AssemblyContext& context,
+    virtual void compute_element_time_derivative_cache( AssemblyContext & context,
                                                         CachedValues& cache );
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
@@ -39,12 +39,10 @@ namespace GRINS
     virtual ~ReactingLowMachNavierStokesSPGSMStabilization(){};
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   private:
 

--- a/src/physics/include/grins/scalar_ode.h
+++ b/src/physics/include/grins/scalar_ode.h
@@ -57,29 +57,27 @@ namespace GRINS
     ~ScalarODE(){};
 
     //! Sets scalar variable(s) to be time-evolving
-    virtual void set_time_evolving_vars( libMesh::FEMSystem* system );
+    virtual void set_time_evolving_vars( libMesh::FEMSystem * system );
 
     //! Prepare the context for evaluations
-    virtual void init_context( AssemblyContext& context );
+    virtual void init_context( AssemblyContext & context );
 
     // residual and jacobian calculations
 
     // User-specified ODE(s)
     virtual void nonlocal_time_derivative ( bool compute_jacobian,
-                                            AssemblyContext& context,
-                                            CachedValues& cache );
+                                            AssemblyContext & context );
 
     // User-specified constraint equation
     virtual void nonlocal_constraint ( bool compute_jacobian,
-                                       AssemblyContext& context,
-                                       CachedValues& cache );
+                                       AssemblyContext & context );
 
     // User-specified (or default "s'") mass term
     virtual void nonlocal_mass_residual ( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext & context );
 
-    VariableIndex scalar_ode_var() const { return _var.var(); }
+    VariableIndex scalar_ode_var() const
+    { return _var.var(); }
 
   private:
 

--- a/src/physics/include/grins/spalart_allmaras.h
+++ b/src/physics/include/grins/spalart_allmaras.h
@@ -71,12 +71,12 @@ namespace GRINS
     virtual void init_context( AssemblyContext& context );
 
     // Element time derivative
-    virtual void element_time_derivative(bool compute_jacobian, AssemblyContext& context, CachedValues& /*cache*/);
+    virtual void element_time_derivative( bool compute_jacobian,
+                                          AssemblyContext & context );
 
     // Mass matrix part(s)
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
     // A distance function to get distances from boundaries to qps
     libMesh::UniquePtr<DistanceFunction> distance_function;

--- a/src/physics/include/grins/spalart_allmaras_spgsm_stab.h
+++ b/src/physics/include/grins/spalart_allmaras_spgsm_stab.h
@@ -44,12 +44,10 @@ namespace GRINS
     virtual void init_variables( libMesh::FEMSystem* system );
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
     // Registers all parameters in this physics and in its property
     // classes

--- a/src/physics/include/grins/stokes.h
+++ b/src/physics/include/grins/stokes.h
@@ -55,18 +55,15 @@ namespace GRINS
 
     // Time dependent part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     // Constraint part(s)
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext& context );
 
     // Mass matrix part(s)
     virtual void mass_residual( bool compute_jacobian,
-                                AssemblyContext& context,
-                                CachedValues& cache );
+                                AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/variable_pinning.h
+++ b/src/physics/include/grins/variable_pinning.h
@@ -41,18 +41,17 @@ namespace GRINS
     ~VariablePinning(){};
 
     //! Initialize context for added physics variables
-    virtual void init_context( AssemblyContext& context );
+    virtual void init_context( AssemblyContext & context );
 
     //! Initialize pinning helper object
-    virtual void auxiliary_init( MultiphysicsSystem& system );
+    virtual void auxiliary_init( MultiphysicsSystem & system );
 
     // residual and jacobian calculations
     // element_*, side_* as *time_derivative, *constraint, *mass_residual
 
     //! Time dependent part(s) of physics for element interiors
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/velocity_drag.h
+++ b/src/physics/include/grins/velocity_drag.h
@@ -64,8 +64,7 @@ namespace GRINS
 
     // Constraint part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
   private:
 

--- a/src/physics/include/grins/velocity_drag_adjoint_stab.h
+++ b/src/physics/include/grins/velocity_drag_adjoint_stab.h
@@ -57,12 +57,10 @@ namespace GRINS
     virtual void init_context( AssemblyContext& context );
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
   protected:
 

--- a/src/physics/include/grins/velocity_penalty.h
+++ b/src/physics/include/grins/velocity_penalty.h
@@ -66,8 +66,7 @@ namespace GRINS
 
     // Constraint part(s)
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,

--- a/src/physics/include/grins/velocity_penalty_adjoint_stab.h
+++ b/src/physics/include/grins/velocity_penalty_adjoint_stab.h
@@ -50,12 +50,10 @@ namespace GRINS
     virtual void init_context( AssemblyContext& context );
 
     virtual void element_time_derivative( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& cache );
+                                          AssemblyContext& context );
 
     virtual void element_constraint( bool compute_jacobian,
-                                     AssemblyContext& context,
-                                     CachedValues& cache );
+                                     AssemblyContext & context );
 
   protected:
 

--- a/src/physics/src/averaged_fan.C
+++ b/src/physics/src/averaged_fan.C
@@ -97,9 +97,9 @@ namespace GRINS
   }
 
   template<class Mu>
-  void AveragedFan<Mu>::element_time_derivative( bool compute_jacobian,
-                                                 AssemblyContext& context,
-                                                 CachedValues& /* cache */ )
+  void AveragedFan<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // Element Jacobian * quadrature weights for interior integration
     const std::vector<libMesh::Real> &JxW =

--- a/src/physics/src/averaged_fan_adjoint_stab.C
+++ b/src/physics/src/averaged_fan_adjoint_stab.C
@@ -65,8 +65,7 @@ namespace GRINS
   template<class Mu>
   void AveragedFanAdjointStabilization<Mu>::element_time_derivative
   ( bool compute_jacobian,
-    AssemblyContext& context,
-    CachedValues& /* cache */ )
+    AssemblyContext & context )
   {
     libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u());
 
@@ -224,9 +223,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void AveragedFanAdjointStabilization<Mu>::element_constraint( bool compute_jacobian,
-                                                                AssemblyContext& context,
-                                                                CachedValues& /*cache*/ )
+  void AveragedFanAdjointStabilization<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();

--- a/src/physics/src/averaged_turbine.C
+++ b/src/physics/src/averaged_turbine.C
@@ -54,9 +54,8 @@ namespace GRINS
 
 
   template<class Mu>
-  void AveragedTurbine<Mu>::element_time_derivative( bool compute_jacobian,
-                                                     AssemblyContext& context,
-                                                     CachedValues& /* cache */ )
+  void AveragedTurbine<Mu>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // Element Jacobian * quadrature weights for interior integration
     const std::vector<libMesh::Real> &JxW =
@@ -226,9 +225,8 @@ namespace GRINS
 
 
   template<class Mu>
-  void AveragedTurbine<Mu>::nonlocal_time_derivative(bool compute_jacobian,
-                                                     AssemblyContext& context,
-                                                     CachedValues& /* cache */ )
+  void AveragedTurbine<Mu>::nonlocal_time_derivative
+  (bool compute_jacobian, AssemblyContext & context )
   {
     libMesh::DenseSubMatrix<libMesh::Number> &Kss =
       context.get_elem_jacobian(this->fan_speed_var(), this->fan_speed_var()); // R_{s},{s}
@@ -264,9 +262,8 @@ namespace GRINS
 
 
   template<class Mu>
-  void AveragedTurbine<Mu>::nonlocal_mass_residual( bool compute_jacobian,
-                                                    AssemblyContext& context,
-                                                    CachedValues& /* cache */ )
+  void AveragedTurbine<Mu>::nonlocal_mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     libMesh::DenseSubMatrix<libMesh::Number> &Kss =
       context.get_elem_jacobian(this->fan_speed_var(), this->fan_speed_var()); // R_{s},{s}

--- a/src/physics/src/averaged_turbine_adjoint_stab.C
+++ b/src/physics/src/averaged_turbine_adjoint_stab.C
@@ -65,8 +65,7 @@ namespace GRINS
   template<class Mu>
   void AveragedTurbineAdjointStabilization<Mu>::element_time_derivative
   ( bool compute_jacobian,
-    AssemblyContext& context,
-    CachedValues& /* cache */ )
+    AssemblyContext & context )
   {
     libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u());
 
@@ -239,9 +238,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void AveragedTurbineAdjointStabilization<Mu>::element_constraint( bool compute_jacobian,
-                                                                    AssemblyContext& context,
-                                                                    CachedValues& /*cache*/ )
+  void AveragedTurbineAdjointStabilization<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -76,9 +76,9 @@ namespace GRINS
     context.get_element_fe(_temp_vars.T())->get_phi();
   }
 
-  void AxisymmetricBoussinesqBuoyancy::element_time_derivative( bool compute_jacobian,
-                                                                AssemblyContext& context,
-                                                                CachedValues& /*cache*/ )
+  void AxisymmetricBoussinesqBuoyancy::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(_flow_vars.u()).size();

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -92,9 +92,8 @@ namespace GRINS
   }
 
   template< class Conductivity>
-  void AxisymmetricHeatTransfer<Conductivity>::element_time_derivative( bool compute_jacobian,
-                                                                        AssemblyContext& context,
-                                                                        CachedValues& /*cache*/ )
+  void AxisymmetricHeatTransfer<Conductivity>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_T_dofs = context.get_dof_indices(_temp_vars.T()).size();
@@ -209,9 +208,8 @@ namespace GRINS
   }
 
   template< class Conductivity>
-  void AxisymmetricHeatTransfer<Conductivity>::mass_residual( bool compute_jacobian,
-                                                              AssemblyContext& context,
-                                                              CachedValues& /*cache*/ )
+  void AxisymmetricHeatTransfer<Conductivity>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // First we get some references to cell-specific data that
     // will be used to assemble the linear system.

--- a/src/physics/src/boussinesq_buoyancy.C
+++ b/src/physics/src/boussinesq_buoyancy.C
@@ -49,9 +49,9 @@ namespace GRINS
     return;
   }
 
-  void BoussinesqBuoyancy::element_time_derivative( bool compute_jacobian,
-                                                    AssemblyContext& context,
-                                                    CachedValues& /*cache*/ )
+  void BoussinesqBuoyancy::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(_flow_vars.u()).size();

--- a/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
@@ -54,7 +54,7 @@ namespace GRINS
   }
 
   template<class Mu>
-  void BoussinesqBuoyancyAdjointStabilization<Mu>::init_context( AssemblyContext& context )
+  void BoussinesqBuoyancyAdjointStabilization<Mu>::init_context( AssemblyContext & context )
   {
     context.get_element_fe(this->_press_var.p())->get_dphi();
 
@@ -65,9 +65,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void BoussinesqBuoyancyAdjointStabilization<Mu>::element_time_derivative( bool compute_jacobian,
-                                                                            AssemblyContext& context,
-                                                                            CachedValues& /*cache*/ )
+  void BoussinesqBuoyancyAdjointStabilization<Mu>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(_flow_vars.u()).size();
@@ -246,9 +245,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void BoussinesqBuoyancyAdjointStabilization<Mu>::element_constraint( bool compute_jacobian,
-                                                                       AssemblyContext& context,
-                                                                       CachedValues& /*cache*/ )
+  void BoussinesqBuoyancyAdjointStabilization<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(_press_var.p()).size();

--- a/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
@@ -60,9 +60,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void BoussinesqBuoyancySPGSMStabilization<Mu>::element_time_derivative( bool compute_jacobian,
-                                                                          AssemblyContext& context,
-                                                                          CachedValues& /*cache*/ )
+  void BoussinesqBuoyancySPGSMStabilization<Mu>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(_flow_vars.u()).size();
@@ -150,9 +149,9 @@ namespace GRINS
   }
 
   template<class Mu>
-  void BoussinesqBuoyancySPGSMStabilization<Mu>::element_constraint( bool compute_jacobian,
-                                                                     AssemblyContext& context,
-                                                                     CachedValues& /*cache*/ )
+  void BoussinesqBuoyancySPGSMStabilization<Mu>::element_constraint
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(_press_var.p()).size();
@@ -216,8 +215,7 @@ namespace GRINS
 
   template<class Mu>
   void BoussinesqBuoyancySPGSMStabilization<Mu>::mass_residual( bool /*compute_jacobian*/,
-                                                                AssemblyContext& /*context*/,
-                                                                CachedValues& /*cache*/ )
+                                                                AssemblyContext& /*context*/ )
   {
     /*
     // The number of local degrees of freedom in each variable.

--- a/src/physics/src/constant_source_term.C
+++ b/src/physics/src/constant_source_term.C
@@ -51,14 +51,8 @@ namespace GRINS
        "Physics/"+physics_name+"/Function/value", _value);
   }
 
-  ConstantSourceTerm::~ConstantSourceTerm()
-  {
-    return;
-  }
-
-  void ConstantSourceTerm::element_time_derivative( bool /*compute_jacobian*/,
-                                                    AssemblyContext& context,
-                                                    CachedValues& /*cache*/ )
+  void ConstantSourceTerm::element_time_derivative
+  ( bool /*compute_jacobian*/, AssemblyContext & context )
   {
     for( std::vector<VariableIndex>::const_iterator v_it = _vars.begin();
          v_it != _vars.end(); ++v_it )

--- a/src/physics/src/convection_diffusion.C
+++ b/src/physics/src/convection_diffusion.C
@@ -78,9 +78,9 @@ namespace GRINS
     context.get_element_fe(_var.var())->get_xyz();
   }
 
-  void ConvectionDiffusion::element_time_derivative( bool compute_jacobian,
-                                                     AssemblyContext& context,
-                                                     CachedValues& /*cache*/ )
+  void ConvectionDiffusion::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     const unsigned int n_dofs = context.get_dof_indices(_var.var()).size();
 
@@ -134,9 +134,8 @@ namespace GRINS
       }
   }
 
-  void ConvectionDiffusion::mass_residual( bool compute_jacobian,
-                                           AssemblyContext& context,
-                                           CachedValues& /*cache*/ )
+  void ConvectionDiffusion::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     const unsigned int n_dofs = context.get_dof_indices(_var.var()).size();
 

--- a/src/physics/src/elastic_cable.C
+++ b/src/physics/src/elastic_cable.C
@@ -221,9 +221,8 @@ namespace GRINS
   }
 
   template<typename StressStrainLaw>
-  void ElasticCable<StressStrainLaw>::element_time_derivative( bool compute_jacobian,
-                                                               AssemblyContext& context,
-                                                               CachedValues& /*cache*/)
+  void ElasticCable<StressStrainLaw>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     const unsigned int n_u_dofs = context.get_dof_indices(this->_disp_vars.u()).size();
 

--- a/src/physics/src/elastic_cable_rayleigh_damping.C
+++ b/src/physics/src/elastic_cable_rayleigh_damping.C
@@ -62,9 +62,8 @@ namespace GRINS
   }
 
   template<typename StressStrainLaw>
-  void ElasticCableRayleighDamping<StressStrainLaw>::damping_residual( bool compute_jacobian,
-                                                                       AssemblyContext& context,
-                                                                       CachedValues& /*cache*/)
+  void ElasticCableRayleighDamping<StressStrainLaw>::damping_residual
+  ( bool compute_jacobian, AssemblyContext & context)
   {
     // First, do the "mass" contribution
     this->mass_residual_impl(compute_jacobian,

--- a/src/physics/src/elastic_membrane.C
+++ b/src/physics/src/elastic_membrane.C
@@ -113,9 +113,8 @@ namespace GRINS
   }
 
   template<typename StressStrainLaw>
-  void ElasticMembrane<StressStrainLaw>::element_time_derivative( bool compute_jacobian,
-                                                                  AssemblyContext& context,
-                                                                  CachedValues& /*cache*/ )
+  void ElasticMembrane<StressStrainLaw>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     const unsigned int n_u_dofs = context.get_dof_indices(this->_disp_vars.u()).size();
 
@@ -310,9 +309,8 @@ namespace GRINS
   }
 
   template<typename StressStrainLaw>
-  void ElasticMembrane<StressStrainLaw>::element_constraint( bool compute_jacobian,
-                                                             AssemblyContext& context,
-                                                             CachedValues& /*cache*/ )
+  void ElasticMembrane<StressStrainLaw>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // Only compute the constraint is tracking lambda_sq as an independent variable
     if( this->_is_compressible )

--- a/src/physics/src/elastic_membrane_constant_pressure.C
+++ b/src/physics/src/elastic_membrane_constant_pressure.C
@@ -65,9 +65,9 @@ namespace GRINS
       libmesh_error_msg("ERROR: ElasticMembraneConstantPressure only valid for three dimensions! Make sure you have three components in your Displacement type variable.");
   }
 
-  void ElasticMembraneConstantPressure::element_time_derivative( bool compute_jacobian,
-                                                                 AssemblyContext& context,
-                                                                 CachedValues& /*cache*/ )
+  void ElasticMembraneConstantPressure::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     const unsigned int n_u_dofs = context.get_dof_indices(_disp_vars.u()).size();
 

--- a/src/physics/src/elastic_membrane_rayleigh_damping.C
+++ b/src/physics/src/elastic_membrane_rayleigh_damping.C
@@ -62,9 +62,8 @@ namespace GRINS
   }
 
   template<typename StressStrainLaw>
-  void ElasticMembraneRayleighDamping<StressStrainLaw>::damping_residual( bool compute_jacobian,
-                                                                          AssemblyContext& context,
-                                                                          CachedValues& /*cache*/ )
+  void ElasticMembraneRayleighDamping<StressStrainLaw>::damping_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // First do the mass part
     this->mass_residual_impl(compute_jacobian,

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -86,9 +86,9 @@ namespace GRINS
   }
 
   template<class K>
-  void HeatConduction<K>::element_time_derivative( bool compute_jacobian,
-                                                   AssemblyContext& context,
-                                                   CachedValues& /*cache*/ )
+  void HeatConduction<K>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_T_dofs = context.get_dof_indices(_temp_vars.T()).size();
@@ -157,9 +157,8 @@ namespace GRINS
   }
 
   template<class K>
-  void HeatConduction<K>::mass_residual( bool compute_jacobian,
-                                         AssemblyContext& context,
-                                         CachedValues& /*cache*/ )
+  void HeatConduction<K>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // First we get some references to cell-specific data that
     // will be used to assemble the linear system.

--- a/src/physics/src/heat_transfer.C
+++ b/src/physics/src/heat_transfer.C
@@ -81,9 +81,9 @@ namespace GRINS
   }
 
   template<class K>
-  void HeatTransfer<K>::element_time_derivative( bool compute_jacobian,
-                                                 AssemblyContext& context,
-                                                 CachedValues& /*cache*/ )
+  void HeatTransfer<K>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T()).size();
@@ -196,9 +196,8 @@ namespace GRINS
   }
 
   template<class K>
-  void HeatTransfer<K>::mass_residual( bool compute_jacobian,
-                                       AssemblyContext& context,
-                                       CachedValues& /*cache*/ )
+  void HeatTransfer<K>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // First we get some references to cell-specific data that
     // will be used to assemble the linear system.

--- a/src/physics/src/heat_transfer_adjoint_stab.C
+++ b/src/physics/src/heat_transfer_adjoint_stab.C
@@ -49,9 +49,9 @@ namespace GRINS
   }
 
   template<class K>
-  void HeatTransferAdjointStabilization<K>::element_time_derivative( bool compute_jacobian,
-                                                                     AssemblyContext& context,
-                                                                     CachedValues& /*cache*/ )
+  void HeatTransferAdjointStabilization<K>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T()).size();
@@ -229,9 +229,8 @@ namespace GRINS
   }
 
   template<class K>
-  void HeatTransferAdjointStabilization<K>::mass_residual( bool compute_jacobian,
-                                                           AssemblyContext& context,
-                                                           CachedValues& /*cache*/ )
+  void HeatTransferAdjointStabilization<K>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T()).size();

--- a/src/physics/src/heat_transfer_spgsm_stab.C
+++ b/src/physics/src/heat_transfer_spgsm_stab.C
@@ -49,9 +49,8 @@ namespace GRINS
   }
 
   template<class K>
-  void HeatTransferSPGSMStabilization<K>::element_time_derivative( bool compute_jacobian,
-                                                                   AssemblyContext& context,
-                                                                   CachedValues& /*cache*/ )
+  void HeatTransferSPGSMStabilization<K>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T()).size();
@@ -102,10 +101,12 @@ namespace GRINS
   }
 
   template<class K>
-  void HeatTransferSPGSMStabilization<K>::mass_residual( bool /*compute_jacobian*/,
-                                                         AssemblyContext& context,
-                                                         CachedValues& /*cache*/ )
+  void HeatTransferSPGSMStabilization<K>::mass_residual( bool compute_jacobian,
+                                                         AssemblyContext & context )
   {
+    if( compute_jacobian )
+      libmesh_not_implemented();
+
     // The number of local degrees of freedom in each variable.
     const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T()).size();
 

--- a/src/physics/src/inc_navier_stokes.C
+++ b/src/physics/src/inc_navier_stokes.C
@@ -94,9 +94,9 @@ namespace GRINS
   }
 
   template<class Mu>
-  void IncompressibleNavierStokes<Mu>::element_time_derivative( bool compute_jacobian,
-                                                                AssemblyContext& context,
-                                                                CachedValues& /*cache*/ )
+  void IncompressibleNavierStokes<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();
@@ -322,9 +322,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void IncompressibleNavierStokes<Mu>::element_constraint( bool compute_jacobian,
-                                                           AssemblyContext& context,
-                                                           CachedValues& /*cache*/ )
+  void IncompressibleNavierStokes<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();
@@ -432,9 +431,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void IncompressibleNavierStokes<Mu>::mass_residual( bool compute_jacobian,
-                                                      AssemblyContext& context,
-                                                      CachedValues& /*cache*/ )
+  void IncompressibleNavierStokes<Mu>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // Element Jacobian * quadrature weights for interior integration
     // We assume the same for each flow variable

--- a/src/physics/src/inc_navier_stokes_adjoint_stab.C
+++ b/src/physics/src/inc_navier_stokes_adjoint_stab.C
@@ -43,9 +43,9 @@ namespace GRINS
   {}
 
   template<class Mu>
-  void IncompressibleNavierStokesAdjointStabilization<Mu>::element_time_derivative( bool compute_jacobian,
-                                                                                    AssemblyContext& context,
-                                                                                    CachedValues& /*cache*/ )
+  void IncompressibleNavierStokesAdjointStabilization<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();
@@ -365,9 +365,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void IncompressibleNavierStokesAdjointStabilization<Mu>::element_constraint( bool compute_jacobian,
-                                                                               AssemblyContext& context,
-                                                                               CachedValues& /*cache*/ )
+  void IncompressibleNavierStokesAdjointStabilization<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();
@@ -519,9 +518,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void IncompressibleNavierStokesAdjointStabilization<Mu>::mass_residual( bool compute_jacobian,
-                                                                          AssemblyContext& context,
-                                                                          CachedValues& /*cache*/ )
+  void IncompressibleNavierStokesAdjointStabilization<Mu>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();

--- a/src/physics/src/inc_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/inc_navier_stokes_spgsm_stab.C
@@ -42,9 +42,9 @@ namespace GRINS
   {}
 
   template<class Mu>
-  void IncompressibleNavierStokesSPGSMStabilization<Mu>::element_time_derivative( bool compute_jacobian,
-                                                                                  AssemblyContext& context,
-                                                                                  CachedValues& /*cache*/ )
+  void IncompressibleNavierStokesSPGSMStabilization<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();
@@ -116,9 +116,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void IncompressibleNavierStokesSPGSMStabilization<Mu>::element_constraint( bool compute_jacobian,
-                                                                             AssemblyContext& context,
-                                                                             CachedValues& /*cache*/ )
+  void IncompressibleNavierStokesSPGSMStabilization<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();
@@ -163,9 +162,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void IncompressibleNavierStokesSPGSMStabilization<Mu>::mass_residual( bool compute_jacobian,
-                                                                        AssemblyContext& context,
-                                                                        CachedValues& /*cache*/ )
+  void IncompressibleNavierStokesSPGSMStabilization<Mu>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -92,7 +92,7 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokes<Mu,SH,TC>::init_context( AssemblyContext& context )
+  void LowMachNavierStokes<Mu,SH,TC>::init_context( AssemblyContext & context )
   {
     // First call base class
     LowMachNavierStokesBase<Mu,SH,TC>::init_context(context);
@@ -111,10 +111,11 @@ namespace GRINS
 
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokes<Mu,SH,TC>::element_time_derivative( bool compute_jacobian,
-                                                               AssemblyContext& context,
-                                                               CachedValues& cache )
+  void LowMachNavierStokes<Mu,SH,TC>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
+    const CachedValues & cache = context.get_cached_values();
+
     this->assemble_mass_time_deriv( compute_jacobian, context, cache );
     this->assemble_momentum_time_deriv( compute_jacobian, context, cache );
     this->assemble_energy_time_deriv( compute_jacobian, context, cache );
@@ -124,9 +125,9 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokes<Mu,SH,TC>::element_constraint( bool compute_jacobian,
-                                                          AssemblyContext& context,
-                                                          CachedValues& /* cache */ )
+  void LowMachNavierStokes<Mu,SH,TC>::element_constraint
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // Pin p = p_value at p_point
     if( this->_pin_pressure )
@@ -134,9 +135,8 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokes<Mu,SH,TC>::mass_residual( bool compute_jacobian,
-                                                     AssemblyContext& context,
-                                                     CachedValues& /*cache*/ )
+  void LowMachNavierStokes<Mu,SH,TC>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     this->assemble_continuity_mass_residual( compute_jacobian, context );
 
@@ -150,8 +150,8 @@ namespace GRINS
 
   template<class Mu, class SH, class TC>
   void LowMachNavierStokes<Mu,SH,TC>::assemble_mass_time_deriv( bool compute_jacobian,
-                                                                AssemblyContext& context,
-                                                                CachedValues& cache )
+                                                                AssemblyContext & context,
+                                                                const CachedValues & cache )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();
@@ -285,8 +285,8 @@ namespace GRINS
 
   template<class Mu, class SH, class TC>
   void LowMachNavierStokes<Mu,SH,TC>::assemble_momentum_time_deriv( bool compute_jacobian,
-                                                                    AssemblyContext& context,
-                                                                    CachedValues& cache )
+                                                                    AssemblyContext & context,
+                                                                    const CachedValues & cache )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();
@@ -579,8 +579,8 @@ namespace GRINS
 
   template<class Mu, class SH, class TC>
   void LowMachNavierStokes<Mu,SH,TC>::assemble_energy_time_deriv( bool compute_jacobian,
-                                                                  AssemblyContext& context,
-                                                                  CachedValues& cache )
+                                                                  AssemblyContext & context,
+                                                                  const CachedValues & cache )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_T_dofs = context.get_dof_indices(this->_temp_vars.T()).size();
@@ -1018,8 +1018,10 @@ namespace GRINS
 
   template<class Mu, class SH, class TC>
   void LowMachNavierStokes<Mu,SH,TC>::compute_element_time_derivative_cache( AssemblyContext & context,
-                                                                             CachedValues& cache )
+                                                                             CachedValues & /*cache*/ )
   {
+    CachedValues & cache = context.get_cached_values();
+
     const unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     std::vector<libMesh::Real> u, v, w, T, p, p0;

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -1017,7 +1017,7 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokes<Mu,SH,TC>::compute_element_time_derivative_cache( const AssemblyContext& context,
+  void LowMachNavierStokes<Mu,SH,TC>::compute_element_time_derivative_cache( AssemblyContext & context,
                                                                              CachedValues& cache )
   {
     const unsigned int n_qpoints = context.get_element_qrule().n_points();

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -1017,8 +1017,7 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokes<Mu,SH,TC>::compute_element_time_derivative_cache( AssemblyContext & context,
-                                                                             CachedValues & /*cache*/ )
+  void LowMachNavierStokes<Mu,SH,TC>::compute_element_time_derivative_cache( AssemblyContext & context )
   {
     CachedValues & cache = context.get_cached_values();
 
@@ -1078,8 +1077,6 @@ namespace GRINS
 
     cache.set_values(Cache::PRESSURE, p);
     cache.set_values(Cache::THERMO_PRESSURE, p0);
-
-    return;
   }
 
   template<class Mu, class SH, class TC>

--- a/src/physics/src/low_mach_navier_stokes_braack_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_braack_stab.C
@@ -53,9 +53,9 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokesBraackStabilization<Mu,SH,TC>::element_time_derivative( bool compute_jacobian,
-                                                                                  AssemblyContext& context,
-                                                                                  CachedValues& /*cache*/ )
+  void LowMachNavierStokesBraackStabilization<Mu,SH,TC>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     this->assemble_continuity_time_deriv( compute_jacobian, context );
     this->assemble_momentum_time_deriv( compute_jacobian, context );
@@ -63,9 +63,8 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokesBraackStabilization<Mu,SH,TC>::mass_residual( bool compute_jacobian,
-                                                                        AssemblyContext& context,
-                                                                        CachedValues& /*cache*/ )
+  void LowMachNavierStokesBraackStabilization<Mu,SH,TC>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     this->assemble_continuity_mass_residual( compute_jacobian, context );
     this->assemble_momentum_mass_residual( compute_jacobian, context );

--- a/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
@@ -51,9 +51,9 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokesSPGSMStabilization<Mu,SH,TC>::element_time_derivative( bool compute_jacobian,
-                                                                                 AssemblyContext& context,
-                                                                                 CachedValues& /*cache*/ )
+  void LowMachNavierStokesSPGSMStabilization<Mu,SH,TC>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     this->assemble_continuity_time_deriv( compute_jacobian, context );
     this->assemble_momentum_time_deriv( compute_jacobian, context );
@@ -61,9 +61,8 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokesSPGSMStabilization<Mu,SH,TC>::mass_residual( bool compute_jacobian,
-                                                                       AssemblyContext& context,
-                                                                       CachedValues& /*cache*/ )
+  void LowMachNavierStokesSPGSMStabilization<Mu,SH,TC>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     this->assemble_continuity_mass_residual( compute_jacobian, context );
     this->assemble_momentum_mass_residual( compute_jacobian, context );

--- a/src/physics/src/low_mach_navier_stokes_vms_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_vms_stab.C
@@ -53,9 +53,9 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokesVMSStabilization<Mu,SH,TC>::element_time_derivative( bool compute_jacobian,
-                                                                               AssemblyContext& context,
-                                                                               CachedValues& /*cache*/ )
+  void LowMachNavierStokesVMSStabilization<Mu,SH,TC>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     this->assemble_continuity_time_deriv( compute_jacobian, context );
     this->assemble_momentum_time_deriv( compute_jacobian, context );
@@ -63,9 +63,8 @@ namespace GRINS
   }
 
   template<class Mu, class SH, class TC>
-  void LowMachNavierStokesVMSStabilization<Mu,SH,TC>::mass_residual( bool compute_jacobian,
-                                                                     AssemblyContext& context,
-                                                                     CachedValues& /*cache*/ )
+  void LowMachNavierStokesVMSStabilization<Mu,SH,TC>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     this->assemble_continuity_mass_residual( compute_jacobian, context );
     this->assemble_momentum_mass_residual( compute_jacobian, context );

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -307,7 +307,7 @@ namespace GRINS
     bool compute_jacobian = true;
     if( !request_jacobian || _use_numerical_jacobians_only ) compute_jacobian = false;
 
-    CachedValues cache;
+    CachedValues & cache = c.get_cached_values();
 
     // Now compute cache for this element
     for( PhysicsListIter physics_iter = _physics_list.begin();
@@ -335,6 +335,8 @@ namespace GRINS
             ((*(physics_iter->second)).*resfunc)( compute_jacobian, c, cache );
           }
       }
+
+    cache.clear();
 
     // TODO: Need to think about the implications of this because there might be some
     // TODO: jacobian terms we don't want to compute for efficiency reasons

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -315,7 +315,7 @@ namespace GRINS
          physics_iter++ )
       {
         // shared_ptr gets confused by operator->*
-        ((*(physics_iter->second)).*cachefunc)( c, cache );
+        ((*(physics_iter->second)).*cachefunc)( c );
       }
 
     // Loop over each physics and compute their contributions
@@ -336,6 +336,8 @@ namespace GRINS
           }
       }
 
+    // We need to clear out the cache when we're done so we don't interfere
+    // with other residual functions
     cache.clear();
 
     // TODO: Need to think about the implications of this because there might be some

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -327,12 +327,12 @@ namespace GRINS
           {
             if( (physics_iter->second)->enabled_on_elem( &c.get_elem() ) )
               {
-                ((*(physics_iter->second)).*resfunc)( compute_jacobian, c, cache );
+                ((*(physics_iter->second)).*resfunc)( compute_jacobian, c );
               }
           }
         else
           {
-            ((*(physics_iter->second)).*resfunc)( compute_jacobian, c, cache );
+            ((*(physics_iter->second)).*resfunc)( compute_jacobian, c );
           }
       }
 

--- a/src/physics/src/parsed_source_term.C
+++ b/src/physics/src/parsed_source_term.C
@@ -44,11 +44,6 @@ namespace GRINS
                         "DIE!");
   }
 
-  ParsedSourceTerm::~ParsedSourceTerm()
-  {
-    return;
-  }
-
   void ParsedSourceTerm::init_context( AssemblyContext& context )
   {
     for( std::vector<VariableIndex>::const_iterator v_it = _vars.begin();
@@ -62,9 +57,8 @@ namespace GRINS
       }
   }
 
-  void ParsedSourceTerm::element_time_derivative( bool /*compute_jacobian*/,
-                                                  AssemblyContext& context,
-                                                  CachedValues& /*cache*/ )
+  void ParsedSourceTerm::element_time_derivative
+  ( bool /*compute_jacobian*/, AssemblyContext & context )
   {
     for( std::vector<VariableIndex>::const_iterator v_it = _vars.begin();
          v_it != _vars.end(); ++v_it )

--- a/src/physics/src/parsed_velocity_source.C
+++ b/src/physics/src/parsed_velocity_source.C
@@ -103,9 +103,9 @@ namespace GRINS
   }
 
   template<class Mu>
-  void ParsedVelocitySource<Mu>::element_time_derivative( bool compute_jacobian,
-                                                          AssemblyContext& context,
-                                                          CachedValues& /* cache */ )
+  void ParsedVelocitySource<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // Element Jacobian * quadrature weights for interior integration
     const std::vector<libMesh::Real> &JxW =

--- a/src/physics/src/parsed_velocity_source_adjoint_stab.C
+++ b/src/physics/src/parsed_velocity_source_adjoint_stab.C
@@ -65,9 +65,9 @@ namespace GRINS
   }
 
   template<class Mu>
-  void ParsedVelocitySourceAdjointStabilization<Mu>::element_time_derivative( bool compute_jacobian,
-                                                                              AssemblyContext& context,
-                                                                              CachedValues& /*cache*/ )
+  void ParsedVelocitySourceAdjointStabilization<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();
@@ -231,9 +231,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void ParsedVelocitySourceAdjointStabilization<Mu>::element_constraint( bool compute_jacobian,
-                                                                         AssemblyContext& context,
-                                                                         CachedValues& /*cache*/ )
+  void ParsedVelocitySourceAdjointStabilization<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();

--- a/src/physics/src/physics.C
+++ b/src/physics/src/physics.C
@@ -132,60 +132,6 @@ namespace GRINS
     return;
   }
 
-  void Physics::compute_element_time_derivative_cache( const AssemblyContext&,
-                                                       CachedValues& )
-  {
-    return;
-  }
-
-  void Physics::compute_side_time_derivative_cache( const AssemblyContext& /*context*/,
-                                                    CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::compute_nonlocal_time_derivative_cache( const AssemblyContext& /*context*/,
-                                                        CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::compute_element_constraint_cache( const AssemblyContext& /*context*/,
-                                                  CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::compute_side_constraint_cache( const AssemblyContext& /*context*/,
-                                               CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::compute_nonlocal_constraint_cache( const AssemblyContext& /*context*/,
-                                                   CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::compute_damping_residual_cache( const AssemblyContext& /*context*/,
-                                                CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::compute_mass_residual_cache( const AssemblyContext& /*context*/,
-                                             CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::compute_nonlocal_mass_residual_cache( const AssemblyContext& /*context*/,
-                                                      CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
   void Physics::element_time_derivative( bool /*compute_jacobian*/,
                                          AssemblyContext& /*context*/,
                                          CachedValues& /*cache*/ )

--- a/src/physics/src/physics.C
+++ b/src/physics/src/physics.C
@@ -132,69 +132,6 @@ namespace GRINS
     return;
   }
 
-  void Physics::element_time_derivative( bool /*compute_jacobian*/,
-                                         AssemblyContext& /*context*/,
-                                         CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::side_time_derivative( bool /*compute_jacobian*/,
-                                      AssemblyContext& /*context*/,
-                                      CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::nonlocal_time_derivative( bool /*compute_jacobian*/,
-                                          AssemblyContext& /*context*/,
-                                          CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::element_constraint( bool /*compute_jacobian*/,
-                                    AssemblyContext& /*context*/,
-                                    CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::side_constraint( bool /*compute_jacobian*/,
-                                 AssemblyContext& /*context*/,
-                                 CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::nonlocal_constraint( bool /*compute_jacobian*/,
-                                     AssemblyContext& /*context*/,
-                                     CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::damping_residual( bool /*compute_jacobian*/,
-                                  AssemblyContext& /*context*/,
-                                  CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::mass_residual( bool /*compute_jacobian*/,
-                               AssemblyContext& /*context*/,
-                               CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
-  void Physics::nonlocal_mass_residual( bool /*compute_jacobian*/,
-                                        AssemblyContext& /*context*/,
-                                        CachedValues& /*cache*/ )
-  {
-    return;
-  }
-
   void Physics::compute_postprocessed_quantity( unsigned int /*quantity_index*/,
                                                 const AssemblyContext& /*context*/,
                                                 const libMesh::Point& /*point*/,

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -540,8 +540,8 @@ namespace GRINS
   }
 
   template<typename Mixture, typename Evaluator>
-  void ReactingLowMachNavierStokes<Mixture,Evaluator>::compute_element_time_derivative_cache( AssemblyContext & context,
-                                                                                              CachedValues & /*cache*/ )
+  void ReactingLowMachNavierStokes<Mixture,Evaluator>::compute_element_time_derivative_cache
+  ( AssemblyContext & context )
   {
     CachedValues & cache = context.get_cached_values();
 

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -541,8 +541,8 @@ namespace GRINS
   }
 
   template<typename Mixture, typename Evaluator>
-  void ReactingLowMachNavierStokes<Mixture,Evaluator>::compute_element_time_derivative_cache( const AssemblyContext& context,
-                                                                                              CachedValues& cache )
+  void ReactingLowMachNavierStokes<Mixture,Evaluator>::compute_element_time_derivative_cache( AssemblyContext & context,
+                                                                                              CachedValues & cache )
   {
     Evaluator gas_evaluator( this->_gas_mixture );
 

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -159,9 +159,7 @@ namespace GRINS
 
   template<typename Mixture, typename Evaluator>
   void ReactingLowMachNavierStokes<Mixture,Evaluator>::element_time_derivative
-  ( bool compute_jacobian,
-    AssemblyContext & context,
-    CachedValues & /*cache*/ )
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     if( compute_jacobian )
       libmesh_not_implemented();
@@ -400,9 +398,9 @@ namespace GRINS
   }
 
   template<typename Mixture, typename Evaluator>
-  void ReactingLowMachNavierStokes<Mixture,Evaluator>::element_constraint( bool compute_jacobian,
-                                                                           AssemblyContext& context,
-                                                                           CachedValues& /* cache */ )
+  void ReactingLowMachNavierStokes<Mixture,Evaluator>::element_constraint
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // Pin p = p_value at p_point
     if( this->_pin_pressure )
@@ -414,9 +412,8 @@ namespace GRINS
   }
 
   template<typename Mixture, typename Evaluator>
-  void ReactingLowMachNavierStokes<Mixture,Evaluator>::mass_residual( bool compute_jacobian,
-                                                                      AssemblyContext& context,
-                                                                      CachedValues& /*cache*/ )
+  void ReactingLowMachNavierStokes<Mixture,Evaluator>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -158,14 +158,16 @@ namespace GRINS
   }
 
   template<typename Mixture, typename Evaluator>
-  void ReactingLowMachNavierStokes<Mixture,Evaluator>::element_time_derivative( bool compute_jacobian,
-                                                                                AssemblyContext& context,
-                                                                                CachedValues& cache )
+  void ReactingLowMachNavierStokes<Mixture,Evaluator>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context,
+    CachedValues & /*cache*/ )
   {
     if( compute_jacobian )
-      {
-        libmesh_not_implemented();
-      }
+      libmesh_not_implemented();
+
+    const CachedValues & cache = context.get_cached_values();
+
     // Convenience
     const VariableIndex s0_var = this->_species_vars.species(0);
 
@@ -542,8 +544,10 @@ namespace GRINS
 
   template<typename Mixture, typename Evaluator>
   void ReactingLowMachNavierStokes<Mixture,Evaluator>::compute_element_time_derivative_cache( AssemblyContext & context,
-                                                                                              CachedValues & cache )
+                                                                                              CachedValues & /*cache*/ )
   {
+    CachedValues & cache = context.get_cached_values();
+
     Evaluator gas_evaluator( this->_gas_mixture );
 
     const unsigned int n_qpoints = context.get_element_qrule().n_points();

--- a/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
@@ -39,9 +39,9 @@ namespace GRINS
   {}
 
   template<typename Mixture, typename Evaluator>
-  void ReactingLowMachNavierStokesSPGSMStabilization<Mixture,Evaluator>::element_time_derivative( bool compute_jacobian,
-                                                                                                  AssemblyContext& context,
-                                                                                                  CachedValues& /*cache*/ )
+  void ReactingLowMachNavierStokesSPGSMStabilization<Mixture,Evaluator>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();
@@ -191,9 +191,8 @@ namespace GRINS
   }
 
   template<typename Mixture, typename Evaluator>
-  void ReactingLowMachNavierStokesSPGSMStabilization<Mixture,Evaluator>::mass_residual( bool compute_jacobian,
-                                                                                        AssemblyContext& context,
-                                                                                        CachedValues& /*cache*/ )
+  void ReactingLowMachNavierStokesSPGSMStabilization<Mixture,Evaluator>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();

--- a/src/physics/src/scalar_ode.C
+++ b/src/physics/src/scalar_ode.C
@@ -102,9 +102,8 @@ namespace GRINS
   }
 
 
-  void ScalarODE::nonlocal_time_derivative(bool compute_jacobian,
-                                           AssemblyContext& context,
-                                           CachedValues& /* cache */ )
+  void ScalarODE::nonlocal_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     libMesh::DenseSubMatrix<libMesh::Number> &Kss =
       context.get_elem_jacobian(this->scalar_ode_var(), this->scalar_ode_var()); // R_{s},{s}
@@ -148,9 +147,8 @@ namespace GRINS
   }
 
 
-  void ScalarODE::nonlocal_mass_residual(bool compute_jacobian,
-                                         AssemblyContext& context,
-                                         CachedValues& /* cache */ )
+  void ScalarODE::nonlocal_mass_residual
+  (bool compute_jacobian, AssemblyContext & context )
   {
     libMesh::DenseSubMatrix<libMesh::Number> &Kss =
       context.get_elem_jacobian(this->scalar_ode_var(), this->scalar_ode_var()); // R_{s},{s}
@@ -194,9 +192,8 @@ namespace GRINS
   }
 
 
-  void ScalarODE::nonlocal_constraint(bool compute_jacobian,
-                                      AssemblyContext& context,
-                                      CachedValues& /* cache */ )
+  void ScalarODE::nonlocal_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     libMesh::DenseSubMatrix<libMesh::Number> &Kss =
       context.get_elem_jacobian(this->scalar_ode_var(), this->scalar_ode_var()); // R_{s},{s}

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -120,9 +120,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void SpalartAllmaras<Mu>::element_time_derivative( bool compute_jacobian,
-                                                     AssemblyContext& context,
-                                                     CachedValues& /*cache*/ )
+  void SpalartAllmaras<Mu>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // Get a pointer to the current element, we need this for computing
     // the distance to wall for the  quadrature points
@@ -262,9 +261,8 @@ namespace GRINS
   }
 
   template<class K>
-  void SpalartAllmaras<K>::mass_residual( bool compute_jacobian,
-                                          AssemblyContext& context,
-                                          CachedValues& /*cache*/ )
+  void SpalartAllmaras<K>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // First we get some references to cell-specific data that
     // will be used to assemble the linear system.

--- a/src/physics/src/spalart_allmaras_spgsm_stab.C
+++ b/src/physics/src/spalart_allmaras_spgsm_stab.C
@@ -63,9 +63,9 @@ namespace GRINS
   }
 
   template<class Mu>
-  void SpalartAllmarasSPGSMStabilization<Mu>::element_time_derivative( bool compute_jacobian,
-                                                                       AssemblyContext& context,
-                                                                       CachedValues& /*cache*/ )
+  void SpalartAllmarasSPGSMStabilization<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // Get a pointer to the current element, we need this for computing the distance to wall for the
     // quadrature points
@@ -147,9 +147,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void SpalartAllmarasSPGSMStabilization<Mu>::mass_residual( bool compute_jacobian,
-                                                             AssemblyContext& context,
-                                                             CachedValues& /*cache*/ )
+  void SpalartAllmarasSPGSMStabilization<Mu>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // Get a pointer to the current element, we need this for computing the distance to wall for the
     // quadrature points

--- a/src/physics/src/stokes.C
+++ b/src/physics/src/stokes.C
@@ -65,9 +65,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void Stokes<Mu>::element_time_derivative( bool compute_jacobian,
-                                            AssemblyContext& context,
-                                            CachedValues& /*cache*/ )
+  void Stokes<Mu>::element_time_derivative
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();
@@ -208,9 +207,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void Stokes<Mu>::element_constraint( bool compute_jacobian,
-                                       AssemblyContext& context,
-                                       CachedValues& /*cache*/ )
+  void Stokes<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();
@@ -293,9 +291,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void Stokes<Mu>::mass_residual( bool compute_jacobian,
-                                  AssemblyContext& context,
-                                  CachedValues& /*cache*/)
+  void Stokes<Mu>::mass_residual
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // Element Jacobian * quadrature weights for interior integration
     // We assume the same for each flow variable

--- a/src/physics/src/variable_pinning.C
+++ b/src/physics/src/variable_pinning.C
@@ -51,7 +51,7 @@ namespace GRINS
       }
   }
 
-  void VariablePinning::auxiliary_init( MultiphysicsSystem& system )
+  void VariablePinning::auxiliary_init( MultiphysicsSystem & system )
   {
     if( _pin_variable )
       {
@@ -69,7 +69,7 @@ namespace GRINS
       }
   }
 
-  void VariablePinning::init_context( AssemblyContext& context )
+  void VariablePinning::init_context( AssemblyContext & context )
   {
     // We should prerequest all the data
     // we will need to build the linear system
@@ -81,15 +81,13 @@ namespace GRINS
       }
   }
 
-  void VariablePinning::element_constraint( bool compute_jacobian,
-                                            AssemblyContext& context,
-                                            CachedValues& /*cache*/ )
+  void VariablePinning::element_constraint
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // Pin var = var_value at p_point
     if( _pin_variable )
-      {
-        _var_pinning.pin_value( context, compute_jacobian, this->_variable_to_pin, this->_penalty );
-      }
+      _var_pinning.pin_value( context, compute_jacobian, this->_variable_to_pin, this->_penalty );
   }
 
 } // namespace GRINS

--- a/src/physics/src/velocity_drag.C
+++ b/src/physics/src/velocity_drag.C
@@ -51,9 +51,9 @@ namespace GRINS
 
 
   template<class Mu>
-  void VelocityDrag<Mu>::element_time_derivative( bool compute_jacobian,
-                                                  AssemblyContext& context,
-                                                  CachedValues& /* cache */ )
+  void VelocityDrag<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // Element Jacobian * quadrature weights for interior integration
     const std::vector<libMesh::Real> &JxW =

--- a/src/physics/src/velocity_drag_adjoint_stab.C
+++ b/src/physics/src/velocity_drag_adjoint_stab.C
@@ -65,8 +65,7 @@ namespace GRINS
   template<class Mu>
   void VelocityDragAdjointStabilization<Mu>::element_time_derivative
   ( bool compute_jacobian,
-    AssemblyContext& context,
-    CachedValues& /* cache */ )
+    AssemblyContext & context )
   {
     libMesh::FEBase* fe = context.get_element_fe(this->_flow_vars.u());
 
@@ -224,9 +223,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void VelocityDragAdjointStabilization<Mu>::element_constraint( bool compute_jacobian,
-                                                                 AssemblyContext& context,
-                                                                 CachedValues& /*cache*/ )
+  void VelocityDragAdjointStabilization<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -123,9 +123,9 @@ namespace GRINS
   }
 
   template<class Mu>
-  void VelocityPenalty<Mu>::element_time_derivative( bool compute_jacobian,
-                                                     AssemblyContext& context,
-                                                     CachedValues& /* cache */ )
+  void VelocityPenalty<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // Element Jacobian * quadrature weights for interior integration
     const std::vector<libMesh::Real> &JxW =

--- a/src/physics/src/velocity_penalty_adjoint_stab.C
+++ b/src/physics/src/velocity_penalty_adjoint_stab.C
@@ -65,9 +65,9 @@ namespace GRINS
   }
 
   template<class Mu>
-  void VelocityPenaltyAdjointStabilization<Mu>::element_time_derivative( bool compute_jacobian,
-                                                                         AssemblyContext& context,
-                                                                         CachedValues& /*cache*/ )
+  void VelocityPenaltyAdjointStabilization<Mu>::element_time_derivative
+  ( bool compute_jacobian,
+    AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_u_dofs = context.get_dof_indices(this->_flow_vars.u()).size();
@@ -231,9 +231,8 @@ namespace GRINS
   }
 
   template<class Mu>
-  void VelocityPenaltyAdjointStabilization<Mu>::element_constraint( bool compute_jacobian,
-                                                                    AssemblyContext& context,
-                                                                    CachedValues& /*cache*/ )
+  void VelocityPenaltyAdjointStabilization<Mu>::element_constraint
+  ( bool compute_jacobian, AssemblyContext & context )
   {
     // The number of local degrees of freedom in each variable.
     const unsigned int n_p_dofs = context.get_dof_indices(this->_press_var.p()).size();


### PR DESCRIPTION
This removes `CachedValues` from the `Physics` API and put it in the `AssemblyContext`. You know, because that's what Context objects are for (looks at past self like he's a total dumbass).

Finally figured out the right strategy for regexing the search/replace with emacs. Doing headers just worked, but the .C were originally giving me trouble when I looked at this forever ago. The key was getting the `(<argument list>)` on a new line and using the new `make reindent`. Then search/replace using emacs just worked and got all but about half-dozen things that I could then do manually.

I also did a little miscellaneous formatting here and there.

Very happy to have this out of the API. Now I just need to make `CachedValues` itself not so stupid...