### PR TITLE
Make CatalycityBase derived from ParameterUser

### DIFF
--- a/src/boundary_conditions/include/grins/arrhenius_catalycity.h
+++ b/src/boundary_conditions/include/grins/arrhenius_catalycity.h
@@ -49,6 +49,8 @@ namespace GRINS
       and worry about memory management. */
     virtual CatalycityBase* clone() const;
 
+    virtual void set_parameters(const GetPot & input, const std::string & param_base);
+
   protected:
 
     libMesh::Real _gamma0;

--- a/src/boundary_conditions/include/grins/catalycity_base.h
+++ b/src/boundary_conditions/include/grins/catalycity_base.h
@@ -28,12 +28,15 @@
 // C++
 #include <vector>
 
+// GRINS
+#include "grins/parameter_user.h"
+
 // libMesh
 #include "libmesh/libmesh_common.h"
 
 namespace GRINS
 {
-  class CatalycityBase
+  class CatalycityBase : public ParameterUser
   {
   public:
 
@@ -51,6 +54,9 @@ namespace GRINS
     /*! A raw pointer is returned and it is assumed the user will take ownership
       and worry about memory management. */
     virtual CatalycityBase* clone() const = 0;
+
+    //! Sets parameters for use in sensitivity analysis
+    virtual void set_parameters(const GetPot & input, const std::string & param_base) =0;
 
   };
 

--- a/src/boundary_conditions/include/grins/catalycity_factories.h
+++ b/src/boundary_conditions/include/grins/catalycity_factories.h
@@ -51,13 +51,16 @@ namespace GRINS
     virtual libMesh::UniquePtr<CatalycityBase>
     build_catalycity( const GetPot& input, const std::string& section )
     {
-      std::string gamma_str = section+"/ConstantCatalycity/gamma";
+      std::string param_base = section+"/ConstantCatalycity/";
 
+      std::string gamma_str = param_base+"gamma";
       if( !input.have_variable(gamma_str) )
         libmesh_error_msg("ERROR: Could not find input "+gamma_str+" for ConstantCatalycity!\n");
 
       libMesh::Real gamma = input(gamma_str, std::numeric_limits<libMesh::Real>::max());
-      return libMesh::UniquePtr<CatalycityBase>( new ConstantCatalycity( gamma ) );
+      libMesh::UniquePtr<CatalycityBase> catalycity( new ConstantCatalycity( gamma ) );
+      catalycity->set_parameters(input,param_base);
+      return catalycity;
     }
 
   };
@@ -78,18 +81,22 @@ namespace GRINS
     virtual libMesh::UniquePtr<CatalycityBase>
     build_catalycity( const GetPot& input, const std::string& section )
     {
-      std::string gamma_str = section+"/ArrheniusCatalycity/gamma0";
+      std::string param_base = section+"/ArrheniusCatalycity/";
+
+      std::string gamma_str = param_base+"gamma0";
       if( !input.have_variable(gamma_str) )
         libmesh_error_msg("ERROR: Could not find input "+gamma_str+" for ArrheniusCatalycity!\n");
 
-      std::string Ta_str = section+"/ArrheniusCatalycity/Ta";
+      std::string Ta_str = param_base+"Ta";
       if( !input.have_variable(Ta_str) )
         libmesh_error_msg("ERROR: Could not find input "+Ta_str+" for ArrheniusCatalycity!\n");
 
       libMesh::Real gamma = input(gamma_str, std::numeric_limits<libMesh::Real>::max());
       libMesh::Real Ta = input(Ta_str, std::numeric_limits<libMesh::Real>::max());
 
-      return libMesh::UniquePtr<CatalycityBase>( new ArrheniusCatalycity( gamma, Ta ) );
+      libMesh::UniquePtr<CatalycityBase> catalycity( new ArrheniusCatalycity( gamma, Ta ) );
+      catalycity->set_parameters(input,param_base);
+      return catalycity;
     }
 
   };
@@ -109,15 +116,17 @@ namespace GRINS
     virtual libMesh::UniquePtr<CatalycityBase>
     build_catalycity( const GetPot& input, const std::string& section )
     {
-      std::string gamma_str = section+"/PowerLawCatalycity/gamma0";
+      std::string param_base = section+"/PowerLawCatalycity/";
+
+      std::string gamma_str = param_base+"gamma0";
       if( !input.have_variable(gamma_str) )
         libmesh_error_msg("ERROR: Could not find input "+gamma_str+" for ArrheniusCatalycity!\n");
 
-      std::string Tref_str = section+"/PowerLawCatalycity/Tref";
+      std::string Tref_str = param_base+"Tref";
       if( !input.have_variable(Tref_str) )
         libmesh_error_msg("ERROR: Could not find input "+Tref_str+" for PowerLawCatalycity!\n");
 
-      std::string alpha_str = section+"/PowerLawCatalycity/alpha";
+      std::string alpha_str = param_base+"alpha";
       if( !input.have_variable(alpha_str) )
         libmesh_error_msg("ERROR: Could not find input "+alpha_str+" for PowerLawCatalycity!\n");
 
@@ -125,7 +134,9 @@ namespace GRINS
       libMesh::Real Tref = input(Tref_str, std::numeric_limits<libMesh::Real>::max());
       libMesh::Real alpha = input(alpha_str, std::numeric_limits<libMesh::Real>::max());
 
-      return libMesh::UniquePtr<CatalycityBase>( new PowerLawCatalycity( gamma, Tref, alpha ) );
+      libMesh::UniquePtr<CatalycityBase> catalycity( new PowerLawCatalycity( gamma, Tref, alpha ) );
+      catalycity->set_parameters(input,param_base);
+      return catalycity;
     }
 
   };

--- a/src/boundary_conditions/include/grins/catalytic_wall_base.h
+++ b/src/boundary_conditions/include/grins/catalytic_wall_base.h
@@ -83,6 +83,9 @@ namespace GRINS
     libMesh::Real domega_dot_dT( const libMesh::Real rho_s, const libMesh::Real T ) const;
 
     void set_catalycity_params( const std::vector<libMesh::Real>& params );
+    
+    virtual void register_parameter(  const std::string & param_name,
+                                      libMesh::ParameterMultiAccessor< libMesh::Number > & param_pointer) const;
 
   protected:
 

--- a/src/boundary_conditions/include/grins/constant_catalycity.h
+++ b/src/boundary_conditions/include/grins/constant_catalycity.h
@@ -49,6 +49,8 @@ namespace GRINS
       and worry about memory management. */
     virtual CatalycityBase* clone() const;
 
+    virtual void set_parameters(const GetPot & input, const std::string & param_base);
+
   protected:
 
     libMesh::Real _gamma;

--- a/src/boundary_conditions/include/grins/neumann_bc_abstract.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_abstract.h
@@ -25,6 +25,9 @@
 #ifndef GRINS_NEUMANN_BC_ABSTRACT_H
 #define GRINS_NEUMANN_BC_ABSTRACT_H
 
+// GRINS
+#include "grins/parameter_user.h"
+
 // libMesh
 #include "libmesh/libmesh_common.h"
 #include "libmesh/auto_ptr.h" // libMesh::UniquePtr
@@ -34,11 +37,13 @@ namespace GRINS
   // Forward declarations
   class AssemblyContext;
 
-  class NeumannBCAbstract
+  class NeumannBCAbstract : public ParameterUser
   {
   public:
 
-    NeumannBCAbstract(){}
+    NeumannBCAbstract()
+    : ParameterUser("NeumannBCAbstract")
+    {}
 
     virtual ~NeumannBCAbstract(){};
 

--- a/src/boundary_conditions/include/grins/power_law_catalycity.h
+++ b/src/boundary_conditions/include/grins/power_law_catalycity.h
@@ -49,6 +49,8 @@ namespace GRINS
       and worry about memory management. */
     virtual CatalycityBase* clone() const;
 
+    virtual void set_parameters(const GetPot & input, const std::string & param_base);
+
   protected:
 
     libMesh::Real _gamma0;

--- a/src/boundary_conditions/src/arrhenius_catalycity.C
+++ b/src/boundary_conditions/src/arrhenius_catalycity.C
@@ -69,4 +69,13 @@ namespace GRINS
     return new ArrheniusCatalycity( *this );
   }
 
+  void ArrheniusCatalycity::set_parameters(const GetPot & input, const std::string & param_base)
+  {
+    std::string gamma0_str = param_base+"gamma0";
+    this->set_parameter(_gamma0,input,gamma0_str,_gamma0);
+
+    std::string Ta_str = param_base+"Ta";
+    this->set_parameter(_Ta,input,Ta_str,_Ta);
+  }
+
 } // end namespace GRINS

--- a/src/boundary_conditions/src/catalycity_base.C
+++ b/src/boundary_conditions/src/catalycity_base.C
@@ -29,6 +29,7 @@
 namespace GRINS
 {
   CatalycityBase::CatalycityBase()
+  : ParameterUser("CatalycityBase")
   {
     return;
   }

--- a/src/boundary_conditions/src/catalytic_wall_base.C
+++ b/src/boundary_conditions/src/catalytic_wall_base.C
@@ -74,4 +74,10 @@ namespace GRINS
       libmesh_error();
   }
 
+  template<typename Chemistry>
+  void CatalyticWallBase<Chemistry>::register_parameter(const std::string & param_name,
+                                                        libMesh::ParameterMultiAccessor< libMesh::Number > & param_pointer) const
+  {
+    _gamma_ptr->register_parameter(param_name,param_pointer);
+  }
 } // end namespace GRINS

--- a/src/boundary_conditions/src/constant_catalycity.C
+++ b/src/boundary_conditions/src/constant_catalycity.C
@@ -62,4 +62,10 @@ namespace GRINS
     return new ConstantCatalycity( *this );
   }
 
+  void ConstantCatalycity::set_parameters(const GetPot & input, const std::string & param_base)
+  {
+    std::string gamma_str = param_base+"gamma";
+    this->set_parameter(_gamma,input,gamma_str,_gamma);
+  }
+
 } // end namespace GRINS

--- a/src/boundary_conditions/src/power_law_catalycity.C
+++ b/src/boundary_conditions/src/power_law_catalycity.C
@@ -73,4 +73,16 @@ namespace GRINS
     return new PowerLawCatalycity( *this );
   }
 
+  void PowerLawCatalycity::set_parameters(const GetPot & input, const std::string & param_base)
+  {
+    std::string gamma0_str = param_base+"gamma0";
+    this->set_parameter(_gamma0,input,gamma0_str,_gamma0);
+
+    std::string Tref_str = param_base+"Tref";
+    this->set_parameter(_Tref,input,Tref_str,_Tref);
+
+    std::string alpha_str = param_base+"alpha";
+    this->set_parameter(_alpha,input,alpha_str,_alpha);
+  }
+
 } // end namespace GRINS

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -244,6 +244,9 @@ namespace GRINS
         (physics_iter->second)->register_parameter( param_name,
                                                     param_pointer );
       }
+
+    for (unsigned int bc=0; bc<_neumann_bcs.size(); bc++)
+      _neumann_bcs[bc]->get_func()->register_parameter(param_name, param_pointer);
   }
 
 

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in
@@ -191,3 +191,8 @@ solver_quiet = false
 print_element_jacobians = 'false'
 
 []
+
+[QoI]
+  forward_sensitivity_parameters = 'BoundaryConditions/Top/MassFracs/ArrheniusCatalycity/gamma0
+                                    BoundaryConditions/Top/MassFracs/ArrheniusCatalycity/Ta'
+[]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_catalytic_wall_regression.in
@@ -178,3 +178,7 @@ solver_quiet = false
 print_element_jacobians = 'false'
 
 []
+
+[QoI]
+  forward_sensitivity_parameters = 'BoundaryConditions/Top/SpeciesMassFractions/ConstantCatalycity/gamma'
+[]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_gassolid_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_constant_gassolid_catalytic_wall_regression.in
@@ -196,3 +196,7 @@ solver_quiet = false
 print_element_jacobians = 'false'
 
 []
+
+[QoI]
+  forward_sensitivity_parameters = 'BoundaryConditions/Top/MassFracs/ConstantCatalycity/gamma'
+[]

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in
@@ -181,3 +181,9 @@ solver_quiet = false
 print_element_jacobians = 'false'
 
 []
+
+[QoI]
+  forward_sensitivity_parameters = 'BoundaryConditions/Top/SpeciesMassFractions/PowerLawCatalycity/gamma0
+                                    BoundaryConditions/Top/SpeciesMassFractions/PowerLawCatalycity/Tref
+                                    BoundaryConditions/Top/SpeciesMassFractions/PowerLawCatalycity/alpha'
+[]


### PR DESCRIPTION
Makes `CatalycityBase` a subclass of `ParameterUser` to allow for adding catalycity parameters for sensitivity analysis.

Requires updating `MultiphysicsSystem::register_parameter()` to search the `NeumannBC`s for the params as well, and making `NeumannBCAbstract` a subclass of `ParameterUser` as well