### PR TITLE
AbsorptionCoeff derivatives

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -497,6 +497,7 @@ include_HEADERS += qoi/include/grins/qoi_options.h
 include_HEADERS += qoi/include/grins/hitran.h
 include_HEADERS += qoi/include/grins/absorption_coeff.h
 include_HEADERS += qoi/include/grins/spectroscopic_absorption.h
+include_HEADERS += qoi/include/grins/fem_function_and_derivative_base.h
 
 # src/solver headers
 include_HEADERS += solver/include/grins/solver.h

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -26,15 +26,13 @@
 #ifndef GRINS_ABSORPTION_COEFF_H
 #define GRINS_ABSORPTION_COEFF_H
 
-// libMesh
-#include "libmesh/fem_function_base.h"
-
 // GRINS
 #include "grins/assembly_context.h"
 #include "grins/hitran.h"
 #include "grins/single_variable.h"
 #include "grins/multicomponent_variable.h"
 #include "grins/variable_warehouse.h"
+#include "grins/fem_function_and_derivative_base.h"
 
 namespace GRINS
 {
@@ -58,7 +56,7 @@ namespace GRINS
     A chemistry library (Antioch or Cantera) is also required.
   */
   template<typename Chemistry>
-  class AbsorptionCoeff : public libMesh::FEMFunctionBase<libMesh::Real>
+  class AbsorptionCoeff : public FEMFunctionAndDerivativeBase<libMesh::Real>
   {
   public:
 
@@ -78,6 +76,13 @@ namespace GRINS
 
     //! Calculate the absorption coefficient at a quadratue point
     virtual libMesh::Real operator()(const libMesh::FEMContext & context, const libMesh::Point & qp_xyz, const libMesh::Real t);
+
+    //! Calculate the derivatives with respect to Temperature, Pressure, and Species Mass Fraction
+    virtual void derivatives( libMesh::FEMContext & context,
+                              const libMesh::Point & p,
+                              const libMesh::Real & JxW,
+                              const unsigned int qoi_index,
+                              const libMesh::Real time = 0.);
 
     //! Not used
     virtual void operator()( const libMesh::FEMContext & context,

--- a/src/qoi/include/grins/composite_qoi.h
+++ b/src/qoi/include/grins/composite_qoi.h
@@ -123,6 +123,9 @@ namespace GRINS
                               const std::vector<libMesh::Number>& other_qoi,
                               const libMesh::QoISet& qoi_indices );
 
+    // Calls each QoI's finalize_derivative function
+    virtual void finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t qoi_index);
+
     //! Basic output for computed QoI's.
     void output_qoi( std::ostream& out ) const;
 

--- a/src/qoi/include/grins/fem_function_and_derivative_base.h
+++ b/src/qoi/include/grins/fem_function_and_derivative_base.h
@@ -1,0 +1,54 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_FEM_FUNCTION_AND_DERIVATIVE_BASE_H
+#define GRINS_FEM_FUNCTION_AND_DERIVATIVE_BASE_H
+
+// libMesh
+#include "libmesh/fem_function_base.h"
+
+// GRINS
+
+namespace GRINS
+{
+  /*!
+    Extends libMesh::FEMFunctionBase by adding a function for computing derivatives
+  */
+  template<typename Output>
+  class FEMFunctionAndDerivativeBase : public libMesh::FEMFunctionBase<Output>
+  {
+  public:
+
+    //! Function Derivative Evaluation
+    virtual void derivatives( libMesh::FEMContext & context,
+                              const libMesh::Point & p,
+                              const libMesh::Real & JxW,
+                              const unsigned int qoi_index,
+                              const libMesh::Real time = 0.) = 0;
+
+  };
+
+}
+#endif //GRINS_FEM_FUNCTION_AND_DERIVATIVE_BASE_H

--- a/src/qoi/include/grins/hitran.h
+++ b/src/qoi/include/grins/hitran.h
@@ -100,6 +100,9 @@ namespace GRINS
     //! Return the data size
     unsigned int get_data_size();
 
+    //! Finite difference derivative for partition function
+    libMesh::Real partition_function_derivative(libMesh::Real T, unsigned int iso);
+
   protected:
     libMesh::Real _Tmin, _Tmax, _Tstep;
 

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -29,12 +29,12 @@
 // libMesh
 #include "libmesh/quadrature.h"
 #include "libmesh/exact_solution.h"
-#include "libmesh/fem_function_base.h"
 
 // GRINS
 #include "grins/qoi_base.h"
 #include "grins/variable_name_defaults.h"
 #include "grins/rayfire_mesh.h"
+#include "grins/fem_function_and_derivative_base.h"
 
 namespace GRINS
 {

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -117,6 +117,11 @@ namespace GRINS
     //! Compute the value of a QoI at a QP
     libMesh::Real qoi_value(Function& f,AssemblyContext& context,const libMesh::Point& xyz);
 
+    //! Compute derivatiuves at QP
+    void qoi_derivative( Function & f, AssemblyContext & context,
+                         const libMesh::Point & qp_xyz, const libMesh::Real JxW,
+                         const unsigned int qoi_index);
+
     //! User cannot call empty constructor
     IntegratedFunction();
 

--- a/src/qoi/include/grins/qoi_base.h
+++ b/src/qoi/include/grins/qoi_base.h
@@ -114,6 +114,10 @@ namespace GRINS
      */
     virtual void thread_join( libMesh::Number& qoi, const libMesh::Number& other_qoi );
 
+    //! Finalize derivatives that require more than a simple sum.
+    //! Does nothing by default.
+    virtual void finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives);
+
     /*!
      * Basic output for computed QoI's. If fancier output is desired, override this method.
      */

--- a/src/qoi/include/grins/spectroscopic_absorption.h
+++ b/src/qoi/include/grins/spectroscopic_absorption.h
@@ -61,6 +61,9 @@ namespace GRINS
                               libMesh::Number & sys_qoi,
                               libMesh::Number & local_qoi );
 
+    //! Override DifferentiableQoI's empty implementation to add chain rule (QoI is exponential)
+    virtual void finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives);
+
   private:
 
     SpectroscopicAbsorption();

--- a/src/qoi/include/grins/spectroscopic_absorption.h
+++ b/src/qoi/include/grins/spectroscopic_absorption.h
@@ -45,14 +45,14 @@ namespace GRINS
 
     Expects all parameters given in standard SI units [m], [K], [Pa]
   */
-  class SpectroscopicAbsorption : public IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >
+  class SpectroscopicAbsorption : public IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >
   {
   public:
 
     /*!
       @param absorb AbsorptionCoeff object
     */
-    SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb);
+    SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb);
 
     virtual QoIBase * clone() const;
 

--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -147,6 +147,17 @@ namespace GRINS
   }
 
   template<typename Chemistry>
+  void AbsorptionCoeff<Chemistry>::derivatives( libMesh::FEMContext & /*context*/,
+                                                const libMesh::Point & /*p*/,
+                                                const libMesh::Real & /*JxW*/,
+                                                const unsigned int /*qoi_index*/,
+                                                const libMesh::Real /*time*/)
+  {
+    // TODO
+    libmesh_not_implemented();
+  }
+
+  template<typename Chemistry>
   void AbsorptionCoeff<Chemistry>::operator()( const libMesh::FEMContext& /*context*/,
                                                const libMesh::Point& /*p*/,
                                                const libMesh::Real /*time*/,

--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -25,6 +25,8 @@
 
 // This class
 #include "grins/absorption_coeff.h"
+
+// GRINS
 #include "grins/variable_warehouse.h"
 #include "grins/physical_constants.h"
 #include "grins/math_constants.h"
@@ -36,6 +38,10 @@
 #if GRINS_HAVE_CANTERA
 #include "grins/cantera_mixture.h"
 #endif
+
+// libMesh
+#include "libmesh/fe.h"
+#include "libmesh/elem.h"
 
 namespace GRINS
 {
@@ -116,6 +122,68 @@ namespace GRINS
   template<typename Chemistry>
   libMesh::Real AbsorptionCoeff<Chemistry>::operator()(const libMesh::FEMContext& context, const libMesh::Point& qp_xyz, const libMesh::Real /*t*/)
   {
+    START_LOG("operator()","AbsorptionCoeff");
+    libMesh::Real T,p,thermo_p; // temperature, hydrostatic pressure, thermodynamic pressure
+    std::vector<libMesh::Real> Y(_chemistry->n_species()); // mass fractions
+    
+    for (unsigned int s=0; s<_chemistry->n_species(); s++)
+      context.point_value(_Y_var.species(s), qp_xyz, Y[s]);
+
+    context.point_value(_T_var.T(), qp_xyz, T); // [K]
+
+    if (_calc_thermo_pressure) {
+      libmesh_not_implemented();
+    } else {
+      thermo_p = _thermo_pressure;
+    }
+
+    context.point_value(_P_var.p(), qp_xyz, p); // [Pa]
+
+    libMesh::Real P = p + thermo_p; // total pressure [Pa]
+    libmesh_assert_greater(P,0.0);
+
+//    P /= 101325.0; // convert to [atm]
+
+    libMesh::Real kv = 0.0;
+
+    for (unsigned int i=_min_index; i<=_max_index; i++)
+      kv += this->kv(T,P,Y,i);
+
+    STOP_LOG("operator()","AbsorptionCoeff");
+    return kv;
+  }
+
+  template<typename Chemistry>
+  void AbsorptionCoeff<Chemistry>::derivatives( libMesh::FEMContext & context,
+                                                const libMesh::Point & qp_xyz,
+                                                const libMesh::Real & JxW,
+                                                const unsigned int qoi_index,
+                                                const libMesh::Real /*time*/)
+  {
+    START_LOG("derivatives()","AbsorptionCoeff");
+    std::vector<libMesh::Point> qp(1);
+    qp[0] = qp_xyz;
+
+    libMesh::DenseSubVector<libMesh::Number> & dT = context.get_qoi_derivatives(qoi_index, _T_var.T());
+    libMesh::DenseSubVector<libMesh::Number> & dP = context.get_qoi_derivatives(qoi_index, _P_var.p());
+    libMesh::DenseSubVector<libMesh::Number> & dY = context.get_qoi_derivatives(qoi_index, _Y_var.species(_species_idx));
+
+
+    libMesh::UniquePtr< libMesh::FEBase > T_fe = libMesh::FEBase::build(context.get_elem().dim(), context.get_element_fe(_T_var.T())->get_fe_type() );
+    T_fe->get_phi();
+    T_fe->reinit(&(context.get_elem()),&qp);
+    const std::vector<std::vector<libMesh::Real> > & T_phi = T_fe->get_phi();
+
+    libMesh::UniquePtr< libMesh::FEBase > P_fe = libMesh::FEBase::build(context.get_elem().dim(), context.get_element_fe(_P_var.p())->get_fe_type() );
+    P_fe->get_phi();
+    P_fe->reinit(&(context.get_elem()),&qp);
+    const std::vector<std::vector<libMesh::Real> > & P_phi = P_fe->get_phi();
+ 
+    libMesh::UniquePtr< libMesh::FEBase > Y_fe = libMesh::FEBase::build(context.get_elem().dim(), context.get_element_fe(_Y_var.species(_species_idx))->get_fe_type() );
+    Y_fe->get_phi();
+    Y_fe->reinit(&(context.get_elem()),&qp);
+    const std::vector<std::vector<libMesh::Real> > & Y_phi = Y_fe->get_phi();
+
     libMesh::Real T,p,thermo_p; // temperature, hydrostatic pressure, thermodynamic pressure
     std::vector<libMesh::Real> Y(_chemistry->n_species()); // mass fractions
 
@@ -136,32 +204,32 @@ namespace GRINS
     for (unsigned int s=0; s<_chemistry->n_species(); s++)
       context.point_value(_Y_var.species(s), qp_xyz, Y[s]);
 
-    libMesh::Real M = _chemistry->M(_species_idx); // [kg/mol]
-    libMesh::Real M_mix = _chemistry->M_mix(Y); // [kg/mol]
-    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+//    P /= 101325.0; // convert to [atm]
 
-    P /= 101325.0; // convert to [atm]
+    for (unsigned int i=_min_index; i<=_max_index; i++)
+      {
+        // no velocity dependence
 
-    return this->kv(P,T,X,M);
+        // temperature deriv
+        for (unsigned int j=0; j<dT.size(); j++)
+          dT(j) += d_kv_dT(T,P,Y,i)*JxW * T_phi[j][0];
 
+        // pressure deriv
+        for (unsigned int j=0; j<dP.size(); j++)
+          dP(j) += d_kv_dP(T,P,Y,i)*JxW * P_phi[j][0];
+
+        // mass fraction deriv
+        for (unsigned int j=0; j<dY.size(); j++)
+          dY(j) += d_kv_dY(T,P,Y,i)*JxW * Y_phi[j][0];
+      }
+    STOP_LOG("derivatives()","AbsorptionCoeff");
   }
 
   template<typename Chemistry>
-  void AbsorptionCoeff<Chemistry>::derivatives( libMesh::FEMContext & /*context*/,
-                                                const libMesh::Point & /*p*/,
-                                                const libMesh::Real & /*JxW*/,
-                                                const unsigned int /*qoi_index*/,
-                                                const libMesh::Real /*time*/)
-  {
-    // TODO
-    libmesh_not_implemented();
-  }
-
-  template<typename Chemistry>
-  void AbsorptionCoeff<Chemistry>::operator()( const libMesh::FEMContext& /*context*/,
-                                               const libMesh::Point& /*p*/,
+  void AbsorptionCoeff<Chemistry>::operator()( const libMesh::FEMContext & /*context*/,
+                                               const libMesh::Point & /*p*/,
                                                const libMesh::Real /*time*/,
-                                               libMesh::DenseVector<libMesh::Real>& /*output*/)
+                                               libMesh::DenseVector<libMesh::Real> & /*output*/)
   {
     libmesh_not_implemented();
   }
@@ -172,88 +240,247 @@ namespace GRINS
     libmesh_not_implemented();
   }
 
+
   template<typename Chemistry>
-  libMesh::Real AbsorptionCoeff<Chemistry>::kv(libMesh::Real P,libMesh::Real T,libMesh::Real X,libMesh::Real M)
+  libMesh::Real AbsorptionCoeff<Chemistry>::kv(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
   {
-    libMesh::Real kv = 0.0;
+    // linestrength
+    libMesh::Real S = this->Sw(T,P,i);
 
-    for (unsigned int i=_min_index; i<=_max_index; i++)
-      {
-        // isotopologue
-        unsigned int iso = _hitran->isotopologue(i);
+    // Voigt profile [cm^-1]
+    libMesh::Real phi_V = this->voigt(T,P,Y,i);
 
-        // linecenter wavenumber
-        libMesh::Real nu0 = _hitran->nu0(i);
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]); 
 
-        // linestrength
-        libMesh::Real sw0 = _hitran->sw(i);
-
-        // partition function at reference temp
-        libMesh::Real QT0 = _hitran->partition_function(_T0,iso);
-
-        // partition function at current temp
-        libMesh::Real QT = _hitran->partition_function(T,iso);
-
-        // lower state energy of transition
-        libMesh::Real E = _hitran->elower(i);
-
-        // air pressure-induced line shift
-        libMesh::Real d_air = _hitran->delta_air(i);
-
-        // pressure shift of the linecenter wavenumber
-        libMesh::Real nu = nu0 + d_air*(P/_Pref);
-
-        // linestrength
-        libMesh::Real S = sw0 * (QT0/QT) * std::exp(-E*_rad_coeff*( (1.0/T) - (1.0/_T0) )) * ( 1.0-std::exp(-_rad_coeff*nu/T) ) * pow(1.0-std::exp(-_rad_coeff*nu/_T0),-1.0);
-
-        // convert linestrength units to [cm^-2 atm^-1]
-        libMesh::Real loschmidt = (101325.0*1.0e-6)/(T*Constants::Boltzmann);
-        S = S*loschmidt;
-
-        // collisional FWHM [cm^-1]
-        libMesh::Real nu_c = this->nu_C(T,X,P,i);
-
-        // Doppler FWHM [cm^-1]
-        libMesh::Real nu_D = this->nu_D(nu,T,M);
-
-        // Voigt profile [cm^-1]
-        libMesh::Real phi_V = this->voigt(nu_D,nu_c,nu);
-
-        // absorption coefficient [cm^-1]
-        kv += S*P*X*phi_V;
-      }
-
-    return kv;
+    // absorption coefficient [cm^-1]
+    return S*(P/101325.0)*X*phi_V;
   }
 
   template<typename Chemistry>
-  libMesh::Real AbsorptionCoeff<Chemistry>::nu_D(libMesh::Real nu,libMesh::Real T,libMesh::Real M)
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_kv_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real dS = dS_dT(T,P,i);
+    libMesh::Real dV = d_voigt_dT(T,P,Y,i);
+
+    libMesh::Real S = this->Sw(T,P,i);
+    libMesh::Real V = this->voigt(T,P,Y,i);
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return X*(P/101325.0) * ( S*dV + dS*V );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_kv_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real dS = dS_dP(T,P,i);
+    libMesh::Real dV = d_voigt_dP(T,P,Y,i);
+
+    libMesh::Real S = this->Sw(T,P,i);
+    libMesh::Real V = this->voigt(T,P,Y,i);
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return X * ( S*(P/101325.0)*dV + S*(1.0/101325.0)*V + dS*P*V );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_kv_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real dX = dX_dY(Y);
+    libMesh::Real dV = d_voigt_dY(T,P,Y,i);
+
+    libMesh::Real S = this->Sw(T,P,i);
+    libMesh::Real V = this->voigt(T,P,Y,i);
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+    
+    return S*(P/101325.0) * ( X*dV + dX*V );
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::Sw(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    // isotopologue
+    unsigned int iso = _hitran->isotopologue(i);
+
+    // linecenter wavenumber
+    libMesh::Real nu = this->get_nu(P,i);
+
+    // linestrength
+    libMesh::Real sw0 = _hitran->sw(i);
+
+    // lower state energy of transition
+    libMesh::Real E = _hitran->elower(i);
+
+    // partition function at reference temp
+    libMesh::Real QT0 = _hitran->partition_function(_T0,iso);
+
+    // partition function at current temp
+    libMesh::Real QT = _hitran->partition_function(T,iso);
+
+    libMesh::Real a = sw0;
+    libMesh::Real b = (QT0/QT);
+    libMesh::Real c = std::exp(-E*_rad_coeff*( (1.0/T) - (1.0/_T0) ));
+    libMesh::Real d = ( 1.0-std::exp(-_rad_coeff*nu/T) );
+    libMesh::Real e = std::pow(1.0-std::exp(-_rad_coeff*nu/_T0),-1.0);
+
+    libMesh::Real S = a*b*c*d*e;
+
+    // convert linestrength units to [cm^-2 atm^-1]
+    libMesh::Real loschmidt = (101325.0)/(T*Constants::Boltzmann*1.0e6);
+    S = S*loschmidt;
+
+    return S;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::dS_dT(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real iso = _hitran->isotopologue(i);
+    libMesh::Real sw = _hitran->sw(i);
+    libMesh::Real E = _hitran->elower(i);
+    libMesh::Real QT0 = _hitran->partition_function(_T0,iso);
+    libMesh::Real QT = _hitran->partition_function(T,iso);
+    libMesh::Real dQT = this->dQ_dT(T,iso);
+    libMesh::Real nu = this->get_nu(P,i);
+    
+    libMesh::Real constants = sw * QT0 * std::pow( (1.0-std::exp(-_rad_coeff*nu/_T0)), -1.0) * 101325.0/(Constants::Boltzmann*1.0e6);
+    libMesh::Real A  = 1.0/T;
+    libMesh::Real dA = -1.0/(T*T);
+
+    libMesh::Real B  = 1.0/QT;
+    libMesh::Real dB = -1.0/(QT*QT) * dQT;
+
+    libMesh::Real C  = std::exp(-_rad_coeff*E* (1.0/T - 1.0/_T0) );
+    libMesh::Real dC = std::exp(-_rad_coeff*E* (1.0/T - 1.0/_T0) ) * (_rad_coeff*E/(T*T));
+
+    libMesh::Real D  = 1.0 - std::exp(-_rad_coeff*nu/T);
+    libMesh::Real dD = -std::exp(-_rad_coeff*nu/T) * (_rad_coeff*nu/(T*T));
+
+    return constants * ( A*B*C*dD + A*B*dC*D + A*dB*C*D + dA*B*C*D );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::dS_dP(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real iso = _hitran->isotopologue(i);
+    libMesh::Real sw = _hitran->sw(i);
+    libMesh::Real E = _hitran->elower(i);
+    libMesh::Real QT0 = _hitran->partition_function(_T0,iso);
+    libMesh::Real QT = _hitran->partition_function(T,iso);
+    libMesh::Real nu = this->get_nu(P,i);
+    libMesh::Real dnu = this->d_nu_dP(i);
+
+    libMesh::Real constants = sw * QT0/QT * std::exp(-_rad_coeff*E*(1.0/T - 1.0/_T0)) * 101325.0/(Constants::Boltzmann*1.0e6 * T);
+
+    libMesh::Real A  = 1.0 - std::exp(-_rad_coeff*nu/T);
+    libMesh::Real dA = -std::exp(-_rad_coeff*nu/T) * (-_rad_coeff/T) * dnu;
+
+    libMesh::Real B  = std::pow( (1.0-std::exp(-_rad_coeff*nu/T)), -1.0);
+    libMesh::Real dB = -std::pow( (1.0-std::exp(-_rad_coeff*nu/T)), -2.0) * -std::exp(-_rad_coeff*nu/_T0) * (-_rad_coeff/_T0) * dnu;
+
+    return constants * ( A*dB + dA*B );
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::nu_D(libMesh::Real T, libMesh::Real P, unsigned int i)
   {
     libMesh::Real k = Constants::Boltzmann;
     libMesh::Real c = Constants::c_vacuum;
     libMesh::Real NA = Constants::Avogadro;
+    libMesh::Real M = _chemistry->M(_species_idx);
+    libMesh::Real nu = this->get_nu(P,i);
 
     return (nu/c)*std::sqrt( ( 8.0*k*T*std::log(2.0) )/( M/NA ) );
   }
 
   template<typename Chemistry>
-  libMesh::Real AbsorptionCoeff<Chemistry>::nu_C(libMesh::Real T,libMesh::Real X,libMesh::Real P, unsigned int index)
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuD_dT(libMesh::Real T, libMesh::Real P, unsigned int i)
   {
-    libMesh::Real g_self = _hitran->gamma_self(index);
-    libMesh::Real g_air = _hitran->gamma_air(index);
-    libMesh::Real n = _hitran->n_air(index);
+    libMesh::Real k = Constants::Boltzmann;
+    libMesh::Real c = Constants::c_vacuum;
+    libMesh::Real NA = Constants::Avogadro;
+    libMesh::Real M = _chemistry->M(_species_idx);
+    libMesh::Real nu = this->get_nu(P,i);
 
-    return 2.0*P*pow(_T0/T,n) * ( X*g_self + (1.0-X)*g_air );
+    return (nu/c) * std::sqrt( (8.0*k*std::log(2.0))/(M/NA) ) * 0.5 * 1.0/(std::sqrt(T));
   }
 
   template<typename Chemistry>
-  libMesh::Real AbsorptionCoeff<Chemistry>::voigt(libMesh::Real nu_D, libMesh::Real nu_c, libMesh::Real nu)
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuD_dP(libMesh::Real T, unsigned int i)
   {
-    //repeated term
-    libMesh::Real root_ln2 = std::sqrt(std::log(2.0));
+    libMesh::Real k = Constants::Boltzmann;
+    libMesh::Real c = Constants::c_vacuum;
+    libMesh::Real NA = Constants::Avogadro;
+    libMesh::Real M = _chemistry->M(_species_idx);
+    libMesh::Real dnu = this->d_nu_dP(i);
 
-    libMesh::Real a = root_ln2*nu_c/nu_D;
-    libMesh::Real w = 2*root_ln2*(_nu-nu)/nu_D;
+    return (1.0/c)*std::sqrt( ( 8.0*k*T*std::log(2.0) )/( M/NA ) ) * dnu;
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::nu_C(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real g_self = _hitran->gamma_self(i);
+    libMesh::Real g_air = _hitran->gamma_air(i);
+    libMesh::Real n = _hitran->n_air(i);
+
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return 2.0*(P/101325.0)*std::pow(_T0/T,n)*( X*g_self + (1.0-X)*g_air );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuC_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real g_self = _hitran->gamma_self(i);
+    libMesh::Real g_air = _hitran->gamma_air(i);
+    libMesh::Real n = _hitran->n_air(i);
+
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return 2.0*(P/101325.0) * n*std::pow(_T0/T,n-1.0)*(-_T0/(T*T)) * ( X*g_self + (1.0-X)*g_air );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuC_dP(libMesh::Real T, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real g_self = _hitran->gamma_self(i);
+    libMesh::Real g_air = _hitran->gamma_air(i);
+    libMesh::Real n = _hitran->n_air(i);
+
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return 2.0*(1.0/101325.0)*std::pow(_T0/T,n)*( X*g_self + (1.0-X)*g_air );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuC_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real g_self = _hitran->gamma_self(i);
+    libMesh::Real g_air = _hitran->gamma_air(i);
+    libMesh::Real n = _hitran->n_air(i);
+    libMesh::Real dX = dX_dY(Y);
+
+    return 2.0*(P/101325.0)*std::pow(_T0/T,n)*( dX*g_self - dX*g_air );
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::voigt(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+
+    libMesh::Real a = this->voigt_a(T,P,Y,i);
+    libMesh::Real w = this->voigt_w(T,P,i);
 
     // Voigt coefficient
     libMesh::Real V = 0.0;
@@ -265,12 +492,130 @@ namespace GRINS
         libMesh::Real Ci = _voigt_coeffs[2][i];
         libMesh::Real Di = _voigt_coeffs[3][i];
 
-        V += ( Ci*(a-Ai) + Di*(w-Bi) )/( (a-Ai)*(a-Ai) + (w-Bi)*(w-Bi) );
+        libMesh::Real aAi = a-Ai;
+        libMesh::Real wBi = w-Bi;
+        libMesh::Real aAi2 = std::pow(a-Ai,2.0);
+        libMesh::Real wBi2 = std::pow(w-Bi,2.0);
+
+        V += ( Ci*aAi + Di*wBi )/( aAi2 + wBi2 );
       }
 
-    libMesh::Real phi_V = (2.0*root_ln2)/(std::sqrt(Constants::pi)*nu_D)*V;
+    libMesh::Real phi_V = (2.0*std::sqrt(std::log(2.0)))/(std::sqrt(Constants::pi)*nu_D)*V;
 
     return phi_V;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_D = d_nuD_dT(T,P,i);
+
+    libMesh::Real a  = this->voigt_a(T,P,Y,i);
+    libMesh::Real da = this->d_voigt_a_dT(T,P,Y,i);
+
+    libMesh::Real w  = this->voigt_w(T,P,i);
+    libMesh::Real dw = this->d_voigt_w_dT(T,P,i); 
+
+    // Voigt coefficient
+    libMesh::Real V  = 0.0;
+    libMesh::Real dV = 0.0;
+
+    for(int i=0; i<4; i++)
+      {
+        libMesh::Real Ai = _voigt_coeffs[0][i];
+        libMesh::Real Bi = _voigt_coeffs[1][i];
+        libMesh::Real Ci = _voigt_coeffs[2][i];
+        libMesh::Real Di = _voigt_coeffs[3][i];
+
+        libMesh::Real aAi = a-Ai;
+        libMesh::Real wBi = w-Bi;
+        libMesh::Real aAi2 = std::pow(a-Ai,2.0);
+        libMesh::Real wBi2 = std::pow(w-Bi,2.0);
+
+        V  += ( Ci*aAi + Di*wBi )/( aAi2 + wBi2 );
+
+        dV += ( (aAi2+wBi2)*(Ci*da + Di*dw) - (Ci*aAi + Di*wBi)*(2.0*aAi*da + 2.0*wBi*dw) )/( std::pow(aAi2+wBi2,2.0) );
+      }
+
+    libMesh::Real constants = 2.0*std::sqrt(std::log(2.0))/std::sqrt(Constants::pi);
+    libMesh::Real C  = 1.0/nu_D;
+    libMesh::Real dC = -1.0/(nu_D*nu_D) * dnu_D;
+
+    return constants * ( C*dV + dC*V );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_D = d_nuD_dP(T,i);
+
+    libMesh::Real a  = this->voigt_a(T,P,Y,i);
+    libMesh::Real da = this->d_voigt_a_dP(T,P,Y,i);
+
+    libMesh::Real w  = this->voigt_w(T,P,i);
+    libMesh::Real dw = this->d_voigt_w_dP(T,P,i);
+
+    // Voigt coefficient
+    libMesh::Real V  = 0.0;
+    libMesh::Real dV = 0.0;
+
+    for(int i=0; i<4; i++)
+      {
+        libMesh::Real Ai = _voigt_coeffs[0][i];
+        libMesh::Real Bi = _voigt_coeffs[1][i];
+        libMesh::Real Ci = _voigt_coeffs[2][i];
+        libMesh::Real Di = _voigt_coeffs[3][i];
+
+        libMesh::Real aAi = a-Ai;
+        libMesh::Real wBi = w-Bi;
+        libMesh::Real aAi2 = std::pow(a-Ai,2.0);
+        libMesh::Real wBi2 = std::pow(w-Bi,2.0);
+
+        V  += ( Ci*aAi + Di*wBi )/( aAi2 + wBi2 );
+
+        dV += ( (aAi2+wBi2)*(Ci*da + Di*dw) - (Ci*aAi + Di*wBi)*(2.0*aAi*da + 2.0*wBi*dw) )/( std::pow(aAi2+wBi2,2.0) );
+      }
+
+    libMesh::Real constants = 2.0*std::sqrt(std::log(2.0))/std::sqrt(Constants::pi);
+    libMesh::Real C  = 1.0/nu_D;
+    libMesh::Real dC = -1.0/(nu_D*nu_D) * dnu_D;
+
+    return constants * ( C*dV + dC*V );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+
+    libMesh::Real a  = this->voigt_a(T,P,Y,i);
+    libMesh::Real da = this->d_voigt_a_dY(T,P,Y,i);
+
+    libMesh::Real w  = this->voigt_w(T,P,i);
+
+    // Voigt coefficient
+    libMesh::Real dV = 0.0;
+
+    for(int i=0; i<4; i++)
+      {
+        libMesh::Real Ai = _voigt_coeffs[0][i];
+        libMesh::Real Bi = _voigt_coeffs[1][i];
+        libMesh::Real Ci = _voigt_coeffs[2][i];
+        libMesh::Real Di = _voigt_coeffs[3][i];
+
+        libMesh::Real aAi = a-Ai;
+        libMesh::Real wBi = w-Bi;
+        libMesh::Real aAi2 = std::pow(a-Ai,2.0);
+        libMesh::Real wBi2 = std::pow(w-Bi,2.0);
+
+        dV += ( (aAi2+wBi2)*(Ci*da) - (Ci*aAi + Di*wBi)*(2.0*aAi*da) )/( std::pow(aAi2+wBi2,2.0) );
+      }
+
+    libMesh::Real constants = 2.0*std::sqrt(std::log(2.0))/(std::sqrt(Constants::pi)*nu_D);
+
+    return constants * dV;
   }
 
   template<typename Chemistry>
@@ -295,6 +640,112 @@ namespace GRINS
     _voigt_coeffs[3][1] = -1.1858;
     _voigt_coeffs[3][2] = -0.0210;
     _voigt_coeffs[3][3] =  1.1858;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::voigt_a(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_c = this->nu_C(T,P,Y,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+
+    return std::sqrt(std::log(2.0))*nu_c/nu_D;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_a_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_c = this->nu_C(T,P,Y,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_c = d_nuC_dT(T,P,Y,i);
+    libMesh::Real dnu_D = d_nuD_dT(T,P,i);
+
+    return std::sqrt(std::log(2.0)) * (nu_D*dnu_c - nu_c*dnu_D)/(nu_D*nu_D);
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_a_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_c = this->nu_C(T,P,Y,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_c = d_nuC_dP(T,Y,i);
+    libMesh::Real dnu_D = d_nuD_dP(T,i);
+
+    return std::sqrt(std::log(2.0)) * (nu_D*dnu_c - nu_c*dnu_D)/(nu_D*nu_D);
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_a_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_c = d_nuC_dY(T,P,Y,i);
+
+    return std::sqrt(std::log(2.0))/nu_D * dnu_c;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::voigt_w(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real nu = this->get_nu(P,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+
+    return 2.0*std::sqrt(std::log(2.0))*(_nu-nu)/nu_D;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_w_dT(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real nu = this->get_nu(P,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_D = d_nuD_dT(T,P,i);
+
+    return 2.0*std::sqrt(std::log(2.0))*(_nu-nu)/(nu_D*nu_D) * -dnu_D;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_w_dP(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real nu = this->get_nu(P,i);
+    libMesh::Real dnu = d_nu_dP(i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_D = d_nuD_dP(T,i);
+
+    return 2.0*std::sqrt(std::log(2.0)) * ( (nu_D)*(-dnu) - (_nu-nu)*(dnu_D) )/(nu_D*nu_D);
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::get_nu(libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real nu = _hitran->nu0(i);
+    libMesh::Real d_air = _hitran->delta_air(i);
+
+    return nu + d_air*((P/101325.0)/_Pref);
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nu_dP(unsigned int i)
+  {
+    libMesh::Real d_air = _hitran->delta_air(i);
+    
+    return d_air/_Pref * 1.0/101325.0;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::dX_dY(std::vector<libMesh::Real> Y)
+  {
+    libMesh::Real MW = _chemistry->M(_species_idx);
+    libMesh::Real MW_mix = _chemistry->M_mix(Y);
+
+    libMesh::Real Ys = Y[_species_idx];
+
+    return 1.0/MW * ( MW_mix - Ys*(MW_mix*MW_mix)/MW );
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::dQ_dT(libMesh::Real T, unsigned int iso)
+  {
+    libMesh::Real deriv = _hitran->partition_function_derivative(T,iso);
+    return deriv;
   }
 
 #if GRINS_HAVE_ANTIOCH

--- a/src/qoi/src/composite_qoi.C
+++ b/src/qoi/src/composite_qoi.C
@@ -203,6 +203,12 @@ namespace GRINS
     return;
   }
 
+  void CompositeQoI::finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t /*qoi_index*/)
+  {
+    for( unsigned int q = 0; q < _qois.size(); q++ )
+      (*_qois[q]).finalize_derivative(derivatives);
+  }
+
   void CompositeQoI::output_qoi( std::ostream& out ) const
   {
     for( std::vector<QoIBase*>::const_iterator qoi = _qois.begin();

--- a/src/qoi/src/hitran.C
+++ b/src/qoi/src/hitran.C
@@ -155,6 +155,34 @@ namespace GRINS
     return _data_size;
   }
 
+  libMesh::Real HITRAN::partition_function_derivative(libMesh::Real T, unsigned int iso)
+  {
+    libMesh::Real deriv = -1.0;
+    if (std::abs(T-_Tmin)<libMesh::TOLERANCE) // 1st order forward difference
+      {
+        libMesh::Real QT0 = this->partition_function(_Tmin,iso);
+        libMesh::Real QT1 = this->partition_function(_Tmin+_Tstep,iso);
+
+        deriv  = (QT1-QT0)/_Tstep;
+      }
+    else if (std::abs(T-_Tmax)<libMesh::TOLERANCE) // 1st order backward difference
+      {
+        libMesh::Real QT0 = this->partition_function(_Tmax-_Tstep,iso);
+        libMesh::Real QT1 = this->partition_function(_Tmax,iso);
+
+        deriv = (QT1-QT0)/_Tstep;
+      }
+    else // 2nd order central difference
+      {
+        libMesh::Real QT1 = this->partition_function(T+_Tstep,iso);
+        libMesh::Real QT0 = this->partition_function(T-_Tstep,iso);
+
+        deriv = (QT1-QT0)/(2.0*_Tstep);
+      }
+
+    return deriv;
+  }
+
   unsigned int HITRAN::isotopologue(unsigned int index)
   {
     libmesh_assert_less(index,_isotop.size());

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -130,11 +130,38 @@ namespace GRINS
   }
 
   template<typename Function>
-  void IntegratedFunction<Function>::element_qoi_derivative( AssemblyContext& /*context*/,
-                                                             const unsigned int /*qoi_index*/ )
+  void IntegratedFunction<Function>::element_qoi_derivative(AssemblyContext& context,
+                                                            const unsigned int qoi_index )
   {
-    //TODO
-    libmesh_not_implemented();
+    const libMesh::Elem& original_elem = context.get_elem();
+    const libMesh::Elem* rayfire_elem = _rayfire->map_to_rayfire_elem(original_elem.id());
+
+    // rayfire_elem will be NULL if the main_elem
+    // is not in the rayfire
+    if (rayfire_elem)
+      {
+        // create and init the quadrature base on the rayfire elem
+        libMesh::QGauss qbase(rayfire_elem->dim(),libMesh::Order(_p_level));
+        qbase.init(rayfire_elem->type(),libMesh::Order(_p_level));
+
+        // need the QP coordinates and JxW
+        libMesh::UniquePtr< libMesh::FEBase > fe = libMesh::FEBase::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
+
+        fe->attach_quadrature_rule( &qbase );
+        fe->get_xyz();
+        fe->get_JxW();
+
+        fe->reinit(rayfire_elem);
+
+        const std::vector<libMesh::Real>& JxW = fe->get_JxW();
+        const std::vector<libMesh::Point>& xyz = fe->get_xyz();
+
+        const unsigned int n_qpoints = fe->n_quadrature_points();
+
+        for (unsigned int qp = 0; qp != n_qpoints; qp++)
+          this->qoi_derivative((*_f),context,xyz[qp],JxW[qp],qoi_index);
+
+      }
   }
 
   // speciaizations of the qoi_value() function
@@ -148,6 +175,23 @@ namespace GRINS
   libMesh::Real IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >::qoi_value(libMesh::FunctionBase<libMesh::Real>& f,AssemblyContext& /*context*/,const libMesh::Point& xyz)
   {
     return f(xyz);
+  }
+
+  // speciaizations of the qoi_derivative() function
+  template<>
+  void IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >::qoi_derivative( FEMFunctionAndDerivativeBase<libMesh::Real> & f, AssemblyContext & context,
+                                                                                         const libMesh::Point & qp_xyz, const libMesh::Real JxW,
+                                                                                         const unsigned int qoi_index)
+  {
+    f.derivatives(context,qp_xyz,JxW,qoi_index);
+  }
+
+  template<>
+  void IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >::qoi_derivative( libMesh::FunctionBase<libMesh::Real> & /*f*/, AssemblyContext & /*context*/,
+                                                                                  const libMesh::Point & /*qp_xyz*/, const libMesh::Real /*JxW*/,
+                                                                                  const unsigned int /*qoi_index*/)
+  {
+    // derivatives are always zero for FunctionBase
   }
 
 template class IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >;

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -31,6 +31,7 @@
 #include "grins/assembly_context.h"
 #include "grins/materials_parsing.h"
 #include "grins/rayfire_mesh.h"
+#include "grins/fem_function_and_derivative_base.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -40,7 +41,6 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/function_base.h"
-#include "libmesh/fem_function_base.h"
 
 namespace GRINS
 {
@@ -139,7 +139,7 @@ namespace GRINS
 
   // speciaizations of the qoi_value() function
   template<>
-  libMesh::Real IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >::qoi_value(libMesh::FEMFunctionBase<libMesh::Real>& f,AssemblyContext& context,const libMesh::Point& xyz)
+  libMesh::Real IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >::qoi_value(FEMFunctionAndDerivativeBase<libMesh::Real>& f,AssemblyContext& context,const libMesh::Point& xyz)
   {
     return f(context,xyz);
   }
@@ -150,7 +150,7 @@ namespace GRINS
     return f(xyz);
   }
 
-  template class IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >;
-  template class IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >;
+template class IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >;
+template class IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >;
 
 } //namespace GRINS

--- a/src/qoi/src/qoi_base.C
+++ b/src/qoi/src/qoi_base.C
@@ -58,6 +58,11 @@ namespace GRINS
     qoi += other_qoi;
   }
 
+  void QoIBase::finalize_derivative(libMesh::NumericVector<libMesh::Number> & /*derivatives*/)
+  {
+    // do nothing by default
+  }
+
   void QoIBase::output_qoi( std::ostream& out ) const
   {
     out << _qoi_name+" = "

--- a/src/qoi/src/qoi_factory.C
+++ b/src/qoi/src/qoi_factory.C
@@ -166,7 +166,7 @@ namespace GRINS
         std::string species;
         this->get_var_value<std::string>(input,species,"QoI/SpectroscopicAbsorption/species_of_interest","");
 
-        SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb;
+        SharedPtr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb;
 
         libMesh::Real thermo_pressure = -1.0;
         bool calc_thermo_pressure = input("QoI/SpectroscopicAbsorption/calc_thermo_pressure", false );

--- a/src/qoi/src/spectroscopic_absorption.C
+++ b/src/qoi/src/spectroscopic_absorption.C
@@ -33,17 +33,17 @@
 #include "grins/assembly_context.h"
 #include "grins/materials_parsing.h"
 #include "grins/single_variable.h"
+#include "grins/fem_function_and_derivative_base.h"
 
 // libMesh
 #include "libmesh/getpot.h"
 #include "libmesh/fem_system.h"
 #include "libmesh/quadrature.h"
-#include "libmesh/fem_function_base.h"
 
 namespace GRINS
 {
-  SpectroscopicAbsorption::SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb)
-    : IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >(input,2 /* QGauss order */,absorb,"SpectroscopicAbsorption",qoi_name)
+  SpectroscopicAbsorption::SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb)
+    : IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >(input,2 /* QGauss order */,absorb,"SpectroscopicAbsorption",qoi_name)
   {}
 
   QoIBase * SpectroscopicAbsorption::clone() const

--- a/src/qoi/src/spectroscopic_absorption.C
+++ b/src/qoi/src/spectroscopic_absorption.C
@@ -63,4 +63,13 @@ namespace GRINS
     QoIBase::_qoi_value = sys_qoi;
   }
 
+  void SpectroscopicAbsorption::finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives)
+  {
+  std::cout <<"QoI: " <<this->_qoi_value <<std::endl;
+    if (!derivatives.closed())
+      derivatives.close();
+
+    derivatives.scale(QoIBase::_qoi_value);
+  }
+
 } //namespace GRINS

--- a/test/unit/input_files/spectroscopic_absorption_qoi_4elem.in
+++ b/test/unit/input_files/spectroscopic_absorption_qoi_4elem.in
@@ -1,0 +1,152 @@
+# Materials
+[Materials]
+   [./TestMaterial]
+      [./ThermalConductivity]
+        model = 'constant'
+        value = '1.0'
+      [../ThermodynamicPressure]
+        value = '5066.25' #[Pa]
+      [../Density]
+        value = '1.0'
+      [../SpecificHeat]
+        model = 'constant'
+        value = '1.0'
+      [../Viscosity]
+        model = 'constant'
+        value = '1.0e-5'
+      [../LewisNumber]
+        value = '1.0'
+
+      [../GasMixture]
+        thermochemistry_library = 'antioch'
+        species = 'CO2 N2'
+        kinetics_data = './test_data/CO2_N2.xml'
+
+        [./Antioch]
+           transport_model = 'constant'
+           thermo_model = 'cea'
+           viscosity_model = 'constant'
+           thermal_conductivity_model = 'constant'
+           mass_diffusivity_model = 'constant_lewis'
+[]
+
+# Options related to all Physics
+[Physics]
+
+   enabled_physics = 'ReactingLowMachNavierStokes
+                      ReactingLowMachNavierStokesSPGSMStabilization'
+
+   [./ReactingLowMachNavierStokes]
+
+      material = 'TestMaterial'
+      pin_pressure = 'true'
+      pin_location = '0.0 0.0'
+      pin_value = '0.0'
+
+      ic_ids = '0'
+      ic_types = 'parsed'
+      ic_variables = 'T:Y_CO2:Y_N2'
+      ic_values = '{300.0}{0.0763662233}{0.9236337767}'
+
+      enable_thermo_press_calc = 'false'
+[]
+
+[BoundaryConditions]
+
+    bc_ids = '0:1:2:3'
+    bc_id_name_map = 'Dirichlet'
+
+    [./Dirichlet]
+
+      [./Temperature]
+         type = 'isothermal'
+         T = '300.0'
+      [../]
+
+      [./Velocity]
+          type = 'no_slip'
+      [../]
+
+      [./SpeciesMassFractions]
+         type = 'mole_fractions'
+         X_CO2 = '0.05'
+         X_N2 = '0.95'
+      [../]
+
+[]
+
+[Variables]
+    [./Temperature]
+      names = 'T'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+
+    [../Velocity]
+      names = 'Ux Uy'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+
+    [../Pressure]
+      names = 'p'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+
+    [../SpeciesMassFractions]
+      names = 'Y_'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+      material = 'TestMaterial'
+[]
+
+# Mesh related options
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      n_elems_x = '2'
+      n_elems_y = '2'
+      x_min = '0.0'
+      x_max = '0.10'
+      y_min = '0.0'
+      y_max = '0.10'
+      element_type = 'QUAD4'
+[]
+
+[QoI]
+
+  enabled_qois = 'spectroscopic_absorption'
+
+  [./SpectroscopicAbsorption]
+
+    material = 'TestMaterial'
+    species_of_interest = 'CO2'
+    hitran_data_file = './test_data/CO2_data.dat'
+    hitran_partition_function_file = './test_data/CO2_partition_function.dat'
+    partition_temperatures = '290 310 0.01'
+    desired_wavenumber = '3682.7649'
+    min_wavenumber = '3682.69'
+    max_wavenumber = '3682.8'
+    calc_thermo_pressure = 'false'
+
+    [./Rayfire]
+      origin = '0.0 0.0'
+      theta = '0.785368' # pi/4
+    [../]
+  [../]
+
+[]
+
+#Linear and nonlinear solver options
+[linear-nonlinear-solver]
+   max_nonlinear_iterations =  25
+   max_linear_iterations = 2500
+   relative_residual_tolerance = '1.0e-14'
+   absolute_residual_tolerance = '1.0e-13'
+   relative_step_tolerance = '1.0e-12'
+   use_numerical_jacobians_only = 'true'
+[]
+
+[Output]
+   [./Display]
+      print_qoi = 'true'
+   [../]
+[]

--- a/test/unit/spectroscopic_absorption_test.C
+++ b/test/unit/spectroscopic_absorption_test.C
@@ -40,6 +40,15 @@
 #include "grins/simulation_builder.h"
 #include "grins/simulation.h"
 #include "grins/variable_warehouse.h"
+#include "grins/single_variable.h"
+#include "grins/multicomponent_variable.h"
+
+#include "grins/absorption_coeff.h"
+#include "grins/chemistry_builder.h"
+
+#if GRINS_HAVE_ANTIOCH
+#include "grins/antioch_chemistry.h"
+#endif
 
 // libMesh
 #include "libmesh/parsed_function.h"
@@ -51,11 +60,14 @@ namespace GRINSTesting
 {
   class SpectroscopicAbsorptionTest : public CppUnit::TestCase
   {
+  
   public:
     CPPUNIT_TEST_SUITE( SpectroscopicAbsorptionTest );
 #if GRINS_HAVE_ANTIOCH
     CPPUNIT_TEST( single_elem_mesh );
     CPPUNIT_TEST( multi_elem_mesh );
+    CPPUNIT_TEST( elem_qoi_derivative );
+    CPPUNIT_TEST( param_derivs );
 #endif
     CPPUNIT_TEST_SUITE_END();
 
@@ -85,6 +97,62 @@ namespace GRINSTesting
       this->run_test(filename,calc_answer);
     }
 
+    void elem_qoi_derivative()
+    {
+      const std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/spectroscopic_absorption_qoi.in";
+      this->init_sim(filename);
+      _sim->run();
+      
+      GRINS::MultiphysicsSystem * system = _sim->get_multiphysics_system();
+      GRINS::AssemblyContext * context = libMesh::cast_ptr<GRINS::AssemblyContext*>(system->build_context().release());
+      system->init_context(*context);
+      context->pre_fe_reinit(*system,system->get_mesh().elem_ptr(0));
+      
+      std::cout <<"-------\nTemperature" <<std::endl;
+      this->T_elem_derivative(system,context);
+      std::cout <<"-------\nPressure" <<std::endl;
+      this->P_elem_derivative(system,context);
+      std::cout <<"-------\nMass Fraction" <<std::endl;
+      this->Y_elem_derivative(system,context);
+    }
+
+    void param_derivs()
+    {
+      const std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/spectroscopic_absorption_qoi.in";
+      this->init_sim(filename);
+      
+      std::string material = "TestMaterial";
+      std::string hitran_data = "./test_data/CO2_data.dat";
+      std::string hitran_partition = "./test_data/CO2_partition_function.dat";
+      libMesh::Real T_min = 290.0,
+                    T_max = 310.0,
+                    T_step = 0.01;
+      GRINS::SharedPtr<GRINS::HITRAN> hitran( new GRINS::HITRAN(hitran_data,hitran_partition,T_min,T_max,T_step) );
+
+      std::string species = "CO2";
+      libMesh::Real thermo_pressure = 5066.25;
+      libMesh::Real nu_desired = 3682.7649;
+      libMesh::Real nu_min = 3682.69;
+      libMesh::Real nu_max = 3682.8;
+      GRINS::ChemistryBuilder chem_builder;
+      libMesh::UniquePtr<GRINS::AntiochChemistry> chem_ptr;
+      chem_builder.build_chemistry(*(_input.get()),material,chem_ptr);
+      GRINS::SharedPtr<GRINS::AntiochChemistry> chem(chem_ptr.release());
+      GRINS::SharedPtr<GRINS::AbsorptionCoeff<GRINS::AntiochChemistry> > absorb = new GRINS::AbsorptionCoeff<GRINS::AntiochChemistry>(chem,hitran,nu_min,nu_max,nu_desired,species,thermo_pressure);
+
+      libMesh::Real T = 300.0;
+      libMesh::Real P = 5066.25;
+      
+      std::vector<libMesh::Real> Y = {0.0763662233, 0.9236337767};
+      
+      for (unsigned int i=0; i<33; ++i)
+        {
+          this->T_param_derivatives(absorb,T,P,Y,i);
+          this->P_param_derivatives(absorb,T,P,Y,i);
+          this->Y_param_derivatives(absorb,T,P,Y,i);
+        }
+    }
+
   private:
     GRINS::SharedPtr<GRINS::Simulation> _sim;
     GRINS::SharedPtr<GetPot> _input;
@@ -112,6 +180,189 @@ namespace GRINSTesting
                                    empty_command_line,
                                    sim_builder,
                                    *TestCommWorld );
+    }
+
+    void T_param_derivatives(GRINS::SharedPtr<GRINS::AbsorptionCoeff<GRINS::AntiochChemistry> >absorb, libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> & Y, unsigned int i)
+    {
+      libMesh::Real delta = 1.0e-6;
+      
+      std::vector<libMesh::Real> T_analytic;
+      T_analytic.push_back(absorb->dS_dT(T,P,i));
+      T_analytic.push_back(absorb->d_nuC_dT(T,P,Y,i));
+      T_analytic.push_back(absorb->d_nuD_dT(T,P,i));
+      T_analytic.push_back(absorb->d_voigt_a_dT(T,P,Y,i));
+      T_analytic.push_back(absorb->d_voigt_w_dT(T,P,i));
+      T_analytic.push_back(absorb->d_voigt_dT(T,P,Y,i));
+      T_analytic.push_back(absorb->d_kv_dT(T,P,Y,i));
+      
+      std::vector<libMesh::Real> fd_plus;
+      fd_plus.push_back(absorb->Sw(T+delta,P,i));
+      fd_plus.push_back(absorb->nu_C(T+delta,P,Y,i));
+      fd_plus.push_back(absorb->nu_D(T+delta,P,i));
+      fd_plus.push_back(absorb->voigt_a(T+delta,P,Y,i));
+      fd_plus.push_back(absorb->voigt_w(T+delta,P,i));
+      fd_plus.push_back(absorb->voigt(T+delta,P,Y,i));
+      fd_plus.push_back(absorb->kv(T+delta,P,Y,i));
+      
+      std::vector<libMesh::Real> fd_minus;
+      fd_minus.push_back(absorb->Sw(T-delta,P,i));
+      fd_minus.push_back(absorb->nu_C(T-delta,P,Y,i));
+      fd_minus.push_back(absorb->nu_D(T-delta,P,i));
+      fd_minus.push_back(absorb->voigt_a(T-delta,P,Y,i));
+      fd_minus.push_back(absorb->voigt_w(T-delta,P,i));
+      fd_minus.push_back(absorb->voigt(T-delta,P,Y,i));
+      fd_minus.push_back(absorb->kv(T-delta,P,Y,i));
+      
+      check_param_derivatives(T_analytic,fd_plus,fd_minus,delta);
+    }
+
+    void P_param_derivatives(GRINS::SharedPtr<GRINS::AbsorptionCoeff<GRINS::AntiochChemistry> >absorb, libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> & Y, unsigned int i)
+    {
+      libMesh::Real delta = 1.0e-3;
+      
+      std::vector<libMesh::Real> P_analytic;
+      P_analytic.push_back(absorb->dS_dP(T,P,i));
+      P_analytic.push_back(absorb->d_nuC_dP(T,Y,i));
+      P_analytic.push_back(absorb->d_nuD_dP(T,i));
+      P_analytic.push_back(absorb->d_voigt_a_dP(T,P,Y,i));
+      P_analytic.push_back(absorb->d_voigt_w_dP(T,P,i));
+      P_analytic.push_back(absorb->d_voigt_dP(T,P,Y,i));
+      P_analytic.push_back(absorb->d_kv_dP(T,P,Y,i));
+      
+      std::vector<libMesh::Real> fd_plus;
+      fd_plus.push_back(absorb->Sw(T,P+delta,i));
+      fd_plus.push_back(absorb->nu_C(T,P+delta,Y,i));
+      fd_plus.push_back(absorb->nu_D(T,P+delta,i));
+      fd_plus.push_back(absorb->voigt_a(T,P+delta,Y,i));
+      fd_plus.push_back(absorb->voigt_w(T,P+delta,i));
+      fd_plus.push_back(absorb->voigt(T,P+delta,Y,i));
+      fd_plus.push_back(absorb->kv(T,P+delta,Y,i));
+      
+      std::vector<libMesh::Real> fd_minus;
+      fd_minus.push_back(absorb->Sw(T,P-delta,i));
+      fd_minus.push_back(absorb->nu_C(T,P-delta,Y,i));
+      fd_minus.push_back(absorb->nu_D(T,P-delta,i));
+      fd_minus.push_back(absorb->voigt_a(T,P-delta,Y,i));
+      fd_minus.push_back(absorb->voigt_w(T,P-delta,i));
+      fd_minus.push_back(absorb->voigt(T,P-delta,Y,i));
+      fd_minus.push_back(absorb->kv(T,P-delta,Y,i));
+      
+      check_param_derivatives(P_analytic,fd_plus,fd_minus,delta);
+    }
+
+    void Y_param_derivatives(GRINS::SharedPtr<GRINS::AbsorptionCoeff<GRINS::AntiochChemistry> >absorb, libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> & Y, unsigned int i)
+    {
+      libMesh::Real delta = 1.0e-8;
+
+      libMesh::Real y_base = Y[0];
+      std::vector<libMesh::Real> Y_analytic;
+      Y_analytic.push_back(absorb->dX_dY(Y));
+      Y_analytic.push_back(absorb->d_nuC_dY(T,P,Y,i));
+      Y_analytic.push_back(absorb->d_voigt_a_dY(T,P,Y,i));
+      Y_analytic.push_back(absorb->d_voigt_dY(T,P,Y,i));
+      Y_analytic.push_back(absorb->d_kv_dY(T,P,Y,i));
+      
+      std::vector<libMesh::Real> fd_plus;
+      Y[0] = y_base + delta;
+      fd_plus.push_back(absorb->_chemistry->X(absorb->_species_idx,absorb->_chemistry->M_mix(Y),Y[absorb->_species_idx]));
+      fd_plus.push_back(absorb->nu_C(T,P,Y,i));
+      fd_plus.push_back(absorb->voigt_a(T,P,Y,i));
+      fd_plus.push_back(absorb->voigt(T,P,Y,i));
+      fd_plus.push_back(absorb->kv(T,P,Y,i));
+      
+      std::vector<libMesh::Real> fd_minus;
+      Y[0] = y_base - delta;
+      fd_minus.push_back(absorb->_chemistry->X(absorb->_species_idx,absorb->_chemistry->M_mix(Y),Y[absorb->_species_idx]));
+      fd_minus.push_back(absorb->nu_C(T,P,Y,i));
+      fd_minus.push_back(absorb->voigt_a(T,P,Y,i));
+      fd_minus.push_back(absorb->voigt(T,P,Y,i));
+      fd_minus.push_back(absorb->kv(T,P,Y,i));
+      
+      Y[0] = y_base;
+      
+      check_param_derivatives(Y_analytic,fd_plus,fd_minus,delta);
+    }
+
+    void check_param_derivatives(std::vector<libMesh::Real> & analytic, std::vector<libMesh::Real> & fd_plus, std::vector<libMesh::Real> & fd_minus, libMesh::Real delta)
+    {
+      for (unsigned int d=0; d<analytic.size(); ++d)
+        {
+          libMesh::Real f_analytic = analytic[d];
+          libMesh::Real fd_approx = (fd_plus[d] - fd_minus[d])/(2.0*delta);
+          
+          libMesh::Real diff = std::abs(f_analytic - fd_approx);
+          if (diff > libMesh::TOLERANCE)
+            std::cout <<"**FAIL d=" <<d <<", plus=" <<fd_plus[d] <<", minus=" <<fd_minus[d] <<", diff=" <<diff <<std::endl;
+          
+          CPPUNIT_ASSERT_DOUBLES_EQUAL(fd_approx,f_analytic,libMesh::TOLERANCE);
+        }
+    }
+
+    void T_elem_derivative(GRINS::MultiphysicsSystem * system, GRINS::AssemblyContext * context)
+    {
+      GRINS::PrimitiveTempFEVariables T_var( GRINS::GRINSPrivate::VariableWarehouse::get_variable_subclass<GRINS::PrimitiveTempFEVariables>("Temperature") );
+      
+      libMesh::Real delta = 1e-6;
+      
+      test_var_elem_derivs(system,context,T_var.T(),delta);
+    }
+
+    void P_elem_derivative(GRINS::MultiphysicsSystem * system, GRINS::AssemblyContext * context)
+    {
+      GRINS::PressureFEVariable P_var( GRINS::GRINSPrivate::VariableWarehouse::get_variable_subclass<GRINS::PressureFEVariable>("Pressure") );
+      
+      libMesh::Real delta = 1e-6;
+      
+      test_var_elem_derivs(system,context,P_var.p(),delta);
+    }
+
+    void Y_elem_derivative(GRINS::MultiphysicsSystem * system, GRINS::AssemblyContext * context)
+    {
+      GRINS::SpeciesMassFractionsVariable Y_var( GRINS::GRINSPrivate::VariableWarehouse::get_variable_subclass<GRINS::SpeciesMassFractionsVariable>("SpeciesMassFractions") );
+      
+      libMesh::Real delta = 1e-6;
+      
+      test_var_elem_derivs(system,context,Y_var.species(0),delta);
+    }
+
+    void test_var_elem_derivs(GRINS::MultiphysicsSystem * system, GRINS::AssemblyContext * context, unsigned int var_index, libMesh::Real delta)
+    {
+      libMesh::QoISet qs;
+      qs.add_index(0);
+      
+      libMesh::DifferentiableQoI * qoi = system->get_qoi();
+      libMesh::Number & qoi_value = context->get_qois()[0];
+      qoi_value = 0.0;
+      
+      qoi->element_qoi_derivative(*context,qs);
+      libMesh::DenseSubVector<libMesh::Number> deriv = context->get_qoi_derivatives(0,var_index);
+      
+      libMesh::DenseSubVector<libMesh::Number> & solution  = context->get_elem_solution(var_index);
+      
+      for (unsigned int d=0; d<solution.size(); ++d)
+        {
+          libMesh::Number soln = solution.el(d);
+          
+          solution(d) = soln+delta;
+          qoi->element_qoi(*context,qs);
+          libMesh::Number qoi_p1 = qoi_value;
+          qoi_value = 0.0;
+          
+          solution(d) = soln-delta;
+          qoi->element_qoi(*context,qs);
+          libMesh::Number qoi_m1= qoi_value;
+          qoi_value = 0.0;
+          
+          solution(d) = soln;
+          
+          libMesh::Real fd_approx = (qoi_p1 - qoi_m1)/(2.0*delta);
+          
+          libMesh::Real diff = std::abs(fd_approx - deriv(d));
+          
+          std::cout <<"FD: " <<fd_approx <<", analytic: " <<deriv(d) <<", diff: " <<diff <<std::endl;
+          
+          //CPPUNIT_ASSERT_DOUBLES_EQUAL(fd_approx,deriv(d),libMesh::TOLERANCE);
+        }
     }
 
   };


### PR DESCRIPTION
Implementation of analytical derivatives of the Beer-Lambert Law for use in AMR.

We subclass `libMesh::FEMFunctionBase` to provide the `derivatives()` function so `IntegratedFunction` can be used with AMR.

The analytical derivatives are fairly long and nasty. I wrote the derivatives for the lowest-level quantities (i.e. broadening half-widths, Voigt lineshape, linestrength, and partition functions) and then used the product rule to combine these, rather than writing out the full derivatives for everything. The relevant state variables are pressure, temperature, and mass fraction of the species of interest.