### PR TITLE
Update VariableParsing Interface, Have QoIs Use FEVariablesBase Objects

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -224,6 +224,7 @@ libgrins_la_SOURCES += strategies/src/adaptive_time_stepping_options.C
 libgrins_la_SOURCES += strategies/src/mesh_adaptivity_options.C
 
 #src/variables
+libgrins_la_SOURCES += variables/src/variables_parsing.C
 libgrins_la_SOURCES += variables/src/variable_warehouse.C
 libgrins_la_SOURCES += variables/src/variable_factory.C
 libgrins_la_SOURCES += variables/src/variable_builder.C

--- a/src/physics/src/averaged_turbine_base.C
+++ b/src/physics/src/averaged_turbine_base.C
@@ -46,7 +46,7 @@ namespace GRINS
     chord_function(""),
     area_swept_function(""),
     aoa_function(""),
-    _var(GRINSPrivate::VariableWarehouse::get_variable_subclass<ScalarVariable>(VariablesParsing::physics_scalar_variable_name(input,physics_name)))
+    _var(GRINSPrivate::VariableWarehouse::get_variable_subclass<ScalarVariable>(VariablesParsing::scalar_variable_name(input,physics_name,VariablesParsing::PHYSICS)))
   {
     this->read_input_options(input);
   }

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -47,7 +47,7 @@ namespace GRINS
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
-      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,physics_name)))
+      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS)))
   {
     this->read_input_options(input);
   }

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -45,7 +45,7 @@ namespace GRINS
   AxisymmetricBoussinesqBuoyancy::AxisymmetricBoussinesqBuoyancy( const std::string& physics_name,
                                                                   const GetPot& input )
     : Physics(physics_name, input),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,physics_name))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,physics_name)))
   {

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -46,7 +46,7 @@ namespace GRINS
                                                                   const GetPot& input )
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS)))
   {
     this->read_input_options(input);

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -49,7 +49,7 @@ namespace GRINS
   AxisymmetricHeatTransfer<Conductivity>::AxisymmetricHeatTransfer( const std::string& physics_name,
                                                                     const GetPot& input)
     : Physics(physics_name, input),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,physics_name))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,physics_name))),
       _k(input,MaterialsParsing::material_name(input,PhysicsNaming::axisymmetric_heat_transfer()))

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -50,7 +50,7 @@ namespace GRINS
                                                                     const GetPot& input)
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _k(input,MaterialsParsing::material_name(input,PhysicsNaming::axisymmetric_heat_transfer()))
   {

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -51,7 +51,7 @@ namespace GRINS
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
-      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,physics_name))),
+      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _k(input,MaterialsParsing::material_name(input,PhysicsNaming::axisymmetric_heat_transfer()))
   {
     this->read_input_options(input);

--- a/src/physics/src/boussinesq_buoyancy_base.C
+++ b/src/physics/src/boussinesq_buoyancy_base.C
@@ -44,7 +44,7 @@ namespace GRINS
   BoussinesqBuoyancyBase::BoussinesqBuoyancyBase( const std::string& physics_name, const GetPot& input )
     : Physics(physics_name,input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _rho(0.0),
       _T_ref(1.0),

--- a/src/physics/src/boussinesq_buoyancy_base.C
+++ b/src/physics/src/boussinesq_buoyancy_base.C
@@ -45,7 +45,7 @@ namespace GRINS
     : Physics(physics_name,input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
-      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,physics_name))),
+      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _rho(0.0),
       _T_ref(1.0),
       _beta_T(1.0)

--- a/src/physics/src/boussinesq_buoyancy_base.C
+++ b/src/physics/src/boussinesq_buoyancy_base.C
@@ -43,7 +43,7 @@ namespace GRINS
 
   BoussinesqBuoyancyBase::BoussinesqBuoyancyBase( const std::string& physics_name, const GetPot& input )
     : Physics(physics_name,input),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,physics_name))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,physics_name))),
       _rho(0.0),

--- a/src/physics/src/convection_diffusion.C
+++ b/src/physics/src/convection_diffusion.C
@@ -47,7 +47,7 @@ namespace GRINS
     : Physics(physics_name,input),
       _v(3,libMesh::ParsedFunction<libMesh::Number>("0.0") ),
       _kappa("0.0"),
-      _var(GRINSPrivate::VariableWarehouse::get_variable_subclass<SingleVariable>(VariablesParsing::physics_single_variable_name(input,physics_name)))
+      _var(GRINSPrivate::VariableWarehouse::get_variable_subclass<SingleVariable>(VariablesParsing::single_variable_name(input,physics_name,VariablesParsing::PHYSICS)))
   {
     unsigned int n_v_comps = input.vector_variable_size("Physics/"+physics_name+"/velocity_field");
 

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -46,7 +46,7 @@ namespace GRINS
   template<class K>
   HeatConduction<K>::HeatConduction( const GRINS::PhysicsName& physics_name, const GetPot& input )
     : Physics(physics_name,input),
-      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,physics_name))),
+      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _rho(0.0),
       _Cp(0.0),
       _k(input,MaterialsParsing::material_name(input,PhysicsNaming::heat_conduction()))

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -48,7 +48,7 @@ namespace GRINS
                                          const std::string& core_physics_name,
                                          const GetPot& input )
     : Physics(physics_name, input),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,core_physics_name))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,core_physics_name))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,core_physics_name))),
       _rho(0.0),

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -49,7 +49,7 @@ namespace GRINS
                                          const GetPot& input )
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,core_physics_name))),
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _rho(0.0),
       _Cp(0.0),

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -50,7 +50,7 @@ namespace GRINS
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,core_physics_name))),
-      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,core_physics_name))),
+      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _rho(0.0),
       _Cp(0.0),
       _k(input,MaterialsParsing::material_name(input,core_physics_name))

--- a/src/physics/src/heat_transfer_stab_helper.C
+++ b/src/physics/src/heat_transfer_stab_helper.C
@@ -49,7 +49,7 @@ namespace GRINS
       _tau_factor(0.5),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,PhysicsNaming::heat_transfer(),VariablesParsing::PHYSICS))),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::heat_transfer(),VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,PhysicsNaming::heat_transfer())))
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,PhysicsNaming::heat_transfer(),VariablesParsing::PHYSICS)))
   {
     if (input.have_variable("Stabilization/tau_constant_T"))
       this->set_parameter

--- a/src/physics/src/heat_transfer_stab_helper.C
+++ b/src/physics/src/heat_transfer_stab_helper.C
@@ -47,7 +47,7 @@ namespace GRINS
     : StabilizationHelper(helper_name),
       _C(1),
       _tau_factor(0.5),
-      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,PhysicsNaming::heat_transfer()))),
+      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,PhysicsNaming::heat_transfer(),VariablesParsing::PHYSICS))),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::heat_transfer(),VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,PhysicsNaming::heat_transfer())))
   {

--- a/src/physics/src/heat_transfer_stab_helper.C
+++ b/src/physics/src/heat_transfer_stab_helper.C
@@ -48,7 +48,7 @@ namespace GRINS
       _C(1),
       _tau_factor(0.5),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,PhysicsNaming::heat_transfer()))),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,PhysicsNaming::heat_transfer()))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::heat_transfer(),VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,PhysicsNaming::heat_transfer())))
   {
     if (input.have_variable("Stabilization/tau_constant_T"))

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -49,7 +49,7 @@ namespace GRINS
                                                                      const GetPot& input )
     : Physics(my_physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,core_physics_name))),
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _rho(0.0),
       _mu(input,MaterialsParsing::material_name(input,core_physics_name))
   {

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -48,7 +48,7 @@ namespace GRINS
                                                                      const std::string& core_physics_name,
                                                                      const GetPot& input )
     : Physics(my_physics_name, input),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,core_physics_name))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,core_physics_name))),
       _rho(0.0),
       _mu(input,MaterialsParsing::material_name(input,core_physics_name))

--- a/src/physics/src/inc_navier_stokes_stab_helper.C
+++ b/src/physics/src/inc_navier_stokes_stab_helper.C
@@ -48,7 +48,7 @@ namespace GRINS
       _C(1),
       _tau_factor(0.5),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::incompressible_navier_stokes(),VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,PhysicsNaming::incompressible_navier_stokes())))
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,PhysicsNaming::incompressible_navier_stokes(),VariablesParsing::PHYSICS)))
   {
     if (input.have_variable("Stabilization/tau_constant_vel"))
       this->set_parameter

--- a/src/physics/src/inc_navier_stokes_stab_helper.C
+++ b/src/physics/src/inc_navier_stokes_stab_helper.C
@@ -47,7 +47,7 @@ namespace GRINS
     : StabilizationHelper(helper_name),
       _C(1),
       _tau_factor(0.5),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,PhysicsNaming::incompressible_navier_stokes()))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::incompressible_navier_stokes(),VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,PhysicsNaming::incompressible_navier_stokes())))
   {
     if (input.have_variable("Stabilization/tau_constant_vel"))

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -62,7 +62,7 @@ namespace GRINS
     _enable_thermo_press_calc = input("Physics/"+PhysicsNaming::low_mach_navier_stokes()+"/enable_thermo_press_calc", false );
     if( _enable_thermo_press_calc )
       {
-        _p0_var = &GRINSPrivate::VariableWarehouse::get_variable_subclass<ThermoPressureVariable>(VariablesParsing::physics_thermo_press_variable_name(input,core_physics_name));
+        _p0_var = &GRINSPrivate::VariableWarehouse::get_variable_subclass<ThermoPressureVariable>(VariablesParsing::thermo_press_variable_name(input,core_physics_name,VariablesParsing::PHYSICS));
         _p0_var->set_is_constraint_var(true);
       }
 

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -51,7 +51,7 @@ namespace GRINS
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,core_physics_name))),
-      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,core_physics_name))),
+      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _p0_var(NULL),
       _mu(input,MaterialsParsing::material_name(input,core_physics_name)),
       _cp(input,MaterialsParsing::material_name(input,core_physics_name)),

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -50,7 +50,7 @@ namespace GRINS
                                                              const GetPot& input)
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,core_physics_name))),
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _p0_var(NULL),
       _mu(input,MaterialsParsing::material_name(input,core_physics_name)),

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -49,7 +49,7 @@ namespace GRINS
                                                              const std::string& core_physics_name,
                                                              const GetPot& input)
     : Physics(physics_name, input),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,core_physics_name))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,core_physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,core_physics_name))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,core_physics_name))),
       _p0_var(NULL),

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -67,7 +67,7 @@ namespace GRINS
     _enable_thermo_press_calc = input("Physics/"+PhysicsNaming::reacting_low_mach_navier_stokes()+"/enable_thermo_press_calc", false );
     if( _enable_thermo_press_calc )
       {
-        _p0_var = &GRINSPrivate::VariableWarehouse::get_variable_subclass<ThermoPressureVariable>(VariablesParsing::physics_thermo_press_variable_name(input,physics_name));
+        _p0_var = &GRINSPrivate::VariableWarehouse::get_variable_subclass<ThermoPressureVariable>(VariablesParsing::thermo_press_variable_name(input,physics_name,VariablesParsing::PHYSICS));
         _p0_var->set_is_constraint_var(true);
       }
 

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -51,7 +51,7 @@ namespace GRINS
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
-      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,physics_name))),
+      _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _species_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<SpeciesMassFractionsVariable>(VariablesParsing::physics_species_mass_frac_variable_name(input,physics_name))),
       _p0_var(NULL),
       _n_species(_species_vars.n_species()),

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -49,7 +49,7 @@ namespace GRINS
   ReactingLowMachNavierStokesAbstract::ReactingLowMachNavierStokesAbstract(const std::string& physics_name,
                                                                            const GetPot& input)
     : Physics(physics_name, input),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,physics_name))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::physics_temp_variable_name(input,physics_name))),
       _species_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<SpeciesMassFractionsVariable>(VariablesParsing::physics_species_mass_frac_variable_name(input,physics_name))),

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -50,7 +50,7 @@ namespace GRINS
                                                                            const GetPot& input)
     : Physics(physics_name, input),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _species_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<SpeciesMassFractionsVariable>(VariablesParsing::physics_species_mass_frac_variable_name(input,physics_name))),
       _p0_var(NULL),

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -52,7 +52,7 @@ namespace GRINS
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
-      _species_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<SpeciesMassFractionsVariable>(VariablesParsing::physics_species_mass_frac_variable_name(input,physics_name))),
+      _species_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<SpeciesMassFractionsVariable>(VariablesParsing::species_mass_frac_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _p0_var(NULL),
       _n_species(_species_vars.n_species()),
       _fixed_density( input("Physics/"+PhysicsNaming::reacting_low_mach_navier_stokes()+"/fixed_density", false ) ),

--- a/src/physics/src/scalar_ode.C
+++ b/src/physics/src/scalar_ode.C
@@ -41,7 +41,7 @@ namespace GRINS
     : Physics(physics_name, input),
       _epsilon(1e-6),
       _input(input),
-      _var(GRINSPrivate::VariableWarehouse::get_variable_subclass<ScalarVariable>(VariablesParsing::physics_scalar_variable_name(input,physics_name)))
+      _var(GRINSPrivate::VariableWarehouse::get_variable_subclass<ScalarVariable>(VariablesParsing::scalar_variable_name(input,physics_name,VariablesParsing::PHYSICS)))
   {
     this->read_input_options(input);
 

--- a/src/physics/src/solid_mechanics_abstract.C
+++ b/src/physics/src/solid_mechanics_abstract.C
@@ -39,7 +39,7 @@ namespace GRINS
   SolidMechanicsAbstract::SolidMechanicsAbstract(const PhysicsName& physics_name,
                                                  const GetPot& input )
     : Physics(physics_name,input),
-      _disp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<DisplacementVariable>(VariablesParsing::physics_disp_variable_name(input,physics_name)))
+      _disp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<DisplacementVariable>(VariablesParsing::disp_variable_name(input,physics_name,VariablesParsing::PHYSICS)))
   {
     // For solid mechanics problems, we need to set the sign for tractions
     // to '-' since the second order time solvers use a Newton residual of the form

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -48,7 +48,7 @@ namespace GRINS
   SpalartAllmaras<Mu>::SpalartAllmaras(const std::string& physics_name, const GetPot& input )
     : TurbulenceModelsBase<Mu>(physics_name, input), // Define class variables
     _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
-    _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
+    _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
     _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::physics_turb_variable_name(input,physics_name))),
     _spalart_allmaras_helper(input),
     _sa_params(input),

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -49,7 +49,7 @@ namespace GRINS
     : TurbulenceModelsBase<Mu>(physics_name, input), // Define class variables
     _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
     _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
-    _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::physics_turb_variable_name(input,physics_name))),
+    _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::turb_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
     _spalart_allmaras_helper(input),
     _sa_params(input),
     _no_of_walls(input("Physics/"+PhysicsNaming::spalart_allmaras()+"/no_of_walls", 0)),

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -47,7 +47,7 @@ namespace GRINS
   template<class Mu>
   SpalartAllmaras<Mu>::SpalartAllmaras(const std::string& physics_name, const GetPot& input )
     : TurbulenceModelsBase<Mu>(physics_name, input), // Define class variables
-    _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,physics_name))),
+    _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
     _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,physics_name))),
     _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::physics_turb_variable_name(input,physics_name))),
     _spalart_allmaras_helper(input),

--- a/src/physics/src/spalart_allmaras_helper.C
+++ b/src/physics/src/spalart_allmaras_helper.C
@@ -46,7 +46,7 @@ namespace GRINS
 {
   SpalartAllmarasHelper::SpalartAllmarasHelper(const GetPot& input )
     : _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,PhysicsNaming::spalart_allmaras())))
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS)))
   {}
 
   libMesh::Real SpalartAllmarasHelper::vorticity(AssemblyContext& context, unsigned int qp) const

--- a/src/physics/src/spalart_allmaras_helper.C
+++ b/src/physics/src/spalart_allmaras_helper.C
@@ -45,7 +45,7 @@
 namespace GRINS
 {
   SpalartAllmarasHelper::SpalartAllmarasHelper(const GetPot& input )
-    : _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,PhysicsNaming::spalart_allmaras()))),
+    : _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,PhysicsNaming::spalart_allmaras())))
   {}
 

--- a/src/physics/src/spalart_allmaras_stab_helper.C
+++ b/src/physics/src/spalart_allmaras_stab_helper.C
@@ -47,7 +47,7 @@ namespace GRINS
       _tau_factor( input("Stabilization/tau_factor_vel", input("Stabilization/tau_factor", 0.5 ) ) ),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
-      _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::physics_turb_variable_name(input,PhysicsNaming::spalart_allmaras()))),
+      _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::turb_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
       _spalart_allmaras_helper(input),
       _sa_params(input)
   {

--- a/src/physics/src/spalart_allmaras_stab_helper.C
+++ b/src/physics/src/spalart_allmaras_stab_helper.C
@@ -45,7 +45,7 @@ namespace GRINS
     : StabilizationHelper(helper_name),
       _C( input("Stabilization/tau_constant_vel", input("Stabilization/tau_constant", 1.0 ) ) ),
       _tau_factor( input("Stabilization/tau_factor_vel", input("Stabilization/tau_factor", 0.5 ) ) ),
-      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::physics_velocity_variable_name(input,PhysicsNaming::spalart_allmaras()))),
+      _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
       _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,PhysicsNaming::spalart_allmaras()))),
       _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::physics_turb_variable_name(input,PhysicsNaming::spalart_allmaras()))),
       _spalart_allmaras_helper(input),

--- a/src/physics/src/spalart_allmaras_stab_helper.C
+++ b/src/physics/src/spalart_allmaras_stab_helper.C
@@ -46,7 +46,7 @@ namespace GRINS
       _C( input("Stabilization/tau_constant_vel", input("Stabilization/tau_constant", 1.0 ) ) ),
       _tau_factor( input("Stabilization/tau_factor_vel", input("Stabilization/tau_factor", 0.5 ) ) ),
       _flow_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
-      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::physics_press_variable_name(input,PhysicsNaming::spalart_allmaras()))),
+      _press_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>(VariablesParsing::press_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
       _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::physics_turb_variable_name(input,PhysicsNaming::spalart_allmaras()))),
       _spalart_allmaras_helper(input),
       _sa_params(input)

--- a/src/properties/src/spalart_allmaras_viscosity.C
+++ b/src/properties/src/spalart_allmaras_viscosity.C
@@ -36,7 +36,7 @@ namespace GRINS
   SpalartAllmarasViscosity<Mu>::SpalartAllmarasViscosity( const GetPot& input )
     : ParameterUser("SpalartAllmarasViscosity"),
       _mu(input),
-      _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::physics_turb_variable_name(input,PhysicsNaming::spalart_allmaras()))),
+      _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::turb_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
       _sa_params(input)
   {
     // Warning about this constructor being deprecated
@@ -59,7 +59,7 @@ namespace GRINS
   SpalartAllmarasViscosity<Mu>::SpalartAllmarasViscosity( const GetPot& input, const std::string& material ):
     ParameterUser("SpalartAllmarasViscosity"),
     _mu(input,material),
-    _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::physics_turb_variable_name(input,PhysicsNaming::spalart_allmaras()))),
+    _turbulence_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<TurbulenceFEVariables>(VariablesParsing::turb_variable_name(input,PhysicsNaming::spalart_allmaras(),VariablesParsing::PHYSICS))),
     _sa_params(input)
   {}
 

--- a/src/qoi/include/grins/average_nusselt_number.h
+++ b/src/qoi/include/grins/average_nusselt_number.h
@@ -32,6 +32,8 @@
 
 namespace GRINS
 {
+  class PrimitiveTempFEVariables;
+
   class AverageNusseltNumber : public QoIBase
   {
   public:
@@ -65,8 +67,7 @@ namespace GRINS
     //! Thermal conductivity
     libMesh::Real _k;
 
-    //! Temperature variable index
-    VariableIndex _T_var;
+    const PrimitiveTempFEVariables * _temp_vars;
 
     //! List of boundary ids for which we want to compute this QoI
     std::set<libMesh::boundary_id_type> _bc_ids;

--- a/src/qoi/include/grins/vorticity.h
+++ b/src/qoi/include/grins/vorticity.h
@@ -32,6 +32,8 @@
 
 namespace GRINS
 {
+  class VelocityVariable;
+
   //! Vorticity QoI
   /*!
     This class implement a vorticity QoI that can be used to both compute
@@ -81,11 +83,7 @@ namespace GRINS
 
   protected:
 
-    //! u-velocity component variable index
-    VariableIndex _u_var;
-
-    //! v-velocity component variable index
-    VariableIndex _v_var;
+    const VelocityVariable * _flow_vars;
 
     //! List of sumdomain ids for which we want to compute this QoI
     std::set<libMesh::subdomain_id_type> _subdomain_ids;

--- a/src/qoi/src/vorticity.C
+++ b/src/qoi/src/vorticity.C
@@ -29,6 +29,9 @@
 // GRINS
 #include "grins/multiphysics_sys.h"
 #include "grins/assembly_context.h"
+#include "grins/variables_parsing.h"
+#include "grins/variable_warehouse.h"
+#include "grins/multi_component_vector_variable.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -57,7 +60,7 @@ namespace GRINS
 
   void Vorticity::init
   (const GetPot& input,
-   const MultiphysicsSystem& system,
+   const MultiphysicsSystem& /*system*/,
    unsigned int /*qoi_num*/ )
   {
     // Extract subdomain on which to compute to qoi
@@ -75,13 +78,7 @@ namespace GRINS
         _subdomain_ids.insert( s_id );
       }
 
-    // Grab velocity variable indices
-    std::string u_var_name = input("Physics/VariableNames/u_velocity", u_var_name_default);
-    std::string v_var_name = input("Physics/VariableNames/v_velocity", v_var_name_default);
-    this->_u_var = system.variable_number(u_var_name);
-    this->_v_var = system.variable_number(v_var_name);
-
-    return;
+    _flow_vars = &(GRINSPrivate::VariableWarehouse::get_variable_subclass<VelocityVariable>(VariablesParsing::velocity_variable_name(input,"Vorticity",VariablesParsing::QOI)));
   }
 
   void Vorticity::init_context( AssemblyContext& context )
@@ -89,8 +86,8 @@ namespace GRINS
     libMesh::FEBase* u_fe = NULL;
     libMesh::FEBase* v_fe = NULL;
 
-    context.get_element_fe<libMesh::Real>(this->_u_var, u_fe);
-    context.get_element_fe<libMesh::Real>(this->_v_var, v_fe);
+    context.get_element_fe<libMesh::Real>(_flow_vars->u(), u_fe);
+    context.get_element_fe<libMesh::Real>(_flow_vars->v(), v_fe);
 
     u_fe->get_dphi();
     u_fe->get_JxW();
@@ -107,7 +104,7 @@ namespace GRINS
     if( _subdomain_ids.find( (&context.get_elem())->subdomain_id() ) != _subdomain_ids.end() )
       {
         libMesh::FEBase* element_fe;
-        context.get_element_fe<libMesh::Real>(this->_u_var, element_fe);
+        context.get_element_fe<libMesh::Real>(_flow_vars->u(), element_fe);
         const std::vector<libMesh::Real> &JxW = element_fe->get_JxW();
 
         unsigned int n_qpoints = context.get_element_qrule().n_points();
@@ -119,8 +116,8 @@ namespace GRINS
           {
             libMesh::Gradient grad_u = 0.;
             libMesh::Gradient grad_v = 0.;
-            context.interior_gradient( this->_u_var, qp, grad_u );
-            context.interior_gradient( this->_v_var, qp, grad_v );
+            context.interior_gradient( _flow_vars->u(), qp, grad_u );
+            context.interior_gradient( _flow_vars->v(), qp, grad_v );
             qoi += (grad_v(0) - grad_u(1)) * JxW[qp];
           }
       }
@@ -136,16 +133,16 @@ namespace GRINS
       {
         // Element
         libMesh::FEBase* element_fe;
-        context.get_element_fe<libMesh::Real>(this->_u_var, element_fe);
+        context.get_element_fe<libMesh::Real>(_flow_vars->u(), element_fe);
 
         // Jacobian times integration weights
         const std::vector<libMesh::Real> &JxW = element_fe->get_JxW();
 
         // Grad of basis functions
         const std::vector<std::vector<libMesh::RealGradient> >& du_phi =
-          context.get_element_fe(_u_var)->get_dphi();
+          context.get_element_fe(_flow_vars->u())->get_dphi();
         const std::vector<std::vector<libMesh::RealGradient> >& dv_phi =
-          context.get_element_fe(_v_var)->get_dphi();
+          context.get_element_fe(_flow_vars->v())->get_dphi();
 
         // Local DOF count and quadrature point count
         const unsigned int n_T_dofs = context.get_dof_indices(0).size();
@@ -154,8 +151,8 @@ namespace GRINS
         // Warning: we assume here that vorticity is the only QoI!
         // This should be consistent with the assertion in grins_mesh_adaptive_solver.C
         /*! \todo Need to generalize this to the multiple QoI case */
-        libMesh::DenseSubVector<libMesh::Number> &Qu = context.get_qoi_derivatives(qoi_index, _u_var);
-        libMesh::DenseSubVector<libMesh::Number> &Qv = context.get_qoi_derivatives(qoi_index, _v_var);
+        libMesh::DenseSubVector<libMesh::Number> &Qu = context.get_qoi_derivatives(qoi_index, _flow_vars->u());
+        libMesh::DenseSubVector<libMesh::Number> &Qv = context.get_qoi_derivatives(qoi_index, _flow_vars->v());
 
         // Integration loop
         for( unsigned int qp = 0; qp != n_qpoints; qp++ )

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -82,7 +82,7 @@ namespace GRINS
     static std::string order_input_name( const std::string& subsection )
     { return VariablesParsing::variables_section()+"/"+subsection+"/order"; }
 
-    enum SECTION_TYPE { PHYSICS = 0 };
+    enum SECTION_TYPE { PHYSICS = 0, QOI };
 
     static std::string single_variable_name( const GetPot& input, const std::string& subsection_name,
                                              const SECTION_TYPE section_type )

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -85,73 +85,72 @@ namespace GRINS
     enum SECTION_TYPE { PHYSICS = 0 };
 
     static std::string physics_single_variable_name( const GetPot& input, const std::string& physics_name )
-    { return VariablesParsing::parse_physics_var_name(input,
+    { return VariablesParsing::section_parse_var_name(input,
                                                       physics_name,
                                                       "var_name",
-                                                      VariablesParsing::single_var_section()); }
+                                                      VariablesParsing::single_var_section(),
+                                                      PHYSICS); }
 
     static std::string physics_scalar_variable_name( const GetPot& input, const std::string& physics_name )
-    { return VariablesParsing::parse_physics_var_name(input,
+    { return VariablesParsing::section_parse_var_name(input,
                                                       physics_name,
                                                       "var_name",
-                                                      VariablesParsing::scalar_var_section()); }
+                                                      VariablesParsing::scalar_var_section(),
+                                                      PHYSICS); }
 
     static std::string physics_velocity_variable_name( const GetPot& input, const std::string& physics_name )
-    { return VariablesParsing::parse_physics_var_name(input,
+    { return VariablesParsing::section_parse_var_name(input,
                                                       physics_name,
                                                       "velocity_var_name",
-                                                      VariablesParsing::velocity_section()); }
+                                                      VariablesParsing::velocity_section(),
+                                                      PHYSICS); }
 
     static std::string physics_temp_variable_name( const GetPot& input, const std::string& physics_name )
-    { return VariablesParsing::parse_physics_var_name(input,
+    { return VariablesParsing::section_parse_var_name(input,
                                                       physics_name,
                                                       "temperature_var_name",
-                                                      VariablesParsing::temperature_section()); }
+                                                      VariablesParsing::temperature_section(),
+                                                      PHYSICS); }
 
     static std::string physics_press_variable_name( const GetPot& input, const std::string& physics_name )
-    { return VariablesParsing::parse_physics_var_name(input,
+    { return VariablesParsing::section_parse_var_name(input,
                                                       physics_name,
                                                       "pressure_var_name",
-                                                      VariablesParsing::pressure_section()); }
+                                                      VariablesParsing::pressure_section(),
+                                                      PHYSICS); }
 
     static std::string physics_thermo_press_variable_name( const GetPot& input, const std::string& physics_name )
-    { return VariablesParsing::parse_physics_var_name(input,
+    { return VariablesParsing::section_parse_var_name(input,
                                                       physics_name,
                                                       "thermo_pressure_var_name",
-                                                      VariablesParsing::thermo_pressure_section()); }
+                                                      VariablesParsing::thermo_pressure_section(),
+                                                      PHYSICS); }
 
     static std::string physics_turb_variable_name( const GetPot& input, const std::string& physics_name )
-    { return VariablesParsing::parse_physics_var_name(input,
+    { return VariablesParsing::section_parse_var_name(input,
                                                       physics_name,
                                                       "turbulence_var_name",
-                                                      VariablesParsing::turbulence_section()); }
+                                                      VariablesParsing::turbulence_section(),
+                                                      PHYSICS); }
 
     static std::string physics_disp_variable_name( const GetPot& input, const std::string& physics_name )
-    { return VariablesParsing::parse_physics_var_name(input,
+    { return VariablesParsing::section_parse_var_name(input,
                                                       physics_name,
                                                       "displacement_var_name",
-                                                      VariablesParsing::displacement_section()); }
+                                                      VariablesParsing::displacement_section(),
+                                                      PHYSICS); }
 
     static std::string physics_species_mass_frac_variable_name( const GetPot& input,
                                                                 const std::string& physics_name )
-    { return VariablesParsing::parse_physics_var_name(input,
+    { return VariablesParsing::section_parse_var_name(input,
                                                       physics_name,
                                                       "species_mass_fracs_var_name",
-                                                      VariablesParsing::species_mass_fractions_section()); }
+                                                      VariablesParsing::species_mass_fractions_section(),
+                                                      PHYSICS); }
+
+
 
   private:
-
-    //! string to feed to GetPot to look up the name of the Variable
-    static std::string physics_var_name_input( const std::string& physics_name, const std::string& var_name )
-    { return std::string("Physics/"+physics_name+"/"+var_name); }
-
-    //! Parse the variable name from the Physics section and falls back to default if it's not there
-    /*! It's intended the default be one of the Variable "types". */
-    static std::string parse_physics_var_name(const GetPot& input,
-                                              const std::string& physics_name,
-                                              const std::string& var_name,
-                                              const std::string& default_name )
-    { return input( VariablesParsing::physics_var_name_input(physics_name,var_name), default_name ); }
 
     static std::string section_parse_var_name( const GetPot & input,
                                                const std::string & input_subsection_name,

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -140,12 +140,13 @@ namespace GRINS
                                                       VariablesParsing::turbulence_section(),
                                                       section_type); }
 
-    static std::string physics_disp_variable_name( const GetPot& input, const std::string& physics_name )
+    static std::string disp_variable_name( const GetPot& input, const std::string& subsection_name,
+                                           const SECTION_TYPE section_type )
     { return VariablesParsing::section_parse_var_name(input,
-                                                      physics_name,
+                                                      subsection_name,
                                                       "displacement_var_name",
                                                       VariablesParsing::displacement_section(),
-                                                      PHYSICS); }
+                                                      section_type); }
 
     static std::string physics_species_mass_frac_variable_name( const GetPot& input,
                                                                 const std::string& physics_name )

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -132,12 +132,13 @@ namespace GRINS
                                                       VariablesParsing::thermo_pressure_section(),
                                                       section_type); }
 
-    static std::string physics_turb_variable_name( const GetPot& input, const std::string& physics_name )
+    static std::string turb_variable_name( const GetPot& input, const std::string& subsection_name,
+                                           const SECTION_TYPE section_type )
     { return VariablesParsing::section_parse_var_name(input,
-                                                      physics_name,
+                                                      subsection_name,
                                                       "turbulence_var_name",
                                                       VariablesParsing::turbulence_section(),
-                                                      PHYSICS); }
+                                                      section_type); }
 
     static std::string physics_disp_variable_name( const GetPot& input, const std::string& physics_name )
     { return VariablesParsing::section_parse_var_name(input,

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -116,12 +116,13 @@ namespace GRINS
                                                       VariablesParsing::temperature_section(),
                                                       section_type); }
 
-    static std::string physics_press_variable_name( const GetPot& input, const std::string& physics_name )
+    static std::string press_variable_name( const GetPot& input, const std::string& subsection_name,
+                                            const SECTION_TYPE section_type )
     { return VariablesParsing::section_parse_var_name(input,
-                                                      physics_name,
+                                                      subsection_name,
                                                       "pressure_var_name",
                                                       VariablesParsing::pressure_section(),
-                                                      PHYSICS); }
+                                                      section_type); }
 
     static std::string physics_thermo_press_variable_name( const GetPot& input, const std::string& physics_name )
     { return VariablesParsing::section_parse_var_name(input,

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -92,12 +92,13 @@ namespace GRINS
                                                       VariablesParsing::single_var_section(),
                                                       section_type); }
 
-    static std::string physics_scalar_variable_name( const GetPot& input, const std::string& physics_name )
+    static std::string scalar_variable_name( const GetPot& input, const std::string& subsection_name,
+                                             const SECTION_TYPE section_type )
     { return VariablesParsing::section_parse_var_name(input,
-                                                      physics_name,
+                                                      subsection_name,
                                                       "var_name",
                                                       VariablesParsing::scalar_var_section(),
-                                                      PHYSICS); }
+                                                      section_type); }
 
     static std::string physics_velocity_variable_name( const GetPot& input, const std::string& physics_name )
     { return VariablesParsing::section_parse_var_name(input,

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -108,12 +108,13 @@ namespace GRINS
                                                       VariablesParsing::velocity_section(),
                                                       section_type); }
 
-    static std::string physics_temp_variable_name( const GetPot& input, const std::string& physics_name )
+    static std::string temp_variable_name( const GetPot& input, const std::string& subsection_name,
+                                           const SECTION_TYPE section_type )
     { return VariablesParsing::section_parse_var_name(input,
-                                                      physics_name,
+                                                      subsection_name,
                                                       "temperature_var_name",
                                                       VariablesParsing::temperature_section(),
-                                                      PHYSICS); }
+                                                      section_type); }
 
     static std::string physics_press_variable_name( const GetPot& input, const std::string& physics_name )
     { return VariablesParsing::section_parse_var_name(input,

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -82,6 +82,8 @@ namespace GRINS
     static std::string order_input_name( const std::string& subsection )
     { return VariablesParsing::variables_section()+"/"+subsection+"/order"; }
 
+    enum SECTION_TYPE { PHYSICS = 0 };
+
     static std::string physics_single_variable_name( const GetPot& input, const std::string& physics_name )
     { return VariablesParsing::parse_physics_var_name(input,
                                                       physics_name,
@@ -150,6 +152,12 @@ namespace GRINS
                                               const std::string& var_name,
                                               const std::string& default_name )
     { return input( VariablesParsing::physics_var_name_input(physics_name,var_name), default_name ); }
+
+    static std::string section_parse_var_name( const GetPot & input,
+                                               const std::string & input_subsection_name,
+                                               const std::string & input_var_name,
+                                               const std::string & default_var_name,
+                                               const SECTION_TYPE section_type );
   };
 
 } // end namespace GRINS

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -100,12 +100,13 @@ namespace GRINS
                                                       VariablesParsing::scalar_var_section(),
                                                       section_type); }
 
-    static std::string physics_velocity_variable_name( const GetPot& input, const std::string& physics_name )
+    static std::string velocity_variable_name( const GetPot& input, const std::string& subsection_name,
+                                               const SECTION_TYPE section_type )
     { return VariablesParsing::section_parse_var_name(input,
-                                                      physics_name,
+                                                      subsection_name,
                                                       "velocity_var_name",
                                                       VariablesParsing::velocity_section(),
-                                                      PHYSICS); }
+                                                      section_type); }
 
     static std::string physics_temp_variable_name( const GetPot& input, const std::string& physics_name )
     { return VariablesParsing::section_parse_var_name(input,

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -124,12 +124,13 @@ namespace GRINS
                                                       VariablesParsing::pressure_section(),
                                                       section_type); }
 
-    static std::string physics_thermo_press_variable_name( const GetPot& input, const std::string& physics_name )
+    static std::string thermo_press_variable_name( const GetPot& input, const std::string& subsection_name,
+                                                   const SECTION_TYPE section_type )
     { return VariablesParsing::section_parse_var_name(input,
-                                                      physics_name,
+                                                      subsection_name,
                                                       "thermo_pressure_var_name",
                                                       VariablesParsing::thermo_pressure_section(),
-                                                      PHYSICS); }
+                                                      section_type); }
 
     static std::string physics_turb_variable_name( const GetPot& input, const std::string& physics_name )
     { return VariablesParsing::section_parse_var_name(input,

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -148,13 +148,14 @@ namespace GRINS
                                                       VariablesParsing::displacement_section(),
                                                       section_type); }
 
-    static std::string physics_species_mass_frac_variable_name( const GetPot& input,
-                                                                const std::string& physics_name )
+    static std::string species_mass_frac_variable_name( const GetPot& input,
+                                                        const std::string& subsection_name,
+                                                        const SECTION_TYPE section_type )
     { return VariablesParsing::section_parse_var_name(input,
-                                                      physics_name,
+                                                      subsection_name,
                                                       "species_mass_fracs_var_name",
                                                       VariablesParsing::species_mass_fractions_section(),
-                                                      PHYSICS); }
+                                                      section_type); }
 
 
 

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -84,12 +84,13 @@ namespace GRINS
 
     enum SECTION_TYPE { PHYSICS = 0 };
 
-    static std::string physics_single_variable_name( const GetPot& input, const std::string& physics_name )
+    static std::string single_variable_name( const GetPot& input, const std::string& subsection_name,
+                                             const SECTION_TYPE section_type )
     { return VariablesParsing::section_parse_var_name(input,
-                                                      physics_name,
+                                                      subsection_name,
                                                       "var_name",
                                                       VariablesParsing::single_var_section(),
-                                                      PHYSICS); }
+                                                      section_type); }
 
     static std::string physics_scalar_variable_name( const GetPot& input, const std::string& physics_name )
     { return VariablesParsing::section_parse_var_name(input,

--- a/src/variables/src/variables_parsing.C
+++ b/src/variables/src/variables_parsing.C
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/variables_parsing.h"
+
+namespace GRINS
+{
+  std::string VariablesParsing::section_parse_var_name( const GetPot & input,
+                                                        const std::string & input_subsection_name,
+                                                        const std::string & input_var_name,
+                                                        const std::string & default_var_name,
+                                                        const SECTION_TYPE section_type )
+  {
+    std::string var_name;
+    switch(section_type)
+      {
+      case(PHYSICS):
+        {
+          var_name = input("Physics/"+input_subsection_name+"/"+input_var_name, default_var_name );
+          break;
+        }
+      default:
+        libmesh_error_msg("ERROR: Invalid section value!");
+
+      }
+
+    return var_name;
+  }
+} // end namespace GRINS

--- a/src/variables/src/variables_parsing.C
+++ b/src/variables/src/variables_parsing.C
@@ -33,19 +33,23 @@ namespace GRINS
                                                         const std::string & default_var_name,
                                                         const SECTION_TYPE section_type )
   {
-    std::string var_name;
+    std::string header;
     switch(section_type)
       {
       case(PHYSICS):
         {
-          var_name = input("Physics/"+input_subsection_name+"/"+input_var_name, default_var_name );
+          header = "Physics";
+          break;
+        }
+      case(QOI):
+        {
+          header = "QoI";
           break;
         }
       default:
         libmesh_error_msg("ERROR: Invalid section value!");
-
       }
 
-    return var_name;
+    return input(header+"/"+input_subsection_name+"/"+input_var_name, default_var_name );
   }
 } // end namespace GRINS


### PR DESCRIPTION
Two main sets of changes, the first set being required for the second.

The first set of changes is to rework the guts of how we call `VariableParsing` to get the variable name. It was more or less hardcoded to `Physics` before, but we'll also want to be able to parse variable information from other sections, so I generalized it.

The second is to update the QoIs that used variable indices to now use `FEVariablesBase` subclasses, similar to how we use them in `Physics`. This way, we have consistency in the parsing, in particular if the user wants to change how the variable section names are referenced in the input file.

These changes are leading up to refactoring QoI construction and a new QoIFactory (forthcoming).
