### PR TITLE
Refactor Antioch Wrapper Construction

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -472,6 +472,7 @@ include_HEADERS += properties/include/grins/materials_parsing.h
 include_HEADERS += properties/include/grins/viscosity_base.h
 include_HEADERS += properties/include/grins/antioch_thermo_curve_fit_instantiation_macro.h
 include_HEADERS += properties/include/grins/antioch_options_naming.h
+include_HEADERS += properties/include/grins/antioch_mixture_builder_base.h
 
 # src/qoi headers
 include_HEADERS += qoi/include/grins/average_nusselt_number.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -179,6 +179,7 @@ libgrins_la_SOURCES += properties/src/hyperelasticity_instantiate.C
 libgrins_la_SOURCES += properties/src/mooney_rivlin.C
 libgrins_la_SOURCES += properties/src/materials_parsing.C
 libgrins_la_SOURCES += properties/src/viscosity_base.C
+libgrins_la_SOURCES += properties/src/antioch_mixture_builder_base.C
 
 # src/qoi files
 libgrins_la_SOURCES += qoi/src/average_nusselt_number.C

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -180,6 +180,7 @@ libgrins_la_SOURCES += properties/src/mooney_rivlin.C
 libgrins_la_SOURCES += properties/src/materials_parsing.C
 libgrins_la_SOURCES += properties/src/viscosity_base.C
 libgrins_la_SOURCES += properties/src/antioch_mixture_builder_base.C
+libgrins_la_SOURCES += properties/src/antioch_mixture_averaged_transport_mixture_builder.C
 
 # src/qoi files
 libgrins_la_SOURCES += qoi/src/average_nusselt_number.C
@@ -475,6 +476,7 @@ include_HEADERS += properties/include/grins/antioch_thermo_curve_fit_instantiati
 include_HEADERS += properties/include/grins/antioch_options_naming.h
 include_HEADERS += properties/include/grins/antioch_mixture_builder_base.h
 include_HEADERS += properties/include/grins/antioch_constant_transport_mixture_builder.h
+include_HEADERS += properties/include/grins/antioch_mixture_averaged_transport_mixture_builder.h
 
 # src/qoi headers
 include_HEADERS += qoi/include/grins/average_nusselt_number.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -474,6 +474,7 @@ include_HEADERS += properties/include/grins/viscosity_base.h
 include_HEADERS += properties/include/grins/antioch_thermo_curve_fit_instantiation_macro.h
 include_HEADERS += properties/include/grins/antioch_options_naming.h
 include_HEADERS += properties/include/grins/antioch_mixture_builder_base.h
+include_HEADERS += properties/include/grins/antioch_constant_transport_mixture_builder.h
 
 # src/qoi headers
 include_HEADERS += qoi/include/grins/average_nusselt_number.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -181,6 +181,7 @@ libgrins_la_SOURCES += properties/src/materials_parsing.C
 libgrins_la_SOURCES += properties/src/viscosity_base.C
 libgrins_la_SOURCES += properties/src/antioch_mixture_builder_base.C
 libgrins_la_SOURCES += properties/src/antioch_mixture_averaged_transport_mixture_builder.C
+libgrins_la_SOURCES += properties/src/chemistry_builder.C
 
 # src/qoi files
 libgrins_la_SOURCES += qoi/src/average_nusselt_number.C
@@ -477,6 +478,7 @@ include_HEADERS += properties/include/grins/antioch_options_naming.h
 include_HEADERS += properties/include/grins/antioch_mixture_builder_base.h
 include_HEADERS += properties/include/grins/antioch_constant_transport_mixture_builder.h
 include_HEADERS += properties/include/grins/antioch_mixture_averaged_transport_mixture_builder.h
+include_HEADERS += properties/include/grins/chemistry_builder.h
 
 # src/qoi headers
 include_HEADERS += qoi/include/grins/average_nusselt_number.h

--- a/src/boundary_conditions/include/grins/gas_recombination_catalytic_wall_neumann_bc_factory_impl.h
+++ b/src/boundary_conditions/include/grins/gas_recombination_catalytic_wall_neumann_bc_factory_impl.h
@@ -59,8 +59,7 @@ namespace GRINS
   protected:
 
     template<typename ChemistryType>
-    void build_wall_ptr(  const GetPot& input,
-                          const std::string& material,
+    void build_wall_ptr(  SharedPtr<ChemistryType> & chem_ptr,
                           SharedPtr<CatalycityBase>& catalycity,
                           const std::string& reactant,
                           const std::string& product,
@@ -69,8 +68,6 @@ namespace GRINS
                           libMesh::Real p0,
                           SharedPtr<NeumannBCAbstract>& catalytic_wall )
     {
-      SharedPtr<ChemistryType> chem_ptr( new ChemistryType(input,material) );
-
       catalytic_wall.reset( new GasRecombinationCatalyticWall<ChemistryType>
                             ( chem_ptr,
                               catalycity,

--- a/src/boundary_conditions/include/grins/gas_solid_catalytic_wall_neumann_bc_factory_impl.h
+++ b/src/boundary_conditions/include/grins/gas_solid_catalytic_wall_neumann_bc_factory_impl.h
@@ -60,19 +60,16 @@ namespace GRINS
   protected:
 
     template<typename ChemistryType>
-    void build_wall_ptr( const GetPot& input,
-                         const std::string& material,
-                         SharedPtr<CatalycityBase>& gamma_ptr,
-                         const std::string& gas_reactant,
-                         const std::string& solid_reactant,
-                         const std::string& product,
-                         const std::vector<VariableIndex>& species_vars,
+    void build_wall_ptr( SharedPtr<ChemistryType> & chem_ptr,
+                         SharedPtr<CatalycityBase> & gamma_ptr,
+                         const std::string & gas_reactant,
+                         const std::string & solid_reactant,
+                         const std::string & product,
+                         const std::vector<VariableIndex> & species_vars,
                          VariableIndex T_var,
                          libMesh::Real p0,
-                         SharedPtr<NeumannBCAbstract>& catalytic_wall )
+                         SharedPtr<NeumannBCAbstract> & catalytic_wall )
     {
-      SharedPtr<ChemistryType> chem_ptr( new ChemistryType(input,material) );
-
       catalytic_wall.reset( new GasSolidCatalyticWall<ChemistryType>
                             ( chem_ptr,
                               gamma_ptr,

--- a/src/boundary_conditions/src/constant_function_dirichlet_bc_factory.C
+++ b/src/boundary_conditions/src/constant_function_dirichlet_bc_factory.C
@@ -29,6 +29,7 @@
 #include "grins/string_utils.h"
 #include "grins/multicomponent_variable.h"
 #include "grins/variable_warehouse.h"
+#include "grins/chemistry_builder.h"
 
 #ifdef GRINS_HAVE_CANTERA
 #include "grins/cantera_mixture.h"
@@ -262,7 +263,11 @@ namespace GRINS
     // Now convert to mass frac and add to composite function
     /*! \todo We should have a ChemsitryWarehouse or something to just grab this from one place
       instead of rebuilding. */
-    ChemistryType chem(input,material);
+    ChemistryBuilder chem_builder;
+    libMesh::UniquePtr<ChemistryType> chem_ptr;
+    chem_builder.build_chemistry(input,material,chem_ptr);
+
+    const ChemistryType & chem = *chem_ptr;
 
     libMesh::Real M = 0.0;
     for(unsigned int v = 0; v < n_vars_found; v++ )

--- a/src/boundary_conditions/src/gas_solid_catalytic_wall_neumann_bc_factory_impl.C
+++ b/src/boundary_conditions/src/gas_solid_catalytic_wall_neumann_bc_factory_impl.C
@@ -27,6 +27,7 @@
 
 // GRINS
 #include "grins/string_utils.h"
+#include "grins/chemistry_builder.h"
 
 #ifdef GRINS_HAVE_CANTERA
 #include "grins/cantera_mixture.h"
@@ -61,10 +62,18 @@ namespace GRINS
     // Now construct the Neumann BC
     SharedPtr<NeumannBCAbstract> catalytic_wall;
 
+    ChemistryBuilder chem_builder;
+
     if( thermochem_lib == "cantera" )
       {
 #ifdef GRINS_HAVE_CANTERA
-        this->build_wall_ptr<CanteraMixture>(input,material,gamma_ptr,gas_reactant,solid_reactant,
+        libMesh::UniquePtr<CanteraMixture> chem_uptr;
+        chem_builder.build_chemistry(input,material,chem_uptr);
+
+        /*! \todo Update the API for the catalytic walls to take a unique_ptr to avoid this garbage.*/
+        SharedPtr<CanteraMixture> chem_ptr(chem_uptr.release());
+
+        this->build_wall_ptr<CanteraMixture>(chem_ptr,gamma_ptr,gas_reactant,solid_reactant,
                                              product,species_vars,T_var,p0,catalytic_wall);
 #else
         libmesh_error_msg("Error: Cantera not enabled in this configuration. Reconfigure using --with-cantera option.");
@@ -73,7 +82,13 @@ namespace GRINS
     else if( thermochem_lib == "antioch" )
       {
 #ifdef GRINS_HAVE_ANTIOCH
-        this->build_wall_ptr<AntiochChemistry>(input,material,gamma_ptr,gas_reactant,solid_reactant,
+        libMesh::UniquePtr<AntiochChemistry> chem_uptr;
+        chem_builder.build_chemistry(input,material,chem_uptr);
+
+        /*! \todo Update the API for the catalytic walls to take a unique_ptr to avoid this garbage.*/
+        SharedPtr<AntiochChemistry> chem_ptr(chem_uptr.release());
+
+        this->build_wall_ptr<AntiochChemistry>(chem_ptr,gamma_ptr,gas_reactant,solid_reactant,
                                                product,species_vars,T_var,p0,catalytic_wall);
 #else
         libmesh_error_msg("Error: Antioch not enabled in this configuration. Reconfigure using --with-antioch option.");

--- a/src/boundary_conditions/src/prescribed_vector_value_dirichlet_old_style_bc_factory.C
+++ b/src/boundary_conditions/src/prescribed_vector_value_dirichlet_old_style_bc_factory.C
@@ -31,6 +31,7 @@
 #include "grins/variable_warehouse.h"
 #include "grins/physics_naming.h"
 #include "grins/physics_factory_helper.h"
+#include "grins/chemistry_builder.h"
 
 #ifdef GRINS_HAVE_CANTERA
 #include "grins/cantera_mixture.h"
@@ -176,7 +177,11 @@ namespace GRINS
 
     /*! \todo We should have a ChemsitryWarehouse or something to just
       grab this from one place instead of rebuilding. */
-    ChemistryType chem(input,material);
+    ChemistryBuilder chem_builder;
+    libMesh::UniquePtr<ChemistryType> chem_ptr;
+    chem_builder.build_chemistry(input,material,chem_ptr);
+
+    const ChemistryType & chem = *chem_ptr;
 
     const unsigned int n_vars = species_mole_fracs.size();
     // Compute M

--- a/src/physics/include/grins/physics_factory_reacting_flows.h
+++ b/src/physics/include/grins/physics_factory_reacting_flows.h
@@ -32,6 +32,8 @@
 #include "grins/antioch_constant_transport_mixture.h"
 #include "grins/antioch_constant_transport_evaluator.h"
 #include "grins/antioch_options_naming.h"
+#include "grins/antioch_constant_transport_mixture_builder.h"
+#include "grins/antioch_mixture_averaged_transport_mixture_builder.h"
 
 namespace GRINS
 {
@@ -58,11 +60,13 @@ namespace GRINS
   private:
 
     void build_mix_avged_physics( const GetPot & input, const std::string & physics_name,
+                                  const std::string & material,
                                   const std::string & thermo_model, const std::string & diffusivity_model,
                                   const std::string & conductivity_model, const std::string & viscosity_model,
                                   libMesh::UniquePtr<Physics> & new_physics );
 
     void build_const_physics( const GetPot & input, const std::string & physics_name,
+                              const std::string & material,
                               const std::string & thermo_model, const std::string & diffusivity_model,
                               const std::string & conductivity_model, const std::string & viscosity_model,
                               libMesh::UniquePtr<Physics> & new_physics );
@@ -70,6 +74,7 @@ namespace GRINS
 #ifdef GRINS_HAVE_ANTIOCH
     template<typename KineticsThermo,typename Thermo>
     void build_mix_avged_physics_with_thermo( const GetPot & input, const std::string & physics_name,
+                                              const std::string & material,
                                               const std::string & diffusivity_model,
                                               const std::string & conductivity_model,
                                               const std::string & viscosity_model,
@@ -83,7 +88,7 @@ namespace GRINS
                                           Thermo,
                                           Antioch::SutherlandViscosity<libMesh::Real>,
                                           Antioch::EuckenThermalConductivity<Thermo>,
-                                          Antioch::ConstantLewisDiffusivity<libMesh::Real> >(input,physics_name,new_physics);
+                                          Antioch::ConstantLewisDiffusivity<libMesh::Real> >(input,physics_name,material,new_physics);
       }
     else if( (diffusivity_model == AntiochOptions::constant_lewis_diffusivity_model()) &&
              (conductivity_model == AntiochOptions::eucken_conductivity_model()) &&
@@ -93,7 +98,7 @@ namespace GRINS
                                           Thermo,
                                           Antioch::BlottnerViscosity<libMesh::Real>,
                                           Antioch::EuckenThermalConductivity<Thermo>,
-                                          Antioch::ConstantLewisDiffusivity<libMesh::Real> >(input,physics_name,new_physics);
+                                          Antioch::ConstantLewisDiffusivity<libMesh::Real> >(input,physics_name,material,new_physics);
       }
     else if( (diffusivity_model == AntiochOptions::kinetic_theory_diffusivity_model()) &&
              (conductivity_model == AntiochOptions::kinetic_theory_conductivity_model()) &&
@@ -104,7 +109,7 @@ namespace GRINS
                                           Thermo,
                                           Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,
                                           Antioch::KineticsTheoryThermalConductivity<Thermo,libMesh::Real>,
-                                          Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> >(input,physics_name,new_physics);
+                                          Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> >(input,physics_name,material,new_physics);
 #else
         libmesh_error_msg("ERROR: Antioch requires GSL in order to use kinetics theory based models!");
 #endif // ANTIOCH_HAVE_GSL
@@ -115,18 +120,18 @@ namespace GRINS
 
     template<typename KineticsThermo,typename Thermo>
     void build_const_physics_with_thermo( const GetPot & input, const std::string & physics_name,
-                                          const std::string & conductivity_model,
+                                          const std::string & material, const std::string & conductivity_model,
                                           libMesh::UniquePtr<Physics> & new_physics )
     {
       if( conductivity_model == AntiochOptions::constant_conductivity_model() )
         {
           this->build_const_physics_ptr<KineticsThermo,Thermo,ConstantConductivity>
-            (input,physics_name,new_physics);
+            (input,physics_name,material,new_physics);
         }
       else if( conductivity_model == AntiochOptions::constant_prandtl_conductivity_model() )
         {
           this->build_const_physics_ptr<KineticsThermo,Thermo,ConstantPrandtlConductivity>
-            (input,physics_name,new_physics);
+            (input,physics_name,material,new_physics);
         }
       else
         {
@@ -140,20 +145,30 @@ namespace GRINS
 
     template<typename KineticsThermo,typename Thermo,typename Viscosity,typename Conductivity,typename Diffusivity>
     void build_mix_avged_physics_ptr( const GetPot& input, const std::string& physics_name,
-                                      libMesh::UniquePtr<Physics> & new_physics )
+                                      const std::string & material, libMesh::UniquePtr<Physics> & new_physics )
     {
+      AntiochMixtureAveragedTransportMixtureBuilder mix_builder;
+
+      libMesh::UniquePtr<AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> >
+        gas_mixture = mix_builder.build_mixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity>(input,material);
+
       new_physics.reset(new DerivedPhysics<AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity>,
                                            AntiochMixtureAveragedTransportEvaluator<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> >
-                        (physics_name,input) );
+                        (physics_name,input,gas_mixture) );
     }
 
     template<typename KineticsThermo,typename Thermo,typename Conductivity>
     void build_const_physics_ptr( const GetPot& input, const std::string& physics_name,
-                                  libMesh::UniquePtr<Physics> & new_physics )
+                                  const std::string & material, libMesh::UniquePtr<Physics> & new_physics )
     {
+      AntiochConstantTransportMixtureBuilder mix_builder;
+
+      libMesh::UniquePtr<GRINS::AntiochConstantTransportMixture<KineticsThermo,Conductivity> >
+        gas_mixture = mix_builder.build_mixture<KineticsThermo,Conductivity>(input,material);
+
       new_physics.reset(new DerivedPhysics<AntiochConstantTransportMixture<KineticsThermo,Conductivity>,
                                            AntiochConstantTransportEvaluator<KineticsThermo,Thermo,Conductivity> >
-                        (physics_name,input) );
+                        (physics_name,input,gas_mixture) );
     }
 #endif // GRINS_HAVE_ANTIOCH
 

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes.h
@@ -36,7 +36,8 @@ namespace GRINS
   {
   public:
 
-    ReactingLowMachNavierStokes(const PhysicsName& physics_name, const GetPot& input);
+    ReactingLowMachNavierStokes(const PhysicsName& physics_name, const GetPot& input,
+                                libMesh::UniquePtr<Mixture> & gas_mix);
 
     virtual ~ReactingLowMachNavierStokes(){};
 

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
@@ -38,9 +38,10 @@ namespace GRINS
   public:
 
     ReactingLowMachNavierStokesBase(const PhysicsName& physics_name,
-                                    const GetPot& input)
+                                    const GetPot& input,
+                                    libMesh::UniquePtr<Mixture> & gas_mix )
       : ReactingLowMachNavierStokesAbstract(physics_name,input),
-        _gas_mixture( new Mixture(input,MaterialsParsing::material_name(input,PhysicsNaming::reacting_low_mach_navier_stokes())) )
+        _gas_mixture(gas_mix.release()) /*! \todo Use std::move when we mandate C++11 */
     {}
 
     virtual ~ReactingLowMachNavierStokesBase(){};

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
@@ -40,7 +40,7 @@ namespace GRINS
     ReactingLowMachNavierStokesBase(const PhysicsName& physics_name,
                                     const GetPot& input)
       : ReactingLowMachNavierStokesAbstract(physics_name,input),
-        _gas_mixture(input,MaterialsParsing::material_name(input,PhysicsNaming::reacting_low_mach_navier_stokes()))
+        _gas_mixture( new Mixture(input,MaterialsParsing::material_name(input,PhysicsNaming::reacting_low_mach_navier_stokes())) )
     {}
 
     virtual ~ReactingLowMachNavierStokesBase(){};
@@ -53,14 +53,14 @@ namespace GRINS
       const
     {
       ParameterUser::register_parameter(param_name, param_pointer);
-      _gas_mixture.register_parameter(param_name, param_pointer);
+      _gas_mixture->register_parameter(param_name, param_pointer);
     }
 
-    const Mixture& gas_mixture() const;
+    const Mixture & gas_mixture() const;
 
   protected:
 
-    Mixture _gas_mixture;
+    libMesh::UniquePtr<Mixture> _gas_mixture;
 
   private:
 
@@ -70,9 +70,9 @@ namespace GRINS
 
   template<typename Mixture>
   inline
-  const Mixture& ReactingLowMachNavierStokesBase<Mixture>::gas_mixture() const
+  const Mixture & ReactingLowMachNavierStokesBase<Mixture>::gas_mixture() const
   {
-    return _gas_mixture;
+    return *_gas_mixture;
   }
 
 } // namespace GRINS

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
@@ -35,7 +35,8 @@ namespace GRINS
   {
   public:
 
-    ReactingLowMachNavierStokesSPGSMStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    ReactingLowMachNavierStokesSPGSMStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input,
+                                                   libMesh::UniquePtr<Mixture> & gas_mix);
     virtual ~ReactingLowMachNavierStokesSPGSMStabilization(){};
 
     virtual void element_time_derivative( bool compute_jacobian,

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_base.h
@@ -39,7 +39,8 @@ namespace GRINS
 
   public:
 
-    ReactingLowMachNavierStokesStabilizationBase( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    ReactingLowMachNavierStokesStabilizationBase( const GRINS::PhysicsName& physics_name, const GetPot& input,
+                                                  libMesh::UniquePtr<Mixture> & gas_mix);
 
     virtual ~ReactingLowMachNavierStokesStabilizationBase(){};
 

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -95,7 +95,7 @@ namespace GRINS
 
                 for( unsigned int s = 0; s < this->n_species(); s++ )
                   {
-                    this->_mole_fractions_index[s] = postprocessing.register_quantity( "X_"+this->_gas_mixture.species_name(s) );
+                    this->_mole_fractions_index[s] = postprocessing.register_quantity( "X_"+this->_gas_mixture->species_name(s) );
                   }
               }
             else if( name == std::string("h_s") )
@@ -104,7 +104,7 @@ namespace GRINS
 
                 for( unsigned int s = 0; s < this->n_species(); s++ )
                   {
-                    this->_h_s_index[s] = postprocessing.register_quantity( "h_"+this->_gas_mixture.species_name(s) );
+                    this->_h_s_index[s] = postprocessing.register_quantity( "h_"+this->_gas_mixture->species_name(s) );
                   }
               }
             else if( name == std::string("omega_dot") )
@@ -112,14 +112,14 @@ namespace GRINS
                 this->_omega_dot_index.resize(this->n_species());
 
                 for( unsigned int s = 0; s < this->n_species(); s++ )
-                  this->_omega_dot_index[s] = postprocessing.register_quantity( "omega_dot_"+this->_gas_mixture.species_name(s) );
+                  this->_omega_dot_index[s] = postprocessing.register_quantity( "omega_dot_"+this->_gas_mixture->species_name(s) );
               }
             else if( name == std::string("D_s") )
               {
                 this->_Ds_index.resize(this->n_species());
 
                 for( unsigned int s = 0; s < this->n_species(); s++ )
-                  this->_Ds_index[s] = postprocessing.register_quantity( "D_"+this->_gas_mixture.species_name(s) );
+                  this->_Ds_index[s] = postprocessing.register_quantity( "D_"+this->_gas_mixture->species_name(s) );
               }
             else
               {
@@ -316,7 +316,7 @@ namespace GRINS
         libMesh::Gradient mass_term(0.0,0.0,0.0);
         for(unsigned int s=0; s < this->_n_species; s++ )
           {
-            mass_term += grad_ws[s]/this->_gas_mixture.M(s);
+            mass_term += grad_ws[s]/this->_gas_mixture->M(s);
           }
         mass_term *= M;
 
@@ -478,7 +478,7 @@ namespace GRINS
         for(unsigned int s=0; s < this->_n_species; s++ )
           ws[s] = context.interior_value(this->_species_vars.species(s), qp);
 
-        Evaluator gas_evaluator( this->_gas_mixture );
+        Evaluator gas_evaluator( *(this->_gas_mixture) );
         const libMesh::Real R_mix = gas_evaluator.R_mix(ws);
         const libMesh::Real p0 = this->get_p0_steady(context,qp);
         const libMesh::Real rho = this->rho(T, p0, R_mix);
@@ -507,7 +507,7 @@ namespace GRINS
               F_s(i) -= rho*ws_dot*s_phi[i][qp]*jac;
 
             // Start accumulating M_dot
-            M_dot += ws_dot/this->_gas_mixture.M(s);
+            M_dot += ws_dot/this->_gas_mixture->M(s);
           }
 
         // Continuity residual
@@ -545,7 +545,7 @@ namespace GRINS
   {
     CachedValues & cache = context.get_cached_values();
 
-    Evaluator gas_evaluator( this->_gas_mixture );
+    Evaluator gas_evaluator( *(this->_gas_mixture) );
 
     const unsigned int n_qpoints = context.get_element_qrule().n_points();
 
@@ -682,7 +682,7 @@ namespace GRINS
                                                                                        const libMesh::Point& point,
                                                                                        libMesh::Real& value )
   {
-    Evaluator gas_evaluator( this->_gas_mixture );
+    Evaluator gas_evaluator( *(this->_gas_mixture) );
 
     if( quantity_index == this->_rho_index )
       {

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -39,8 +39,10 @@
 namespace GRINS
 {
   template<typename Mixture, typename Evaluator>
-  ReactingLowMachNavierStokes<Mixture,Evaluator>::ReactingLowMachNavierStokes(const PhysicsName& physics_name, const GetPot& input)
-    : ReactingLowMachNavierStokesBase<Mixture>(physics_name,input),
+  ReactingLowMachNavierStokes<Mixture,Evaluator>::ReactingLowMachNavierStokes(const PhysicsName& physics_name,
+                                                                              const GetPot& input,
+                                                                              libMesh::UniquePtr<Mixture> & gas_mix)
+    : ReactingLowMachNavierStokesBase<Mixture>(physics_name,input,gas_mix),
     _p_pinning(input,physics_name),
     _rho_index(0),
     _mu_index(0),

--- a/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
@@ -108,7 +108,7 @@ namespace GRINS
             ws[s] = context.fixed_interior_value(this->_species_vars.species(s), qp);
           }
 
-        Evaluator gas_evaluator( this->_gas_mixture );
+        Evaluator gas_evaluator( *(this->_gas_mixture) );
         const libMesh::Real R_mix = gas_evaluator.R_mix(ws);
         const libMesh::Real p0 = this->get_p0_steady(context,qp);
         libMesh::Real rho = this->rho(T, p0, R_mix);
@@ -256,7 +256,7 @@ namespace GRINS
         for(unsigned int s=0; s < this->_n_species; s++ )
           ws[s] = context.fixed_interior_value(this->_species_vars.species(s), qp);
 
-        Evaluator gas_evaluator( this->_gas_mixture );
+        Evaluator gas_evaluator( *(this->_gas_mixture) );
         const libMesh::Real R_mix = gas_evaluator.R_mix(ws);
         const libMesh::Real p0 = this->get_p0_steady(context,qp);
         libMesh::Real rho = this->rho(T, p0, R_mix);

--- a/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
@@ -34,8 +34,9 @@
 namespace GRINS
 {
   template<typename Mixture, typename Evaluator>
-  ReactingLowMachNavierStokesSPGSMStabilization<Mixture,Evaluator>::ReactingLowMachNavierStokesSPGSMStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input )
-    : ReactingLowMachNavierStokesStabilizationBase<Mixture,Evaluator>(physics_name,input)
+  ReactingLowMachNavierStokesSPGSMStabilization<Mixture,Evaluator>::ReactingLowMachNavierStokesSPGSMStabilization
+  ( const GRINS::PhysicsName& physics_name, const GetPot& input,libMesh::UniquePtr<Mixture> & gas_mix )
+    : ReactingLowMachNavierStokesStabilizationBase<Mixture,Evaluator>(physics_name,input,gas_mix)
   {}
 
   template<typename Mixture, typename Evaluator>

--- a/src/physics/src/reacting_low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_stab_base.C
@@ -34,9 +34,9 @@ namespace GRINS
 {
 
   template<typename Mixture, typename Evaluator>
-  ReactingLowMachNavierStokesStabilizationBase<Mixture,Evaluator>::ReactingLowMachNavierStokesStabilizationBase( const std::string& physics_name,
-                                                                                                                 const GetPot& input )
-    : ReactingLowMachNavierStokesBase<Mixture>(physics_name,input),
+  ReactingLowMachNavierStokesStabilizationBase<Mixture,Evaluator>::ReactingLowMachNavierStokesStabilizationBase
+  ( const std::string& physics_name,const GetPot& input,libMesh::UniquePtr<Mixture> & gas_mix )
+    : ReactingLowMachNavierStokesBase<Mixture>(physics_name,input,gas_mix),
     _stab_helper( physics_name+"StabHelper", input )
   {}
 

--- a/src/physics/src/reacting_low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_stab_base.C
@@ -117,7 +117,7 @@ namespace GRINS
         hess_ws[s] = context.interior_hessian(this->_species_vars.species(s), qp);
       }
 
-    Evaluator gas_evaluator( this->_gas_mixture );
+    Evaluator gas_evaluator( *(this->_gas_mixture) );
     const libMesh::Real R_mix = gas_evaluator.R_mix(ws);
     const libMesh::Real p0 = this->get_p0_steady(context,qp);
     libMesh::Real rho = this->rho(T, p0, R_mix );
@@ -244,7 +244,7 @@ namespace GRINS
 
         /* Accumulate mass term for continuity residual
            mass_term = grad_M/M */
-        mass_term += grad_ws[s]/this->_gas_mixture.M(s);
+        mass_term += grad_ws[s]/this->_gas_mixture->M(s);
 
         libMesh::Real hess_s_term = hess_ws[s](0,0) + hess_ws[s](1,1);
 #if LIBMESH_DIM > 2
@@ -291,7 +291,7 @@ namespace GRINS
         ws[s] = context.interior_value(this->_species_vars.species(s), qp);
       }
 
-    Evaluator gas_evaluator( this->_gas_mixture );
+    Evaluator gas_evaluator( *(this->_gas_mixture) );
     const libMesh::Real R_mix = gas_evaluator.R_mix(ws);
     const libMesh::Real p0 = this->get_p0_transient(context,qp);
     const libMesh::Real rho = this->rho(T, p0, R_mix);
@@ -306,7 +306,7 @@ namespace GRINS
         context.interior_rate(this->_species_vars.species(s), qp, ws_dot[s]);
 
         // Start accumulating M_dot
-        M_dot += ws_dot[s]/this->_gas_mixture.M(s);
+        M_dot += ws_dot[s]/this->_gas_mixture->M(s);
       }
     libMesh::Real M_dot_over_M = M_dot*(-M);
 

--- a/src/properties/include/grins/antioch_chemistry.h
+++ b/src/properties/include/grins/antioch_chemistry.h
@@ -60,9 +60,13 @@ namespace GRINS
   {
   public:
 
+    //! Deprecated Constructor
     AntiochChemistry( const GetPot& input, const std::string& material );
 
-    virtual ~AntiochChemistry();
+    //! User passes in built ChemicalMixture and this class takes ownership
+    AntiochChemistry( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture );
+
+    virtual ~AntiochChemistry(){}
 
     //! Species molar mass (molecular weight), [kg/mol]
     libMesh::Real M( unsigned int species ) const;

--- a/src/properties/include/grins/antioch_constant_transport_mixture.h
+++ b/src/properties/include/grins/antioch_constant_transport_mixture.h
@@ -59,7 +59,18 @@ namespace GRINS
   {
   public:
 
+    //! Deprecated Constructor
     AntiochConstantTransportMixture( const GetPot & input, const std::string & material );
+
+    //! Constructor with user-built objects
+    AntiochConstantTransportMixture( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
+                                     libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
+                                     libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
+                                     libMesh::UniquePtr<ConstantViscosity> & visc,
+                                     libMesh::UniquePtr<Conductivity> & cond,
+                                     libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > & diff,
+                                     libMesh::Real min_T = -std::numeric_limits<libMesh::Real>::max(),
+                                     bool clip_negative_rho = false );
 
     virtual ~AntiochConstantTransportMixture(){}
 

--- a/src/properties/include/grins/antioch_constant_transport_mixture_builder.h
+++ b/src/properties/include/grins/antioch_constant_transport_mixture_builder.h
@@ -1,0 +1,87 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_ANTIOCH_CONSTANT_TRANSPORT_MIXTURE_BUILDER_H
+#define GRINS_ANTIOCH_CONSTANT_TRANSPORT_MIXTURE_BUILDER_H
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_ANTIOCH
+
+// GRINS
+#include "grins/antioch_mixture_builder_base.h"
+#include "grins/antioch_constant_transport_mixture.h"
+
+namespace GRINS
+{
+
+  class AntiochConstantTransportMixtureBuilder : public AntiochMixtureBuilderBase
+  {
+  public:
+    AntiochConstantTransportMixtureBuilder(){}
+    ~AntiochConstantTransportMixtureBuilder(){}
+
+    template<typename KineticsThermoCurveFit,typename Conductivity>
+    libMesh::UniquePtr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
+    build_mixture( const GetPot & input, const std::string & material );
+
+  };
+
+  template<typename KineticsThermoCurveFit,typename Conductivity>
+  inline
+  libMesh::UniquePtr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
+  AntiochConstantTransportMixtureBuilder::build_mixture( const GetPot & input, const std::string & material )
+  {
+    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix =
+      this->build_chem_mix(input,material);
+
+    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > reaction_set =
+      this->build_reaction_set(input,material,*chem_mix);
+
+    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > kinetics_thermo =
+      this->build_nasa_thermo_mix<KineticsThermoCurveFit>(input,material,*chem_mix);
+
+    libMesh::UniquePtr<ConstantViscosity> visc =
+      this->build_constant_viscosity(input,material);
+
+    libMesh::UniquePtr<Conductivity> cond =
+      this->build_constant_conductivity<Conductivity>(input,material);
+
+    libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > diff =
+      this->build_constant_lewis_diff(input,material);
+
+    libMesh::Real min_T = this->parse_min_T(input,material);
+    bool clip_negative_rho = this->parse_clip_negative_rho(input,material);
+
+    return libMesh::UniquePtr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
+      ( new AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity>
+        (chem_mix, reaction_set, kinetics_thermo, visc, cond, diff, min_T, clip_negative_rho) );
+  }
+
+} // end namespace GRINS
+
+#endif // GRINS_HAVE_ANTIOCH
+
+#endif // GRINS_ANTIOCH_CONSTANT_TRANSPORT_MIXTURE_BUILDER_H

--- a/src/properties/include/grins/antioch_constant_transport_mixture_builder.h
+++ b/src/properties/include/grins/antioch_constant_transport_mixture_builder.h
@@ -33,6 +33,13 @@
 // GRINS
 #include "grins/antioch_mixture_builder_base.h"
 #include "grins/antioch_constant_transport_mixture.h"
+#include "grins/property_types.h"
+#include "grins/constant_viscosity.h"
+#include "grins/constant_conductivity.h"
+#include "grins/constant_prandtl_conductivity.h"
+
+// Antioch
+#include "antioch/constant_lewis_diffusivity.h"
 
 namespace GRINS
 {
@@ -46,6 +53,43 @@ namespace GRINS
     template<typename KineticsThermoCurveFit,typename Conductivity>
     libMesh::UniquePtr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
     build_mixture( const GetPot & input, const std::string & material );
+
+    libMesh::UniquePtr<ConstantViscosity>
+    build_constant_viscosity( const GetPot & input, const std::string & material )
+    {
+      return libMesh::UniquePtr<ConstantViscosity>( new ConstantViscosity(input,material) );
+    }
+
+    template<typename Conductivity>
+    libMesh::UniquePtr<Conductivity>
+    build_constant_conductivity( const GetPot & input, const std::string & material )
+    {
+      return specialized_build_conductivity( input, material, conductivity_type<Conductivity>() );
+    }
+
+    libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> >
+    build_constant_lewis_diff( const GetPot & input, const std::string & material )
+    {
+      libMesh::Real Le = MaterialsParsing::parse_lewis_number(input,material);
+      return libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> >
+        ( new Antioch::ConstantLewisDiffusivity<libMesh::Real>(Le) );
+    }
+
+  private:
+
+    libMesh::UniquePtr<ConstantConductivity>
+    specialized_build_conductivity( const GetPot & input, const std::string & material,
+                                    conductivity_type<ConstantConductivity> )
+    {
+      return libMesh::UniquePtr<ConstantConductivity>( new ConstantConductivity(input,material) );
+    }
+
+    libMesh::UniquePtr<ConstantPrandtlConductivity>
+    specialized_build_conductivity( const GetPot & input, const std::string & material,
+                                    conductivity_type<ConstantPrandtlConductivity> )
+    {
+      return libMesh::UniquePtr<ConstantPrandtlConductivity>( new ConstantPrandtlConductivity(input,material) );
+    }
 
   };
 

--- a/src/properties/include/grins/antioch_mixture.h
+++ b/src/properties/include/grins/antioch_mixture.h
@@ -67,7 +67,18 @@ namespace GRINS
   {
   public:
 
+    //! Deprecated Constructor
     AntiochMixture( const GetPot& input, const std::string& material );
+
+
+    //! Constructor with user-built objects
+    /*! This constructor expects the user to pass in a ChemicalMixture, ReactionSet, and NASAThermoMixture
+        object already built; this class will take ownership of the pointer. */
+    AntiochMixture( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
+                    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
+                    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
+                    libMesh::Real min_T = -std::numeric_limits<libMesh::Real>::max(),
+                    bool clip_negative_rho = false );
 
     virtual ~AntiochMixture(){};
 

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_mixture_builder.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_mixture_builder.h
@@ -1,0 +1,195 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_ANTIOCH_MIXTURE_AVERAGED_TRANSPORT_MIXTURE_BUILDER_H
+#define GRINS_ANTIOCH_MIXTURE_AVERAGED_TRANSPORT_MIXTURE_BUILDER_H
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_ANTIOCH
+
+// GRINS
+#include "grins/antioch_mixture_builder_base.h"
+#include "grins/antioch_mixture_averaged_transport_mixture.h"
+
+namespace GRINS
+{
+
+  class AntiochMixtureAveragedTransportMixtureBuilder : public AntiochMixtureBuilderBase
+  {
+  public:
+    AntiochMixtureAveragedTransportMixtureBuilder(){}
+    ~AntiochMixtureAveragedTransportMixtureBuilder(){}
+
+    template<typename KineticsThermoCurveFit, typename Thermo, typename Viscosity, typename Conductivity, typename Diffusivity>
+    libMesh::UniquePtr<AntiochMixtureAveragedTransportMixture<KineticsThermoCurveFit,Thermo,Viscosity,Conductivity,Diffusivity> >
+    build_mixture( const GetPot & input, const std::string & material );
+
+  private:
+
+    libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> >
+    build_transport_mixture( const GetPot& input, const std::string& material,
+                             const Antioch::ChemicalMixture<libMesh::Real> & chem_mix );
+
+    libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> >
+    build_mix_avg_trans_mixture( const Antioch::TransportMixture<libMesh::Real> & trans_mix )
+    { return libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> >
+        ( new Antioch::MixtureAveragedTransportMixture<libMesh::Real>(trans_mix) ); }
+
+    template<typename Viscosity>
+    libMesh::UniquePtr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> >
+    build_viscosity( const GetPot& input, const std::string& material,
+                     const Antioch::TransportMixture<libMesh::Real> & trans_mix )
+    { return specialized_build_viscosity( input, material, trans_mix, viscosity_type<Viscosity>() ); }
+
+    template<typename Diffusivity>
+    libMesh::UniquePtr<Antioch::MixtureDiffusion<Diffusivity,libMesh::Real> >
+    build_diffusivity( const GetPot& input, const std::string& material,
+                       const Antioch::TransportMixture<libMesh::Real> & trans_mix )
+    { return specialized_build_diffusivity( input, material, trans_mix, diffusivity_type<Diffusivity>() ); }
+
+    libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> >
+    specialized_build_viscosity( const GetPot& input,
+                                 const std::string& material,
+                                 const Antioch::TransportMixture<libMesh::Real> & trans_mix,
+                                 viscosity_type<Antioch::SutherlandViscosity<libMesh::Real> > )
+    {
+      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> >
+        viscosity( new Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real>(trans_mix) );
+
+      std::string sutherland_data = input("Materials/"+material+"/GasMixture/Antioch/sutherland_data", "default");
+      if( sutherland_data == "default" )
+        sutherland_data = Antioch::DefaultInstallFilename::sutherland_data();
+
+      Antioch::read_sutherland_data_ascii( *(viscosity.get()), sutherland_data );
+
+      return viscosity;
+    }
+
+    libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> >
+    specialized_build_viscosity( const GetPot& input,
+                                 const std::string& material,
+                                 const Antioch::TransportMixture<libMesh::Real> & trans_mix,
+                                 viscosity_type<Antioch::BlottnerViscosity<libMesh::Real> > )
+    {
+      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> >
+        viscosity( new Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real>(trans_mix) );
+
+      std::string blottner_data = input("Materials/"+material+"/GasMixture/Antioch/blottner_data", "default");
+      if( blottner_data == "default" )
+        blottner_data = Antioch::DefaultInstallFilename::blottner_data();
+
+      Antioch::read_blottner_data_ascii( *(viscosity.get()), blottner_data );
+
+      return viscosity;
+    }
+
+#ifdef ANTIOCH_HAVE_GSL
+    libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
+    specialized_build_viscosity( const GetPot& /*input*/,
+                                 const std::string& /*material*/,
+                                 const Antioch::TransportMixture<libMesh::Real> & trans_mix,
+                                 viscosity_type<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner> > )
+    {
+      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
+        viscosity( new Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real>(trans_mix) );
+
+      Antioch::build_kinetics_theory_viscosity<libMesh::Real,Antioch::GSLSpliner>( *(viscosity.get()) );
+
+      return viscosity;
+    }
+#endif // ANTIOCH_HAVE_GSL
+
+
+    libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> >
+    specialized_build_diffusivity( const GetPot& input,
+                                   const std::string& material,
+                                   const Antioch::TransportMixture<libMesh::Real> & trans_mix,
+                                   diffusivity_type<Antioch::ConstantLewisDiffusivity<libMesh::Real> > )
+    {
+      libMesh::Real Le = MaterialsParsing::parse_lewis_number(input,material);
+
+      libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> >
+        diffusivity( new Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real>(trans_mix) );
+
+      Antioch::build_constant_lewis_diffusivity<libMesh::Real>( *(diffusivity.get()), Le);
+
+      return diffusivity;
+    }
+
+#ifdef ANTIOCH_HAVE_GSL
+    libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
+    specialized_build_diffusivity( const GetPot& /*input*/,
+                                   const std::string& /*material*/,
+                                   const Antioch::TransportMixture<libMesh::Real> & trans_mix,
+                                   diffusivity_type<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > )
+    {
+      return libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
+        ( new Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real>(trans_mix) );
+    }
+#endif // ANTIOCH_HAVE_GSL
+
+  };
+
+
+  template<typename KT, typename T, typename V, typename C, typename D>
+  inline
+  libMesh::UniquePtr<AntiochMixtureAveragedTransportMixture<KT,T,V,C,D> >
+  AntiochMixtureAveragedTransportMixtureBuilder::
+  build_mixture( const GetPot & input, const std::string & material )
+  {
+    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix =
+      this->build_chem_mix(input,material);
+
+    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > reaction_set =
+      this->build_reaction_set(input,material,*chem_mix);
+
+    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KT> > kinetics_thermo =
+      this->build_nasa_thermo_mix<KT>(input,material,*chem_mix);
+
+    libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> > trans_mix =
+      this->build_transport_mixture(input,material,*chem_mix);
+
+    libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > wilke_mix =
+      this->build_mix_avg_trans_mixture(*trans_mix);
+
+    libMesh::UniquePtr<Antioch::MixtureViscosity<V,libMesh::Real> > visc =
+      this->build_viscosity<V>(input,material,*trans_mix);
+
+    libMesh::UniquePtr<Antioch::MixtureDiffusion<D,libMesh::Real> > diff =
+      this->build_diffusivity<D>(input,material,*trans_mix);
+
+    libMesh::Real min_T = this->parse_min_T(input,material);
+    bool clip_negative_rho = this->parse_clip_negative_rho(input,material);
+
+    return libMesh::UniquePtr<AntiochMixtureAveragedTransportMixture<KT,T,V,C,D> >
+      ( new AntiochMixtureAveragedTransportMixture<KT,T,V,C,D>
+        (chem_mix, reaction_set, kinetics_thermo, trans_mix, wilke_mix, visc, diff, min_T, clip_negative_rho) );
+  }
+
+} // end namespace GRINS
+
+#endif // GRINS_HAVE_ANTIOCH
+
+#endif // GRINS_ANTIOCH_MIXTURE_AVERAGED_TRANSPORT_MIXTURE_BUILDER_H

--- a/src/properties/include/grins/antioch_mixture_builder_base.h
+++ b/src/properties/include/grins/antioch_mixture_builder_base.h
@@ -102,6 +102,17 @@ namespace GRINS
         ( new Antioch::ConstantLewisDiffusivity<libMesh::Real>(Le) );
     }
 
+    libMesh::Real parse_min_T( const GetPot & input, const std::string & material )
+    {
+      return input( "Materials/"+material+"/GasMixture/Antioch/minimum_T",
+                    -std::numeric_limits<libMesh::Real>::max() );
+    }
+
+    bool parse_clip_negative_rho( const GetPot & input, const std::string & material )
+    {
+      return input( "Materials/"+material+"/GasMixture/Antioch/clip_negative_rho", false);
+    }
+
   protected:
 
     void parse_nasa_data

--- a/src/properties/include/grins/antioch_mixture_builder_base.h
+++ b/src/properties/include/grins/antioch_mixture_builder_base.h
@@ -1,0 +1,64 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_ANTIOCH_MIXTURE_BUILDER_BASE_H
+#define GRINS_ANTIOCH_MIXTURE_BUILDER_BASE_H
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_ANTIOCH
+
+// Antioch
+#include "antioch/vector_utils_decl.h"
+#include "antioch/vector_utils.h"
+#include "antioch/chemical_mixture.h"
+#include "antioch/reaction_set.h"
+#include "antioch/nasa_mixture.h"
+#include "antioch/cea_curve_fit.h"
+
+// C++
+#include <string>
+
+// libMesh forward declarations
+class GetPot;
+
+namespace GRINS
+{
+  //! Base class building Antioch mixture wrappers
+  /*! This class only worries about building the kinetics
+      and the thermo associated with kinetics. Subclasses
+      will handle thermo and transport. */
+  class AntiochMixtureBuilderBase
+  {
+  public:
+    AntiochMixtureBuilderBase(){}
+    ~AntiochMixtureBuilderBase(){}
+
+  };
+} // end namespace GRINS
+
+#endif // GRINS_HAVE_ANTIOCH
+
+#endif // GRINS_ANTIOCH_MIXTURE_BUILDER_BASE_H

--- a/src/properties/include/grins/antioch_mixture_builder_base.h
+++ b/src/properties/include/grins/antioch_mixture_builder_base.h
@@ -38,6 +38,9 @@
 #include "antioch/nasa_mixture.h"
 #include "antioch/cea_curve_fit.h"
 
+// libMesh
+#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+
 // C++
 #include <string>
 
@@ -55,6 +58,9 @@ namespace GRINS
   public:
     AntiochMixtureBuilderBase(){}
     ~AntiochMixtureBuilderBase(){}
+
+    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> >
+    build_chem_mix( const GetPot & input, const std::string & material );
 
   };
 } // end namespace GRINS

--- a/src/properties/include/grins/antioch_mixture_builder_base.h
+++ b/src/properties/include/grins/antioch_mixture_builder_base.h
@@ -32,10 +32,6 @@
 
 // GRINS
 #include "grins/materials_parsing.h"
-#include "grins/property_types.h"
-#include "grins/constant_viscosity.h"
-#include "grins/constant_conductivity.h"
-#include "grins/constant_prandtl_conductivity.h"
 
 // Antioch
 #include "antioch/vector_utils_decl.h"
@@ -45,7 +41,6 @@
 #include "antioch/nasa_mixture.h"
 #include "antioch/cea_curve_fit.h"
 #include "antioch/nasa_mixture_parsing.h"
-#include "antioch/constant_lewis_diffusivity.h"
 
 // libMesh
 #include "libmesh/auto_ptr.h" // libMesh::UniquePtr
@@ -81,26 +76,6 @@ namespace GRINS
     build_nasa_thermo_mix( const GetPot & input, const std::string & material,
                            const Antioch::ChemicalMixture<libMesh::Real> & chem_mix );
 
-    libMesh::UniquePtr<ConstantViscosity>
-    build_constant_viscosity( const GetPot & input, const std::string & material )
-    {
-      return libMesh::UniquePtr<ConstantViscosity>( new ConstantViscosity(input,material) );
-    }
-
-    template<typename Conductivity>
-    libMesh::UniquePtr<Conductivity>
-    build_constant_conductivity( const GetPot & input, const std::string & material )
-    {
-      return specialized_build_conductivity( input, material, conductivity_type<Conductivity>() );
-    }
-
-    libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> >
-    build_constant_lewis_diff( const GetPot & input, const std::string & material )
-    {
-      libMesh::Real Le = MaterialsParsing::parse_lewis_number(input,material);
-      return libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> >
-        ( new Antioch::ConstantLewisDiffusivity<libMesh::Real>(Le) );
-    }
 
     libMesh::Real parse_min_T( const GetPot & input, const std::string & material )
     {
@@ -125,20 +100,6 @@ namespace GRINS
         cea_data_filename = Antioch::DefaultInstallFilename::thermo_data();
 
       Antioch::read_nasa_mixture_data( nasa_mixture, cea_data_filename, Antioch::ASCII, true );
-    }
-
-    libMesh::UniquePtr<ConstantConductivity>
-    specialized_build_conductivity( const GetPot & input, const std::string & material,
-                                    conductivity_type<ConstantConductivity> )
-    {
-      return libMesh::UniquePtr<ConstantConductivity>( new ConstantConductivity(input,material) );
-    }
-
-    libMesh::UniquePtr<ConstantPrandtlConductivity>
-    specialized_build_conductivity( const GetPot & input, const std::string & material,
-                                    conductivity_type<ConstantPrandtlConductivity> )
-    {
-      return libMesh::UniquePtr<ConstantPrandtlConductivity>( new ConstantPrandtlConductivity(input,material) );
     }
 
   };

--- a/src/properties/include/grins/antioch_mixture_builder_base.h
+++ b/src/properties/include/grins/antioch_mixture_builder_base.h
@@ -62,6 +62,10 @@ namespace GRINS
     libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> >
     build_chem_mix( const GetPot & input, const std::string & material );
 
+    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> >
+    build_reaction_set( const GetPot & input, const std::string & material,
+                        const Antioch::ChemicalMixture<libMesh::Real> & chem_mix );
+
   };
 } // end namespace GRINS
 

--- a/src/properties/include/grins/chemistry_builder.h
+++ b/src/properties/include/grins/chemistry_builder.h
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_CHEMISTRY_BUILDER_H
+#define GRINS_CHEMISTRY_BUILDER_H
+
+// libMesh
+#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+#include "libmesh/getpot.h"
+
+// C++
+#include <string>
+
+namespace GRINS
+{
+  class ChemistryBuilder
+  {
+  public:
+    ChemistryBuilder(){}
+    ~ChemistryBuilder(){}
+
+    template<typename ChemistryType>
+    void build_chemistry( const GetPot & input,const std::string & material,
+                          libMesh::UniquePtr<ChemistryType> & chem_ptr );
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_CHEMISTRY_BUILDER_H

--- a/src/properties/src/antioch_chemistry.C
+++ b/src/properties/src/antioch_chemistry.C
@@ -45,6 +45,15 @@ namespace GRINS
                                       const std::string& material )
     : ParameterUser("AntiochChemistry")
   {
+    {
+      std::string warning = "==============================================\n";
+      warning += "WARNING: This AntiochChemistry constructor is DEPREACTED!\n";
+      warning += "         Prefer alternate constructor where parsing\n";
+      warning += "         is done outside this class.\n";
+      warning += "==============================================\n";
+
+      libmesh_warning(warning);
+    }
     std::vector<std::string> species_list;
     MaterialsParsing::parse_chemical_species(input,material,species_list);
 
@@ -70,9 +79,12 @@ namespace GRINS
                                                                      electronic_data_filename ) );
   }
 
-  AntiochChemistry::~AntiochChemistry()
+  AntiochChemistry::AntiochChemistry
+  ( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture )
+    : ParameterUser("AntiochChemistry")
   {
-    return;
+    /*! \todo Use std::move when we have C++11 */
+    _antioch_gas.reset( chem_mixture.release() );
   }
 
   std::string AntiochChemistry::species_name( unsigned int species_index ) const

--- a/src/properties/src/antioch_mixture_averaged_transport_mixture_builder.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_mixture_builder.C
@@ -1,0 +1,57 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_ANTIOCH
+
+// This class
+#include "grins/antioch_mixture_averaged_transport_mixture_builder.h"
+
+namespace GRINS
+{
+  libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> >
+  AntiochMixtureAveragedTransportMixtureBuilder::
+  build_transport_mixture( const GetPot & input, const std::string & material,
+                           const Antioch::ChemicalMixture<libMesh::Real> & chem_mix )
+  {
+    std::string transport_data_filename =
+      input( "Materials/"+material+"/GasMixture/Antioch/transport_data", "default" );
+
+    if( transport_data_filename == std::string("default") )
+      transport_data_filename = Antioch::DefaultInstallFilename::transport_mixture();
+
+    bool verbose_transport_read =
+      input( "Materials/"+material+"/GasMixture/Antioch/verbose_transport_read", false );
+
+    return libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> >
+      ( new Antioch::TransportMixture<libMesh::Real>( chem_mix,
+                                                      transport_data_filename,
+                                                      verbose_transport_read,
+                                                      Antioch::ParsingType::ASCII ) );
+  }
+
+} // end namespace GRINS
+
+#endif // GRINS_HAVE_ANTIOCH

--- a/src/properties/src/antioch_mixture_builder_base.C
+++ b/src/properties/src/antioch_mixture_builder_base.C
@@ -34,6 +34,7 @@
 
 // Antioch
 #include "antioch/default_filename.h"
+#include "antioch/read_reaction_set_data.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -67,6 +68,22 @@ namespace GRINS
                                                      species_data_filename,
                                                      vibration_data_filename,
                                                      electronic_data_filename ) );
+  }
+
+  libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> >
+  AntiochMixtureBuilderBase::build_reaction_set( const GetPot & input, const std::string & material,
+                                                 const Antioch::ChemicalMixture<libMesh::Real> & chem_mix )
+  {
+    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> >
+      reaction_set( new Antioch::ReactionSet<libMesh::Real>(chem_mix) );
+
+    std::string kinetics_data_filename = MaterialsParsing::parse_chemical_kinetics_datafile_name( input, material );
+
+    bool verbose_read = input("screen-options/verbose_kinetics_read", false );
+
+    Antioch::read_reaction_set_data_xml<libMesh::Real>( kinetics_data_filename, verbose_read, *reaction_set );
+
+    return reaction_set;
   }
 
 } // end namespace GRINS

--- a/src/properties/src/antioch_mixture_builder_base.C
+++ b/src/properties/src/antioch_mixture_builder_base.C
@@ -36,9 +36,6 @@
 #include "antioch/default_filename.h"
 #include "antioch/read_reaction_set_data.h"
 
-// libMesh
-#include "libmesh/getpot.h"
-
 namespace GRINS
 {
   libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> >

--- a/src/properties/src/antioch_mixture_builder_base.C
+++ b/src/properties/src/antioch_mixture_builder_base.C
@@ -1,0 +1,74 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_ANTIOCH
+
+// This class
+#include "grins/antioch_mixture_builder_base.h"
+
+// GRINS
+#include "grins/materials_parsing.h"
+
+// Antioch
+#include "antioch/default_filename.h"
+
+// libMesh
+#include "libmesh/getpot.h"
+
+namespace GRINS
+{
+  libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> >
+  AntiochMixtureBuilderBase::build_chem_mix( const GetPot & input, const std::string & material )
+  {
+    std::vector<std::string> species_list;
+    MaterialsParsing::parse_chemical_species(input,material,species_list);
+
+    bool verbose_antioch_read = input("Materials/"+material+"/GasMixture/Antioch/verbose_read",false);
+
+    std::string species_data_filename = input("Materials/"+material+"/GasMixture/Antioch/species_data", "default" );
+    if( species_data_filename == std::string("default") )
+      species_data_filename = Antioch::DefaultInstallFilename::chemical_mixture();
+
+    std::string vibration_data_filename = input("Materials/"+material+"/GasMixture/Antioch/vibration_data", "default" );
+    if( vibration_data_filename == std::string("default") )
+      vibration_data_filename = Antioch::DefaultInstallFilename::vibrational_data();
+
+    std::string electronic_data_filename = input("Materials/"+material+"/GasMixture/Antioch/electronic_data", "default" );
+    if( electronic_data_filename == std::string("default") )
+      electronic_data_filename = Antioch::DefaultInstallFilename::electronic_data();
+
+    // By default, Antioch is using its ASCII parser. We haven't added more options yet.
+    return libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> >
+      ( new Antioch::ChemicalMixture<libMesh::Real>( species_list,
+                                                     verbose_antioch_read,
+                                                     species_data_filename,
+                                                     vibration_data_filename,
+                                                     electronic_data_filename ) );
+  }
+
+} // end namespace GRINS
+
+#endif // GRINS_HAVE_ANTIOCH

--- a/src/properties/src/chemistry_builder.C
+++ b/src/properties/src/chemistry_builder.C
@@ -1,0 +1,66 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/chemistry_builder.h"
+
+#include "grins_config.h"
+
+// GRINS
+#include "grins/antioch_mixture_builder_base.h"
+
+#ifdef GRINS_HAVE_CANTERA
+#include "grins/cantera_mixture.h"
+#endif
+
+#ifdef GRINS_HAVE_ANTIOCH
+#include "grins/antioch_chemistry.h"
+#endif
+
+namespace GRINS
+{
+  #ifdef GRINS_HAVE_CANTERA
+  template<>
+  void ChemistryBuilder::build_chemistry(const GetPot & input,const std::string & material,
+                                         libMesh::UniquePtr<CanteraMixture> & chem_ptr )
+  {
+    chem_ptr.reset( new CanteraMixture(input,material) );
+  }
+#endif // GRINS_HAVE_CANTERA
+
+#ifdef GRINS_HAVE_ANTIOCH
+  template<>
+  void ChemistryBuilder::build_chemistry(const GetPot & input,const std::string & material,
+                                         libMesh::UniquePtr<AntiochChemistry> & chem_ptr )
+  {
+    AntiochMixtureBuilderBase builder;
+
+    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > antioch_chem_mix
+      = builder.build_chem_mix(input,material);
+
+    chem_ptr.reset( new AntiochChemistry(antioch_chem_mix) );
+  }
+#endif // GRINS_HAVE_ANTIOCH
+
+} // end namespace GRINS

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -136,7 +136,8 @@ interface_driver_SOURCES = interface/interface_driver.C \
                            interface/nasa_thermo_test_base.h \
                            interface/species_test_base.h \
                            interface/thermochem_test_common.h \
-                           interface/air_5sp.C
+                           interface/air_5sp.C \
+                           interface/antioch_mixture_builder_test.C
 
 antioch_mixture_averaged_transport_evaluator_regression_SOURCES = interface/antioch_mixture_averaged_transport_evaluator_regression.C
 

--- a/test/input_files/antioch.in
+++ b/test/input_files/antioch.in
@@ -6,7 +6,13 @@
         thermochemistry_library = 'antioch'
         species = 'N2 O2 NO N O'
         kinetics_data = './input_files/air_5sp_test.xml'
+
+        [./Antioch]
+           minimum_T = '114.15'
+           clip_negative_rho = 'true'
+        [../]
      [../]
+
      [./LewisNumber]
         value = '1.4'
      [../]

--- a/test/input_files/antioch.in
+++ b/test/input_files/antioch.in
@@ -6,9 +6,19 @@
         thermochemistry_library = 'antioch'
         species = 'N2 O2 NO N O'
         kinetics_data = './input_files/air_5sp_test.xml'
-
-      [../LewisNumber]
+     [../]
+     [./LewisNumber]
         value = '1.4'
+     [../]
+     [./Viscosity]
+        value = '3.14'
+     [../]
+     [./ThermalConductivity]
+        value = '2.71'
+     [../]
+     [./PrandtlNumber]
+        value = '0.7'
+     [../]
 []
 
 [screen-options]

--- a/test/interface/antioch_mixture_averaged_transport_evaluator_regression.C
+++ b/test/interface/antioch_mixture_averaged_transport_evaluator_regression.C
@@ -38,6 +38,7 @@
 #include "grins/cached_values.h"
 #include "grins/materials_parsing.h"
 #include "grins/physics_naming.h"
+#include "grins/antioch_mixture_averaged_transport_mixture_builder.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -116,7 +117,15 @@ int test_D<Antioch::StatMechThermodynamics<libMesh::Real>,
 template<typename KineticsThermo, typename Thermo, typename Viscosity, typename Conductivity, typename Diffusivity>
 int test_evaluator( const GetPot& input )
 {
-  GRINS::AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> mixture(input,"TestMaterial");
+  GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
+
+  libMesh::UniquePtr<GRINS::AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> >
+    mixture_ptr = builder.build_mixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity>
+    (input,"TestMaterial");
+
+
+  const GRINS::AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> &
+    mixture = *mixture_ptr;
 
   GRINS::AntiochMixtureAveragedTransportEvaluator<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> evaluator(mixture);
 

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -45,6 +45,10 @@ namespace GRINSTesting
     CPPUNIT_TEST( test_build_chem_mix );
     CPPUNIT_TEST( test_build_reaction_set );
     CPPUNIT_TEST( test_build_nasa_thermo_mix_cea );
+    CPPUNIT_TEST( test_build_constant_viscosity );
+    CPPUNIT_TEST( test_build_constant_conductivity );
+    CPPUNIT_TEST( test_build_constant_prandtl_conductivity );
+    CPPUNIT_TEST( test_build_constant_lewis_diff );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -100,10 +104,70 @@ namespace GRINSTesting
       CPPUNIT_ASSERT(nasa_mix->check());
     }
 
+    void test_build_constant_viscosity()
+    {
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      libMesh::UniquePtr<GRINS::ConstantViscosity> visc =
+        builder.build_constant_viscosity( *_input, "TestMaterial" );
+
+      libMesh::Real mu = (*visc)();
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( 3.14, mu, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+    void test_build_constant_conductivity()
+    {
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      libMesh::UniquePtr<GRINS::ConstantConductivity> conductivity =
+        builder.build_constant_conductivity<GRINS::ConstantConductivity>( *_input, "TestMaterial" );
+
+      libMesh::Real k = (*conductivity)();
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( 2.71, k, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+    void test_build_constant_prandtl_conductivity()
+    {
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      libMesh::UniquePtr<GRINS::ConstantPrandtlConductivity> conductivity =
+        builder.build_constant_conductivity<GRINS::ConstantPrandtlConductivity>( *_input, "TestMaterial" );
+
+      libMesh::Real mu = 1.2;
+      libMesh::Real cp = 2.3;
+      libMesh::Real Pr = 0.7;
+      libMesh::Real k = (*conductivity)( mu, cp );
+      libMesh::Real k_exact = mu*cp/Pr;
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( k_exact, k, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+    void test_build_constant_lewis_diff()
+    {
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > diff =
+        builder.build_constant_lewis_diff( *_input, "TestMaterial" );
+
+      libMesh::Real rho = 1.2;
+      libMesh::Real cp = 2.3;
+      libMesh::Real k = 3.4;
+      libMesh::Real Le = 1.4;
+
+      libMesh::Real D = diff->D(rho,cp,k);
+
+      libMesh::Real D_exact = k/rho/cp/Le;
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( D_exact, D, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
   private:
 
     libMesh::UniquePtr<GetPot> _input;
   };
+
 
   CPPUNIT_TEST_SUITE_REGISTRATION( AntiochMixtureBuilderBaseTest );
 

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -44,6 +44,7 @@ namespace GRINSTesting
 
     CPPUNIT_TEST( test_build_chem_mix );
     CPPUNIT_TEST( test_build_reaction_set );
+    CPPUNIT_TEST( test_build_nasa_thermo_mix_cea );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -83,6 +84,20 @@ namespace GRINSTesting
 
       CPPUNIT_ASSERT_EQUAL( 5, (int)reaction_set->n_species() );
       CPPUNIT_ASSERT_EQUAL( 5, (int)reaction_set->n_reactions() );
+    }
+
+    void test_build_nasa_thermo_mix_cea()
+    {
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix
+        = builder.build_chem_mix(*_input, "TestMaterial");
+
+      libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > >
+        nasa_mix =
+        builder.build_nasa_thermo_mix<Antioch::CEACurveFit<libMesh::Real> >(*_input, "TestMaterial", *chem_mix);
+
+      CPPUNIT_ASSERT(nasa_mix->check());
     }
 
   private:

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -34,6 +34,7 @@
 
 //GRINS
 #include "grins/antioch_mixture_builder_base.h"
+#include "grins/antioch_constant_transport_mixture_builder.h"
 
 namespace GRINSTesting
 {
@@ -191,7 +192,86 @@ namespace GRINSTesting
   };
 
 
+
+  class AntiochConstantTransportMixtureBuilderTest : public CppUnit::TestCase
+  {
+  public:
+    CPPUNIT_TEST_SUITE( AntiochConstantTransportMixtureBuilderTest );
+
+    CPPUNIT_TEST( test_build_cea_constcond_mix );
+    CPPUNIT_TEST( test_build_cea_constpr_mix );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+
+    void setUp()
+    {
+      std::string input_file = std::string(GRINS_TEST_SRCDIR)+"/input_files/antioch.in";
+      _input.reset( new GetPot(input_file) );
+    }
+
+    void test_build_cea_constcond_mix()
+    {
+      GRINS::AntiochConstantTransportMixtureBuilder builder;
+
+      libMesh::UniquePtr<GRINS::AntiochConstantTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+                                                                GRINS::ConstantConductivity> >
+        mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,GRINS::ConstantConductivity>
+        (*_input, "TestMaterial");
+
+      libMesh::Real mu = mixture->mu();
+      libMesh::Real k = (mixture->conductivity())();
+
+      libMesh::Real rho = 1.2;
+      libMesh::Real cp = 2.3;
+
+      libMesh::Real Le = 1.4;
+
+      libMesh::Real D = mixture->diffusivity().D(rho,cp,k);
+
+      libMesh::Real D_exact = k/rho/cp/Le;
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( 3.14, mu, std::numeric_limits<libMesh::Real>::epsilon() );
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( 2.71, k, std::numeric_limits<libMesh::Real>::epsilon() );
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( D_exact, D, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+    void test_build_cea_constpr_mix()
+    {
+      GRINS::AntiochConstantTransportMixtureBuilder builder;
+
+      libMesh::UniquePtr<GRINS::AntiochConstantTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+                                                                GRINS::ConstantPrandtlConductivity> >
+        mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,GRINS::ConstantPrandtlConductivity>
+        (*_input, "TestMaterial");
+
+      libMesh::Real mu = mixture->mu();
+      libMesh::Real cp = 2.3;
+      libMesh::Real Pr = 0.7;
+      libMesh::Real k = (mixture->conductivity())(mu, cp);
+      libMesh::Real k_exact = mu*cp/Pr;
+
+      libMesh::Real rho = 1.2;
+
+      libMesh::Real Le = 1.4;
+
+      libMesh::Real D = mixture->diffusivity().D(rho,cp,k);
+
+      libMesh::Real D_exact = k/rho/cp/Le;
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( 3.14, mu, std::numeric_limits<libMesh::Real>::epsilon() );
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( k_exact, k, std::numeric_limits<libMesh::Real>::epsilon() );
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( D_exact, D, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+  private:
+
+    libMesh::UniquePtr<GetPot> _input;
+  };
+
   CPPUNIT_TEST_SUITE_REGISTRATION( AntiochMixtureBuilderBaseTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( AntiochConstantTransportMixtureBuilderTest );
 
 } // end namespace GRINSTesting
 

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -49,6 +49,8 @@ namespace GRINSTesting
     CPPUNIT_TEST( test_build_constant_conductivity );
     CPPUNIT_TEST( test_build_constant_prandtl_conductivity );
     CPPUNIT_TEST( test_build_constant_lewis_diff );
+    CPPUNIT_TEST( test_parse_min_T );
+    CPPUNIT_TEST( test_parse_clip_negative_rho );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -161,6 +163,26 @@ namespace GRINSTesting
       libMesh::Real D_exact = k/rho/cp/Le;
 
       CPPUNIT_ASSERT_DOUBLES_EQUAL( D_exact, D, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+    void test_parse_min_T()
+    {
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      libMesh::Real min_T_exact = 114.15;
+      libMesh::Real min_T = builder.parse_min_T( *_input, "TestMaterial" );
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( min_T_exact, min_T, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+    void test_parse_clip_negative_rho()
+    {
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      bool clip_negative_rho_exact = true;
+      bool clip_negative_rho = builder.parse_clip_negative_rho( *_input, "TestMaterial" );
+
+      CPPUNIT_ASSERT_EQUAL( clip_negative_rho_exact, clip_negative_rho );
     }
 
   private:

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -46,10 +46,6 @@ namespace GRINSTesting
     CPPUNIT_TEST( test_build_chem_mix );
     CPPUNIT_TEST( test_build_reaction_set );
     CPPUNIT_TEST( test_build_nasa_thermo_mix_cea );
-    CPPUNIT_TEST( test_build_constant_viscosity );
-    CPPUNIT_TEST( test_build_constant_conductivity );
-    CPPUNIT_TEST( test_build_constant_prandtl_conductivity );
-    CPPUNIT_TEST( test_build_constant_lewis_diff );
     CPPUNIT_TEST( test_parse_min_T );
     CPPUNIT_TEST( test_parse_clip_negative_rho );
 
@@ -107,65 +103,6 @@ namespace GRINSTesting
       CPPUNIT_ASSERT(nasa_mix->check());
     }
 
-    void test_build_constant_viscosity()
-    {
-      GRINS::AntiochMixtureBuilderBase builder;
-
-      libMesh::UniquePtr<GRINS::ConstantViscosity> visc =
-        builder.build_constant_viscosity( *_input, "TestMaterial" );
-
-      libMesh::Real mu = (*visc)();
-
-      CPPUNIT_ASSERT_DOUBLES_EQUAL( 3.14, mu, std::numeric_limits<libMesh::Real>::epsilon() );
-    }
-
-    void test_build_constant_conductivity()
-    {
-      GRINS::AntiochMixtureBuilderBase builder;
-
-      libMesh::UniquePtr<GRINS::ConstantConductivity> conductivity =
-        builder.build_constant_conductivity<GRINS::ConstantConductivity>( *_input, "TestMaterial" );
-
-      libMesh::Real k = (*conductivity)();
-
-      CPPUNIT_ASSERT_DOUBLES_EQUAL( 2.71, k, std::numeric_limits<libMesh::Real>::epsilon() );
-    }
-
-    void test_build_constant_prandtl_conductivity()
-    {
-      GRINS::AntiochMixtureBuilderBase builder;
-
-      libMesh::UniquePtr<GRINS::ConstantPrandtlConductivity> conductivity =
-        builder.build_constant_conductivity<GRINS::ConstantPrandtlConductivity>( *_input, "TestMaterial" );
-
-      libMesh::Real mu = 1.2;
-      libMesh::Real cp = 2.3;
-      libMesh::Real Pr = 0.7;
-      libMesh::Real k = (*conductivity)( mu, cp );
-      libMesh::Real k_exact = mu*cp/Pr;
-
-      CPPUNIT_ASSERT_DOUBLES_EQUAL( k_exact, k, std::numeric_limits<libMesh::Real>::epsilon() );
-    }
-
-    void test_build_constant_lewis_diff()
-    {
-      GRINS::AntiochMixtureBuilderBase builder;
-
-      libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > diff =
-        builder.build_constant_lewis_diff( *_input, "TestMaterial" );
-
-      libMesh::Real rho = 1.2;
-      libMesh::Real cp = 2.3;
-      libMesh::Real k = 3.4;
-      libMesh::Real Le = 1.4;
-
-      libMesh::Real D = diff->D(rho,cp,k);
-
-      libMesh::Real D_exact = k/rho/cp/Le;
-
-      CPPUNIT_ASSERT_DOUBLES_EQUAL( D_exact, D, std::numeric_limits<libMesh::Real>::epsilon() );
-    }
-
     void test_parse_min_T()
     {
       GRINS::AntiochMixtureBuilderBase builder;
@@ -192,12 +129,15 @@ namespace GRINSTesting
   };
 
 
-
   class AntiochConstantTransportMixtureBuilderTest : public CppUnit::TestCase
   {
   public:
     CPPUNIT_TEST_SUITE( AntiochConstantTransportMixtureBuilderTest );
 
+    CPPUNIT_TEST( test_build_constant_viscosity );
+    CPPUNIT_TEST( test_build_constant_conductivity );
+    CPPUNIT_TEST( test_build_constant_prandtl_conductivity );
+    CPPUNIT_TEST( test_build_constant_lewis_diff );
     CPPUNIT_TEST( test_build_cea_constcond_mix );
     CPPUNIT_TEST( test_build_cea_constpr_mix );
 
@@ -209,6 +149,65 @@ namespace GRINSTesting
     {
       std::string input_file = std::string(GRINS_TEST_SRCDIR)+"/input_files/antioch.in";
       _input.reset( new GetPot(input_file) );
+    }
+
+    void test_build_constant_viscosity()
+    {
+      GRINS::AntiochConstantTransportMixtureBuilder builder;
+
+      libMesh::UniquePtr<GRINS::ConstantViscosity> visc =
+        builder.build_constant_viscosity( *_input, "TestMaterial" );
+
+      libMesh::Real mu = (*visc)();
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( 3.14, mu, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+    void test_build_constant_conductivity()
+    {
+      GRINS::AntiochConstantTransportMixtureBuilder builder;
+
+      libMesh::UniquePtr<GRINS::ConstantConductivity> conductivity =
+        builder.build_constant_conductivity<GRINS::ConstantConductivity>( *_input, "TestMaterial" );
+
+      libMesh::Real k = (*conductivity)();
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( 2.71, k, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+    void test_build_constant_prandtl_conductivity()
+    {
+      GRINS::AntiochConstantTransportMixtureBuilder builder;
+
+      libMesh::UniquePtr<GRINS::ConstantPrandtlConductivity> conductivity =
+        builder.build_constant_conductivity<GRINS::ConstantPrandtlConductivity>( *_input, "TestMaterial" );
+
+      libMesh::Real mu = 1.2;
+      libMesh::Real cp = 2.3;
+      libMesh::Real Pr = 0.7;
+      libMesh::Real k = (*conductivity)( mu, cp );
+      libMesh::Real k_exact = mu*cp/Pr;
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( k_exact, k, std::numeric_limits<libMesh::Real>::epsilon() );
+    }
+
+    void test_build_constant_lewis_diff()
+    {
+      GRINS::AntiochConstantTransportMixtureBuilder builder;
+
+      libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > diff =
+        builder.build_constant_lewis_diff( *_input, "TestMaterial" );
+
+      libMesh::Real rho = 1.2;
+      libMesh::Real cp = 2.3;
+      libMesh::Real k = 3.4;
+      libMesh::Real Le = 1.4;
+
+      libMesh::Real D = diff->D(rho,cp,k);
+
+      libMesh::Real D_exact = k/rho/cp/Le;
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL( D_exact, D, std::numeric_limits<libMesh::Real>::epsilon() );
     }
 
     void test_build_cea_constcond_mix()

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -35,6 +35,7 @@
 //GRINS
 #include "grins/antioch_mixture_builder_base.h"
 #include "grins/antioch_constant_transport_mixture_builder.h"
+#include "grins/antioch_mixture_averaged_transport_mixture_builder.h"
 
 namespace GRINSTesting
 {
@@ -269,8 +270,96 @@ namespace GRINSTesting
     libMesh::UniquePtr<GetPot> _input;
   };
 
+
+
+
+  class AntiochMixtureAveragedTransportMixtureBuilderTest : public CppUnit::TestCase
+  {
+  public:
+    CPPUNIT_TEST_SUITE( AntiochMixtureAveragedTransportMixtureBuilderTest );
+
+    CPPUNIT_TEST( test_build_cea_sutherland_eucken_constlewis_mix );
+    CPPUNIT_TEST( test_build_cea_statmech_sutherland_eucken_constlewis_mix );
+
+#ifdef ANTIOCH_HAVE_GSL
+    CPPUNIT_TEST( test_build_cea_kinetic_theory_mix );
+#endif // ANTIOCH_HAVE_GSL
+
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+
+    void setUp()
+    {
+      std::string input_file = std::string(GRINS_TEST_SRCDIR)+"/input_files/antioch.in";
+      _input.reset( new GetPot(input_file) );
+    }
+
+    void test_build_cea_sutherland_eucken_constlewis_mix()
+    {
+      GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
+
+      libMesh::UniquePtr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+                                                                       Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
+                                                                       Antioch::SutherlandViscosity<libMesh::Real>,
+                                                                       Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> > ,
+                                                                       Antioch::ConstantLewisDiffusivity<libMesh::Real> > >
+          mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,
+                                          Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
+                                          Antioch::SutherlandViscosity<libMesh::Real>,
+                                          Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> >,
+                                          Antioch::ConstantLewisDiffusivity<libMesh::Real> >( *_input, "TestMaterial" );
+
+      CPPUNIT_ASSERT(mixture);
+    }
+
+    void test_build_cea_statmech_sutherland_eucken_constlewis_mix()
+    {
+      GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
+
+      libMesh::UniquePtr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+                                                                       Antioch::StatMechThermodynamics<libMesh::Real>,
+                                                                       Antioch::SutherlandViscosity<libMesh::Real>,
+                                                                       Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >,
+                                                                       Antioch::ConstantLewisDiffusivity<libMesh::Real> > >
+          mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,
+                                          Antioch::StatMechThermodynamics<libMesh::Real>,
+                                          Antioch::SutherlandViscosity<libMesh::Real>,
+                                          Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >,
+                                          Antioch::ConstantLewisDiffusivity<libMesh::Real> >( *_input, "TestMaterial" );
+
+      CPPUNIT_ASSERT(mixture);
+    }
+
+#ifdef ANTIOCH_HAVE_GSL
+    void test_build_cea_kinetic_theory_mix()
+    {
+      GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
+
+      libMesh::UniquePtr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+                                                                       Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
+                                                                       Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,
+                                                                       Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,libMesh::Real>,
+                                                                       Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >
+          mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,
+                                          Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
+                                          Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,
+                                          Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,libMesh::Real>,
+                                          Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> >( *_input, "TestMaterial" );
+
+      CPPUNIT_ASSERT(mixture);
+    }
+#endif // ANTIOCH_HAVE_GSL
+
+  private:
+
+    libMesh::UniquePtr<GetPot> _input;
+  };
+
+
   CPPUNIT_TEST_SUITE_REGISTRATION( AntiochMixtureBuilderBaseTest );
   CPPUNIT_TEST_SUITE_REGISTRATION( AntiochConstantTransportMixtureBuilderTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( AntiochMixtureAveragedTransportMixtureBuilderTest );
 
 } // end namespace GRINSTesting
 

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -1,0 +1,83 @@
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+#ifdef GRINS_HAVE_ANTIOCH
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+// Testing
+#include "grins_test_paths.h"
+
+//GRINS
+#include "grins/antioch_mixture_builder_base.h"
+
+namespace GRINSTesting
+{
+  class AntiochMixtureBuilderBaseTest : public CppUnit::TestCase
+  {
+  public:
+    CPPUNIT_TEST_SUITE( AntiochMixtureBuilderBaseTest );
+
+    CPPUNIT_TEST( test_build_chem_mix );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+
+    void setUp()
+    {
+      std::string input_file = std::string(GRINS_TEST_SRCDIR)+"/input_files/antioch.in";
+      _input.reset( new GetPot(input_file) );
+    }
+
+    void test_build_chem_mix()
+    {
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix
+        = builder.build_chem_mix(*_input, "TestMaterial");
+
+      // Just a couple of basic tests for the parsed ChemicalMixture
+      CPPUNIT_ASSERT_EQUAL( 5, (int)chem_mix->n_species() );
+
+      const std::vector<Antioch::ChemicalSpecies<libMesh::Real>*> & all_species =
+        chem_mix->chemical_species();
+
+      CPPUNIT_ASSERT_EQUAL( 5, (int)all_species.size() );
+    }
+
+  private:
+
+    libMesh::UniquePtr<GetPot> _input;
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( AntiochMixtureBuilderBaseTest );
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_ANTIOCH
+#endif // GRINS_HAVE_CPPUNIT

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -43,6 +43,7 @@ namespace GRINSTesting
     CPPUNIT_TEST_SUITE( AntiochMixtureBuilderBaseTest );
 
     CPPUNIT_TEST( test_build_chem_mix );
+    CPPUNIT_TEST( test_build_reaction_set );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -68,6 +69,20 @@ namespace GRINSTesting
         chem_mix->chemical_species();
 
       CPPUNIT_ASSERT_EQUAL( 5, (int)all_species.size() );
+    }
+
+    void test_build_reaction_set()
+    {
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix
+        = builder.build_chem_mix(*_input, "TestMaterial");
+
+      libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > reaction_set
+        = builder.build_reaction_set(*_input, "TestMaterial", *chem_mix);
+
+      CPPUNIT_ASSERT_EQUAL( 5, (int)reaction_set->n_species() );
+      CPPUNIT_ASSERT_EQUAL( 5, (int)reaction_set->n_reactions() );
     }
 
   private:

--- a/test/interface/antioch_test_base.h
+++ b/test/interface/antioch_test_base.h
@@ -35,6 +35,7 @@
 // libMesh
 #include "libmesh/libmesh_common.h"
 #include "libmesh/getpot.h"
+#include "grins/antioch_mixture_builder_base.h"
 
 namespace GRINSTesting
 {
@@ -46,7 +47,10 @@ namespace GRINSTesting
     {
       GetPot input(input_file);
 
-      _antioch_mixture.reset( new GRINS::AntiochMixture<Antioch::CEACurveFit<libMesh::Real> >(input,material_name) );
+      GRINS::AntiochMixtureBuilderBase builder;
+
+      this->_antioch_mixture =
+        builder.build_antioch_mixture<Antioch::CEACurveFit<libMesh::Real> >(input,material_name);
     }
 
   protected:

--- a/test/unit/antioch_mixture.C
+++ b/test/unit/antioch_mixture.C
@@ -34,6 +34,7 @@
 #include "grins/antioch_mixture.h"
 #include "grins/materials_parsing.h"
 #include "grins/physics_naming.h"
+#include "grins/antioch_mixture_builder_base.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -55,7 +56,11 @@ int main( int argc, char* argv[] )
 
   GetPot input( argv[1] );
 
-  GRINS::AntiochMixture<Antioch::CEACurveFit<libMesh::Real> > antioch(input,"TestMaterial");
+  GRINS::AntiochMixtureBuilderBase builder;
+  libMesh::UniquePtr<GRINS::AntiochMixture<Antioch::CEACurveFit<libMesh::Real> > >
+    antioch_ptr = builder.build_antioch_mixture<Antioch::CEACurveFit<libMesh::Real> >(input,"TestMaterial");
+
+  const GRINS::AntiochMixture<Antioch::CEACurveFit<libMesh::Real> > & antioch = *antioch_ptr;
 
   std::vector<double> mass_fractions( 5, 0.2 );
 

--- a/test/unit/gas_recombination_catalytic_wall.C
+++ b/test/unit/gas_recombination_catalytic_wall.C
@@ -34,6 +34,7 @@
 #include "grins/antioch_chemistry.h"
 #include "grins/materials_parsing.h"
 #include "grins/physics_naming.h"
+#include "grins/chemistry_builder.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -143,11 +144,14 @@ int main(int argc, char* argv[])
 
   int return_flag = 0;
 
+  GRINS::ChemistryBuilder chem_builder;
+
   if( test_type == "cantera" )
     {
 #ifdef GRINS_HAVE_CANTERA
-      GRINS::CanteraMixture chem_mixture( input, "TestMaterial" );
-      return_flag = test<GRINS::CanteraMixture>( chem_mixture );
+      libMesh::UniquePtr<GRINS::CanteraMixture> chem_uptr;
+      chem_builder.build_chemistry(input,"TestMaterial",chem_uptr);
+      return_flag = test<GRINS::CanteraMixture>( *chem_uptr );
 #else
       return_flag = 77;
 #endif
@@ -155,8 +159,9 @@ int main(int argc, char* argv[])
   else if( test_type == "antioch" )
     {
 #ifdef GRINS_HAVE_ANTIOCH
-      GRINS::AntiochChemistry chem_mixture( input, "TestMaterial" );
-      return_flag = test<GRINS::AntiochChemistry>( chem_mixture );
+      libMesh::UniquePtr<GRINS::AntiochChemistry> chem_uptr;
+      chem_builder.build_chemistry(input,"TestMaterial",chem_uptr);
+      return_flag = test<GRINS::AntiochChemistry>( *chem_uptr );
 #else
       return_flag = 77;
 #endif

--- a/test/unit/gas_solid_catalytic_wall.C
+++ b/test/unit/gas_solid_catalytic_wall.C
@@ -34,6 +34,7 @@
 #include "grins/antioch_chemistry.h"
 #include "grins/materials_parsing.h"
 #include "grins/physics_naming.h"
+#include "grins/chemistry_builder.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -202,11 +203,14 @@ int main(int argc, char* argv[])
 
   int return_flag = 0;
 
+  GRINS::ChemistryBuilder chem_builder;
+
   if( test_type == "cantera" )
     {
 #ifdef GRINS_HAVE_CANTERA
-      GRINS::CanteraMixture chem_mixture( input, "CanteraMaterial" );
-      return_flag = test<GRINS::CanteraMixture>( chem_mixture );
+      libMesh::UniquePtr<GRINS::CanteraMixture> chem_uptr;
+      chem_builder.build_chemistry(input,"CanteraMaterial",chem_uptr);
+      return_flag = test<GRINS::CanteraMixture>( *chem_uptr );
 #else
       return_flag = 77;
 #endif
@@ -214,8 +218,9 @@ int main(int argc, char* argv[])
   else if( test_type == "antioch" )
     {
 #ifdef GRINS_HAVE_ANTIOCH
-      GRINS::AntiochChemistry chem_mixture( input, "AntiochMaterial" );
-      return_flag = test<GRINS::AntiochChemistry>( chem_mixture );
+      libMesh::UniquePtr<GRINS::AntiochChemistry> chem_uptr;
+      chem_builder.build_chemistry(input,"AntiochMaterial",chem_uptr);
+      return_flag = test<GRINS::AntiochChemistry>( *chem_uptr );
 #else
       return_flag = 77;
 #endif


### PR DESCRIPTION
This moves the construction of Antioch mixture objects to builder objects to try and better contain the parsing. The new constructors now take unique pointers to the necessary things that the object needs to run; those are constructed in the builder. Also updated tests in the appropriate places to use the new construction objects.

I've left the deprecated constructors in for now, but we'll remove them after the next release. I have a branch where I've removed them to make sure we've cleaned out the deprecated constructor usage internally (I'll open a separate PR for that).