### PR TITLE
RayfireMesh::init() fixes for restart

### DIFF
--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -175,7 +175,7 @@ namespace GRINS
     bool check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, const libMesh::Elem& edge_elem, libMesh::Point& next_point);
 
     //! Knowing the end_point, get the appropraite next elem along the path
-    const libMesh::Elem* get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side, bool same_parent);
+    const libMesh::Elem* get_correct_neighbor(libMesh::Point & start_point, libMesh::Point & end_point, const libMesh::Elem * cur_elem, unsigned int side, bool same_parent);
 
     //! Ensure the supplied origin is on a boundary of the mesh
     void check_origin_on_boundary(const libMesh::Elem* start_elem);
@@ -186,6 +186,9 @@ namespace GRINS
       @return Elem* First elem on the rayfire
     */
     const libMesh::Elem* get_start_elem(const libMesh::MeshBase& mesh_base);
+
+    //! Ensures the rayfire doesn't wander into the middle of an elem
+    bool validate_edge(const libMesh::Point & start_point, const libMesh::Point & end_point, const libMesh::Elem * side_elem, const libMesh::Elem * neighbor);
 
     //! Walks a short distance along the rayfire and checks if elem contains that point
     bool rayfire_in_elem(const libMesh::Point& end_point, const libMesh::Elem* elem);


### PR DESCRIPTION
Issues arose when calling `RafireMesh::init()` on an already refined mesh from a restart file.

The first case was that `INACTIVE` elements were being added to the rayfire. `Elem::neighbor_ptr()` gives the neighbor that is on the same refinement level as the current elem, whether or not that neighbor is `ACTIVE`. Instead, we have to check that the neighbor is active, and if it isn't, we check it's children to try and find the next elem for the rayfire. We also add asserts to try and catch these inactive elements.

The second case is not easily reproduced because it relies on the numbering of elem sides and edges as well as the coordinate values. If a refined elem shares its bottom edge with an unrefined elem and the rayfire traverses along that edge, then the rayfire may wander into the middle of the lower elem and get confused.  This happens with `QUAD9` elements when the intersection point is the middle node of the bottom edge. We add a check which says that if the rayfire `start_` and `intersection_point` are both on an edge, then they must be the end nodes (0 & 1) of that edge elem, and not the middle node if it is an `EDGE3`.  Sorry if this isn't clear, it's much easier to draw out. When I wrote this fix, I was unable to create a unit test that captures this behavior. But I can try again if you think it's necessary.