### PR TITLE
Update minimum libMesh in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In addition to a modern C++ compiler, GRINS requires an up-to-date installation 
 
 libMesh
 -------
-GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is 7f436d7, as of GRINS [PR #497](https://github.com/grinsfem/grins/pull/497).
+GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is 8be0a4e, as of GRINS [PR #499](https://github.com/grinsfem/grins/pull/499).
 GRINS release 0.5.0 can use libMesh versions as old as 0.9.4. Subsequent to
 the 0.5.0 release requires at least libMesh 1.0.0.
 


### PR DESCRIPTION
I've updated the minimum libMesh on `femputer`, and in the GRINS README, to libMesh/libmesh@8be0a4e, corresponding to fixes by @roystgnr in libMesh/libmesh#1352. Thus, all tests should pass now.