### PR TITLE
Cleanup Warnings

### DIFF
--- a/src/apps/cantera_kinetic_rates.C
+++ b/src/apps/cantera_kinetic_rates.C
@@ -72,8 +72,6 @@ int main(int argc, char* argv[])
       Y[s] = input( "Conditions/mass_fractions", 0.0, s );
     }
 
-  libMesh::Real R_mix = mixture.R_mix(Y);
-
   std::vector<double> omega_dot(n_species,0.0);
 
   libMesh::Real T = T0;

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_abstract.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_abstract.h
@@ -78,11 +78,11 @@ namespace GRINS
     PressureFEVariable& _press_var;
     PrimitiveTempFEVariables& _temp_vars;
 
+     SpeciesMassFractionsVariable& _species_vars;
+
     /*! \todo When we mandate C++11, switch this to a SharedPtr. Then, in the VariableWarhouse,
       we can use dynamic_pointer_cast to get a SharedPtr. */
     ThermoPressureVariable* _p0_var;
-
-    SpeciesMassFractionsVariable& _species_vars;
 
     //! Number of species
     unsigned int _n_species;

--- a/src/properties/src/antioch_kinetics.C
+++ b/src/properties/src/antioch_kinetics.C
@@ -79,10 +79,12 @@ namespace GRINS
     // to check (and potentially clip) each species
     if (!have_density)
       for (unsigned int i=0; i != n_species; ++i)
-        if (molar_densities[i] <= 0)
-          molar_densities[i] = 0;
-        else
-          have_density = true;
+        {
+          if (molar_densities[i] <= 0)
+            molar_densities[i] = 0;
+          else
+            have_density = true;
+        }
 
     if (have_density)
       _antioch_kinetics.compute_mass_sources( temp_cache.T,


### PR DESCRIPTION
A little tidying up of warnings. If I turn of Cantera, this produces no warnings for me and, with a little build system work, we'll be able to start turning on `-Werror` on `femputer` builds.

I'll merge this very soon because I want to use this to test new `femputer` recipes I added for merges-to-master.