### PR TITLE
Removing deprecated libMesh calls

### DIFF
--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -172,7 +172,7 @@ namespace GRINS
     const libMesh::Elem* get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point& start_point, libMesh::Point& end_point, bool same_parent = false);
 
     //! Ensure the calculated intersection point is on the edge_elem and is not the start_point
-    bool check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, libMesh::Elem& edge_elem, libMesh::Point& next_point);
+    bool check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, const libMesh::Elem& edge_elem, libMesh::Point& next_point);
 
     //! Knowing the end_point, get the appropraite next elem along the path
     const libMesh::Elem* get_correct_neighbor(libMesh::Point& end_point, const libMesh::Elem* cur_elem, unsigned int side, bool same_parent);

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -220,7 +220,7 @@ namespace GRINS
         if (state == libMesh::Elem::RefinementState::INACTIVE)
           {
             if (main_elem->has_children())
-              if (main_elem->child(0)->refinement_flag() == libMesh::Elem::RefinementState::JUST_REFINED)
+              if (main_elem->child_ptr(0)->refinement_flag() == libMesh::Elem::RefinementState::JUST_REFINED)
                 elems_to_refine.push_back(std::pair<const libMesh::Elem*, libMesh::Elem*>(main_elem,_mesh->elem(it->second)));
           }
       }
@@ -562,13 +562,13 @@ namespace GRINS
     libMesh::dof_id_type start_child = libMesh::invalid_uint;
     for(unsigned int i=0; i<main_elem->n_children(); i++)
       {
-        if ( (main_elem->child(i))->contains_point(*start_node) )
+        if ( (main_elem->child_ptr(i))->contains_point(*start_node) )
           {
             // check if the start point is a vertex
             bool is_vertex = false;
-            for(unsigned int n=0; n<main_elem->child(i)->n_nodes(); n++)
+            for(unsigned int n=0; n<main_elem->child_ptr(i)->n_nodes(); n++)
               {
-                if ((main_elem->child(i)->node_ptr(n))->absolute_fuzzy_equals(*start_node))
+                if ((main_elem->child_ptr(i)->node_ptr(n))->absolute_fuzzy_equals(*start_node))
                   {
                     is_vertex = true;
                     break;
@@ -577,7 +577,7 @@ namespace GRINS
 
             if (is_vertex)
               {
-                if ( this->rayfire_in_elem(*start_node, main_elem->child(i)) )
+                if ( this->rayfire_in_elem(*start_node, main_elem->child_ptr(i)) )
                   {
                     start_child = i;
                     break;
@@ -600,7 +600,7 @@ namespace GRINS
     libMesh::Point end_point;
 
     const libMesh::Elem* next_elem;
-    const libMesh::Elem* prev_elem = main_elem->child(start_child);
+    const libMesh::Elem* prev_elem = main_elem->child_ptr(start_child);
 
     // if prev_elem is INACTIVE, then more than one refinement
     // has taken place between reinit() calls and will
@@ -665,7 +665,7 @@ namespace GRINS
 
         for (unsigned int c=0; c<parent_elem->n_children(); c++)
           {
-            libMesh::Elem* rayfire_child = this->get_rayfire_elem(parent_elem->child(c)->id());
+            libMesh::Elem* rayfire_child = this->get_rayfire_elem(parent_elem->child_ptr(c)->id());
 
             if (rayfire_child)
               {

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -257,7 +257,7 @@ namespace GRINS
           continue;
 
         // we found a boundary elem, so make an edge and see if it contains the origin
-        libMesh::UniquePtr<libMesh::Elem> edge_elem = start_elem->build_edge(s);
+        libMesh::UniquePtr<const libMesh::Elem> edge_elem = start_elem->build_edge_ptr(s);
         valid |= edge_elem->contains_point(_origin);
       }
 
@@ -323,7 +323,7 @@ namespace GRINS
     // loop over all sides of the elem and check each one for intersection
     for (unsigned int s=0; s<cur_elem->n_sides(); s++)
       {
-        const libMesh::UniquePtr<libMesh::Elem> edge_elem = cur_elem->build_edge(s);
+        libMesh::UniquePtr<const libMesh::Elem> edge_elem = cur_elem->build_edge_ptr(s);
 
         // Using the default tol can cause a false positive when start_point is near a node,
         // causing this loop to skip over an otherwise valid edge to check
@@ -346,7 +346,7 @@ namespace GRINS
   }
 
 
-  bool RayfireMesh::check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, libMesh::Elem& edge_elem, libMesh::Point& next_point)
+  bool RayfireMesh::check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, const libMesh::Elem& edge_elem, libMesh::Point& next_point)
   {
     bool is_not_start = !(intersection_point.absolute_fuzzy_equals(start_point));
     bool is_on_edge = edge_elem.contains_point(intersection_point);
@@ -407,7 +407,7 @@ namespace GRINS
         // check elem neighbors first
         for (unsigned int s=0; s<cur_elem->n_sides(); s++)
           {
-            libMesh::UniquePtr<libMesh::Elem> side_elem = cur_elem->build_side(s);
+            libMesh::UniquePtr<const libMesh::Elem> side_elem = cur_elem->build_side_ptr(s);
             if (side_elem->contains_point(end_point))
               {
                 const libMesh::Elem * neighbor = cur_elem->neighbor_ptr(s);

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -183,7 +183,7 @@ namespace GRINS
     std::map<libMesh::dof_id_type,libMesh::dof_id_type>::const_iterator it = _elem_id_map.begin();
     for(; it != _elem_id_map.end(); it++)
       {
-        if (_mesh->elem(it->second)->active())
+        if (_mesh->elem_ptr(it->second)->active())
           id_vector.push_back(it->first);
       }
   }
@@ -206,7 +206,7 @@ namespace GRINS
     std::map<libMesh::dof_id_type,libMesh::dof_id_type>::iterator it = _elem_id_map.begin();
     for(; it != _elem_id_map.end(); it++)
       {
-        const libMesh::Elem* main_elem = mesh_base.elem(it->first);
+        const libMesh::Elem* main_elem = mesh_base.elem_ptr(it->first);
         libmesh_assert(main_elem);
 
         if (main_elem->parent())
@@ -221,7 +221,7 @@ namespace GRINS
           {
             if (main_elem->has_children())
               if (main_elem->child_ptr(0)->refinement_flag() == libMesh::Elem::RefinementState::JUST_REFINED)
-                elems_to_refine.push_back(std::pair<const libMesh::Elem*, libMesh::Elem*>(main_elem,_mesh->elem(it->second)));
+                elems_to_refine.push_back(std::pair<const libMesh::Elem*, libMesh::Elem*>(main_elem,_mesh->elem_ptr(it->second)));
           }
       }
 
@@ -307,8 +307,8 @@ namespace GRINS
     std::map<libMesh::dof_id_type,libMesh::dof_id_type>::iterator it;
     it = _elem_id_map.find(elem_id);
     if (it != _elem_id_map.end())
-      if (_mesh->elem(it->second)->refinement_flag() != libMesh::Elem::RefinementState::INACTIVE)
-        retval = _mesh->elem(it->second);
+      if (_mesh->elem_ptr(it->second)->refinement_flag() != libMesh::Elem::RefinementState::INACTIVE)
+        retval = _mesh->elem_ptr(it->second);
 
     return retval;
   }

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -389,13 +389,13 @@ namespace GRINS
 
     // check if the intersection point is a vertex
     bool is_vertex = false;
-    libMesh::Node * vertex = NULL;
+    const libMesh::Node * vertex = NULL;
     for(unsigned int n=0; n<cur_elem->n_nodes(); n++)
       {
-        if ((cur_elem->get_node(n))->absolute_fuzzy_equals(end_point))
+        if ((cur_elem->node_ptr(n))->absolute_fuzzy_equals(end_point))
           {
             is_vertex = true;
-            vertex = cur_elem->get_node(n);
+            vertex = cur_elem->node_ptr(n);
             break;
           }
       }
@@ -516,10 +516,10 @@ namespace GRINS
 
         for(unsigned int i=0; i<phi.size(); i++)
           {
-            X  += (*(edge_elem->get_node(i)))(0) * phi[i];
-            dX += (*(edge_elem->get_node(i)))(0) * dphi[i];
-            Y  += (*(edge_elem->get_node(i)))(1) * phi[i];
-            dY += (*(edge_elem->get_node(i)))(1) * dphi[i];
+            X  += (*(edge_elem->node_ptr(i)))(0) * phi[i];
+            dX += (*(edge_elem->node_ptr(i)))(0) * dphi[i];
+            Y  += (*(edge_elem->node_ptr(i)))(1) * phi[i];
+            dY += (*(edge_elem->node_ptr(i)))(1) * dphi[i];
           }
 
         libMesh::Real  f = tan_theta*(X-x0) - (Y-y0);
@@ -552,8 +552,8 @@ namespace GRINS
     libmesh_assert_equal_to(main_elem->refinement_flag(),libMesh::Elem::RefinementState::INACTIVE);
 
     // these nodes cannot change
-    libMesh::Node* start_node = rayfire_elem->get_node(0);
-    libMesh::Node* end_node   = rayfire_elem->get_node(1);
+    libMesh::Node* start_node = rayfire_elem->node_ptr(0);
+    libMesh::Node* end_node   = rayfire_elem->node_ptr(1);
 
     // set the rayfire_elem as INACTIVE
     rayfire_elem->set_refinement_flag(libMesh::Elem::RefinementState::INACTIVE);
@@ -568,7 +568,7 @@ namespace GRINS
             bool is_vertex = false;
             for(unsigned int n=0; n<main_elem->child(i)->n_nodes(); n++)
               {
-                if ((main_elem->child(i)->get_node(n))->absolute_fuzzy_equals(*start_node))
+                if ((main_elem->child(i)->node_ptr(n))->absolute_fuzzy_equals(*start_node))
                   {
                     is_vertex = true;
                     break;
@@ -622,7 +622,7 @@ namespace GRINS
         elem->set_node(0) = prev_node;
         elem->set_node(1) = new_node;
 
-        libmesh_assert_less( (*(elem->get_node(0))-_origin).norm(),  (*(elem->get_node(1))-_origin).norm());
+        libmesh_assert_less( (*(elem->node_ptr(0))-_origin).norm(),  (*(elem->node_ptr(1))-_origin).norm());
 
         // warn if rayfire elem is shorter than TOLERANCE
         if ( (start_point-end_point).norm() < libMesh::TOLERANCE)
@@ -671,16 +671,16 @@ namespace GRINS
               {
                 if (!start_node)
                   {
-                    start_node = rayfire_child->get_node(0);
-                    end_node = rayfire_child->get_node(1);
+                    start_node = rayfire_child->node_ptr(0);
+                    end_node = rayfire_child->node_ptr(1);
                   }
                 else
                   {
-                    if ( (this->_origin - *(rayfire_child->get_node(0))).norm() < (this->_origin - *start_node).norm() )
-                      start_node = rayfire_child->get_node(0);
+                    if ( (this->_origin - *(rayfire_child->node_ptr(0))).norm() < (this->_origin - *start_node).norm() )
+                      start_node = rayfire_child->node_ptr(0);
 
-                    if ( (this->_origin - *(rayfire_child->get_node(1))).norm() > (this->_origin - *end_node).norm() )
-                      end_node = rayfire_child->get_node(1);
+                    if ( (this->_origin - *(rayfire_child->node_ptr(1))).norm() > (this->_origin - *end_node).norm() )
+                      end_node = rayfire_child->node_ptr(1);
                   }
 
                 rayfire_child->set_refinement_flag(libMesh::Elem::RefinementState::INACTIVE);
@@ -696,7 +696,7 @@ namespace GRINS
         elem->set_node(0) = _mesh->node_ptr(start_node->id());
         elem->set_node(1) = _mesh->node_ptr(end_node->id());
 
-        libmesh_assert_less( (*(elem->get_node(0))-_origin).norm(),  (*(elem->get_node(1))-_origin).norm());
+        libmesh_assert_less( (*(elem->node_ptr(0))-_origin).norm(),  (*(elem->node_ptr(1))-_origin).norm());
 
         // add new rayfire elem to the map
         _elem_id_map[parent_elem->id()] = elem->id();

--- a/test/unit/rayfireAMR_test.C
+++ b/test/unit/rayfireAMR_test.C
@@ -545,10 +545,10 @@ namespace GRINSTesting
       const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child(1)->id() );
       CPPUNIT_ASSERT(rayfire_elem1);
 
-      CPPUNIT_ASSERT( (rayfire_elem0->get_node(0))->absolute_fuzzy_equals(origin) );
-      CPPUNIT_ASSERT( (rayfire_elem0->get_node(1))->absolute_fuzzy_equals(libMesh::Point(0.5,0.15)) );
-      CPPUNIT_ASSERT( (rayfire_elem1->get_node(0))->absolute_fuzzy_equals(libMesh::Point(0.5,0.15)) );
-      CPPUNIT_ASSERT( (rayfire_elem1->get_node(1))->absolute_fuzzy_equals(end_point) );
+      CPPUNIT_ASSERT( (rayfire_elem0->node_ptr(0))->absolute_fuzzy_equals(origin) );
+      CPPUNIT_ASSERT( (rayfire_elem0->node_ptr(1))->absolute_fuzzy_equals(libMesh::Point(0.5,0.15)) );
+      CPPUNIT_ASSERT( (rayfire_elem1->node_ptr(0))->absolute_fuzzy_equals(libMesh::Point(0.5,0.15)) );
+      CPPUNIT_ASSERT( (rayfire_elem1->node_ptr(1))->absolute_fuzzy_equals(end_point) );
     }
 
     void test_through_vertex(GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh)
@@ -576,10 +576,10 @@ namespace GRINSTesting
       const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child(3)->id() );
       CPPUNIT_ASSERT(rayfire_elem1);
 
-      CPPUNIT_ASSERT( (rayfire_elem0->get_node(0))->absolute_fuzzy_equals(origin) );
-      CPPUNIT_ASSERT( (rayfire_elem0->get_node(1))->absolute_fuzzy_equals(libMesh::Point(0.5,0.5)) );
-      CPPUNIT_ASSERT( (rayfire_elem1->get_node(0))->absolute_fuzzy_equals(libMesh::Point(0.5,0.5)) );
-      CPPUNIT_ASSERT( (rayfire_elem1->get_node(1))->absolute_fuzzy_equals(end_point) );
+      CPPUNIT_ASSERT( (rayfire_elem0->node_ptr(0))->absolute_fuzzy_equals(origin) );
+      CPPUNIT_ASSERT( (rayfire_elem0->node_ptr(1))->absolute_fuzzy_equals(libMesh::Point(0.5,0.5)) );
+      CPPUNIT_ASSERT( (rayfire_elem1->node_ptr(0))->absolute_fuzzy_equals(libMesh::Point(0.5,0.5)) );
+      CPPUNIT_ASSERT( (rayfire_elem1->node_ptr(1))->absolute_fuzzy_equals(end_point) );
     }
 
     void test_near_vertex(GRINS::SharedPtr<libMesh::UnstructuredMesh> mesh)

--- a/test/unit/rayfireAMR_test.C
+++ b/test/unit/rayfireAMR_test.C
@@ -148,7 +148,7 @@ namespace GRINSTesting
 
       // no children of elem 0 should be in the rayfire
       for (unsigned int i=0; i<4; i++)
-        CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem( mesh->elem(0)->child(i)->id() ) ) );
+        CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem( mesh->elem(0)->child_ptr(i)->id() ) ) );
     }
 
     //! Test for multiple successive refinements
@@ -193,21 +193,21 @@ namespace GRINSTesting
       mr.uniformly_refine();
       rayfire->reinit(*mesh);
 
-      // refine elem(0)->child(1)->child(1)
-      mesh->elem(0)->child(1)->child(1)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
-      // coarsen elem(0)->child(0)
-      for (unsigned int c=0; c<mesh->elem(0)->child(0)->n_children(); c++)
-        mesh->elem(0)->child(0)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+      // refine elem(0)->child_ptr(1)->child_ptr(1)
+      mesh->elem(0)->child_ptr(1)->child_ptr(1)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+      // coarsen elem(0)->child_ptr(0)
+      for (unsigned int c=0; c<mesh->elem(0)->child_ptr(0)->n_children(); c++)
+        mesh->elem(0)->child_ptr(0)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
 
       mr.refine_and_coarsen_elements();
       rayfire->reinit(*mesh);
 
-      CPPUNIT_ASSERT( mesh->elem(0)->child(0)->active() );
+      CPPUNIT_ASSERT( mesh->elem(0)->child_ptr(0)->active() );
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(1)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(1)->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->child_ptr(1)->id()) );
 
 
     }
@@ -247,17 +247,17 @@ namespace GRINSTesting
       rayfire->reinit(*mesh);
 
       // check post-refinement
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(6)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(9)->child(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(8)->child(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(6)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(9)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(8)->child_ptr(2)->id()) );
 
       // coarsen two of the TRIs
       for (unsigned int c=0; c<mesh->elem(6)->n_children(); c++)
         {
-          mesh->elem(6)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
-          mesh->elem(9)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem(6)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem(9)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
         }
 
       mr.coarsen_elements();
@@ -267,16 +267,16 @@ namespace GRINSTesting
       CPPUNIT_ASSERT( mesh->elem(9)->active() );
 
       // check post-coarsen
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(8)->child(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(8)->child_ptr(2)->id()) );
       CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(6) );
       CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(9) );
 
       for (unsigned int c=0; c<mesh->elem(6)->n_children(); c++)
         {
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(6)->child(c)->id())) );
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(9)->child(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(6)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(9)->child_ptr(c)->id())) );
         }
     }
 
@@ -297,20 +297,20 @@ namespace GRINSTesting
       GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
       rayfire->init(*mesh);
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->id()) );
 
-      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->child(2)->id())) );
-      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->child(3)->id())) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(2)->id())) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(3)->id())) );
 
       // refine again
       mr.uniformly_refine();
       rayfire->reinit(*mesh);
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->child(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->id()) );
 
       // uniformly coarsen twice to get back to a single elem
       mr.uniformly_coarsen();
@@ -374,10 +374,10 @@ namespace GRINSTesting
 
       CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(elem1->id()) );
 
-      CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(elem0->child(0)->id()) );
-      CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(elem0->child(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem0->child(2)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem0->child(3)->id()) );
+      CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(elem0->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(elem0->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem0->child_ptr(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem0->child_ptr(3)->id()) );
     }
 
     //! QUAD4 elem is deformed, rayfire goes within libMesh::TOLERANCE central node
@@ -539,10 +539,10 @@ namespace GRINSTesting
 
       rayfire->reinit(*mesh);
 
-      const libMesh::Elem* rayfire_elem0 = rayfire->map_to_rayfire_elem( elem->child(0)->id() );
+      const libMesh::Elem* rayfire_elem0 = rayfire->map_to_rayfire_elem( elem->child_ptr(0)->id() );
       CPPUNIT_ASSERT(rayfire_elem0);
 
-      const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child(1)->id() );
+      const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child_ptr(1)->id() );
       CPPUNIT_ASSERT(rayfire_elem1);
 
       CPPUNIT_ASSERT( (rayfire_elem0->node_ptr(0))->absolute_fuzzy_equals(origin) );
@@ -570,10 +570,10 @@ namespace GRINSTesting
 
       rayfire->reinit(*mesh);
 
-      const libMesh::Elem* rayfire_elem0 = rayfire->map_to_rayfire_elem( elem->child(0)->id() );
+      const libMesh::Elem* rayfire_elem0 = rayfire->map_to_rayfire_elem( elem->child_ptr(0)->id() );
       CPPUNIT_ASSERT(rayfire_elem0);
 
-      const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child(3)->id() );
+      const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child_ptr(3)->id() );
       CPPUNIT_ASSERT(rayfire_elem1);
 
       CPPUNIT_ASSERT( (rayfire_elem0->node_ptr(0))->absolute_fuzzy_equals(origin) );
@@ -601,17 +601,17 @@ namespace GRINSTesting
 
       rayfire->reinit(*mesh);
 
-      const libMesh::Elem* rayfire_elem0 = rayfire->map_to_rayfire_elem( elem->child(0)->id() );
+      const libMesh::Elem* rayfire_elem0 = rayfire->map_to_rayfire_elem( elem->child_ptr(0)->id() );
       CPPUNIT_ASSERT(rayfire_elem0);
 
-      const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child(1)->id() );
+      const libMesh::Elem* rayfire_elem1 = rayfire->map_to_rayfire_elem( elem->child_ptr(1)->id() );
       CPPUNIT_ASSERT(rayfire_elem1);
 
-      const libMesh::Elem* rayfire_elem2 = rayfire->map_to_rayfire_elem( elem->child(3)->id() );
+      const libMesh::Elem* rayfire_elem2 = rayfire->map_to_rayfire_elem( elem->child_ptr(3)->id() );
       CPPUNIT_ASSERT(rayfire_elem2);
 
       // not in rayfire
-      const libMesh::Elem* non_rayfire_elem = rayfire->map_to_rayfire_elem( elem->child(2)->id() );
+      const libMesh::Elem* non_rayfire_elem = rayfire->map_to_rayfire_elem( elem->child_ptr(2)->id() );
       CPPUNIT_ASSERT(!non_rayfire_elem);
     }
 
@@ -698,11 +698,11 @@ namespace GRINSTesting
                   if (c==children[index])
                     {
                       index++;
-                      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem( elem->child(c)->id() ) );
+                      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem( elem->child_ptr(c)->id() ) );
                     }
                 }
               else
-                CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem( elem->child(c)->id() )) );
+                CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem( elem->child_ptr(c)->id() )) );
             }
         }
     }
@@ -726,15 +726,15 @@ namespace GRINSTesting
           rayfire->reinit(*mesh);
         }
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->child(0)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->child(0)->child(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->child(1)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(0)->child(1)->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(0)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(1)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(1)->child_ptr(1)->id()) );
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(0)->child(2)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(0)->child(3)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(1)->child(2)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(1)->child(1)->child(3)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(0)->child_ptr(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(0)->child_ptr(3)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->child_ptr(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->child_ptr(3)->id()) );
 
     }
 
@@ -756,10 +756,10 @@ namespace GRINSTesting
       // coarsen specific elements along the rayfire
       for(unsigned int c=0; c<4; c++)
         {
-          mesh->elem(60)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
-          mesh->elem(25)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
-          mesh->elem(26)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
-          mesh->elem(9)->child(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem(60)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem(25)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem(26)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem(9)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
         }
 
       mr.coarsen_elements();
@@ -774,10 +774,10 @@ namespace GRINSTesting
       // and that their children are not
       for(unsigned int c=0; c<4; c++)
         {
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(60)->child(c)->id())) );
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(25)->child(c)->id())) );
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(26)->child(c)->id())) );
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(9)->child(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(60)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(25)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(26)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(9)->child_ptr(c)->id())) );
         }
     }
 
@@ -800,10 +800,10 @@ namespace GRINSTesting
       rayfire->reinit(*mesh);
 
       for (unsigned int c=0; c<children_in_rayfire.size(); c++)
-        CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child(children_in_rayfire[c])->id()) );
+        CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(children_in_rayfire[c])->id()) );
 
       for (unsigned int c=0; c<children_not_in_rayfire.size(); c++)
-        CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(mesh->elem(0)->child(children_not_in_rayfire[c])->id()) );
+        CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(children_not_in_rayfire[c])->id()) );
 
     }
 

--- a/test/unit/rayfireAMR_test.C
+++ b/test/unit/rayfireAMR_test.C
@@ -136,7 +136,7 @@ namespace GRINSTesting
       rayfire->init(*mesh);
 
       // elem 0 is not along the rayfire
-      mesh->elem(0)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+      mesh->elem_ptr(0)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
 
       libMesh::MeshRefinement mr(*mesh);
       mr.refine_elements();
@@ -144,11 +144,11 @@ namespace GRINSTesting
       rayfire->reinit(*mesh);
 
       // elem 0 should not be in the rayfire
-      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->id()) ) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->id()) ) );
 
       // no children of elem 0 should be in the rayfire
       for (unsigned int i=0; i<4; i++)
-        CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem( mesh->elem(0)->child_ptr(i)->id() ) ) );
+        CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem( mesh->elem_ptr(0)->child_ptr(i)->id() ) ) );
     }
 
     //! Test for multiple successive refinements
@@ -194,20 +194,20 @@ namespace GRINSTesting
       rayfire->reinit(*mesh);
 
       // refine elem(0)->child_ptr(1)->child_ptr(1)
-      mesh->elem(0)->child_ptr(1)->child_ptr(1)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+      mesh->elem_ptr(0)->child_ptr(1)->child_ptr(1)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
       // coarsen elem(0)->child_ptr(0)
-      for (unsigned int c=0; c<mesh->elem(0)->child_ptr(0)->n_children(); c++)
-        mesh->elem(0)->child_ptr(0)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+      for (unsigned int c=0; c<mesh->elem_ptr(0)->child_ptr(0)->n_children(); c++)
+        mesh->elem_ptr(0)->child_ptr(0)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
 
       mr.refine_and_coarsen_elements();
       rayfire->reinit(*mesh);
 
-      CPPUNIT_ASSERT( mesh->elem(0)->child_ptr(0)->active() );
+      CPPUNIT_ASSERT( mesh->elem_ptr(0)->child_ptr(0)->active() );
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->child_ptr(1)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->child_ptr(1)->child_ptr(1)->id()) );
 
 
     }
@@ -247,36 +247,36 @@ namespace GRINSTesting
       rayfire->reinit(*mesh);
 
       // check post-refinement
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(6)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(9)->child_ptr(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(8)->child_ptr(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(6)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(9)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(8)->child_ptr(2)->id()) );
 
       // coarsen two of the TRIs
-      for (unsigned int c=0; c<mesh->elem(6)->n_children(); c++)
+      for (unsigned int c=0; c<mesh->elem_ptr(6)->n_children(); c++)
         {
-          mesh->elem(6)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
-          mesh->elem(9)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem_ptr(6)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem_ptr(9)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
         }
 
       mr.coarsen_elements();
       rayfire->reinit(*mesh);
 
-      CPPUNIT_ASSERT( mesh->elem(6)->active() );
-      CPPUNIT_ASSERT( mesh->elem(9)->active() );
+      CPPUNIT_ASSERT( mesh->elem_ptr(6)->active() );
+      CPPUNIT_ASSERT( mesh->elem_ptr(9)->active() );
 
       // check post-coarsen
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(8)->child_ptr(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(8)->child_ptr(2)->id()) );
       CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(6) );
       CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(9) );
 
-      for (unsigned int c=0; c<mesh->elem(6)->n_children(); c++)
+      for (unsigned int c=0; c<mesh->elem_ptr(6)->n_children(); c++)
         {
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(6)->child_ptr(c)->id())) );
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(9)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem_ptr(6)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem_ptr(9)->child_ptr(c)->id())) );
         }
     }
 
@@ -297,20 +297,20 @@ namespace GRINSTesting
       GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
       rayfire->init(*mesh);
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->id()) );
 
-      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(2)->id())) );
-      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(3)->id())) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(2)->id())) );
+      CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(3)->id())) );
 
       // refine again
       mr.uniformly_refine();
       rayfire->reinit(*mesh);
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->child_ptr(1)->id()) );
 
       // uniformly coarsen twice to get back to a single elem
       mr.uniformly_coarsen();
@@ -319,7 +319,7 @@ namespace GRINSTesting
       rayfire->reinit(*mesh);
 
       // ensure the original elem is active
-      CPPUNIT_ASSERT( mesh->elem(0)->active() );
+      CPPUNIT_ASSERT( mesh->elem_ptr(0)->active() );
 
       // the original elem should be in the rayfire
       CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(0) );
@@ -529,7 +529,7 @@ namespace GRINSTesting
       GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
       rayfire->init(*mesh);
 
-      libMesh::Elem* elem = mesh->elem(0);
+      libMesh::Elem* elem = mesh->elem_ptr(0);
       CPPUNIT_ASSERT(elem);
 
       elem->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
@@ -560,7 +560,7 @@ namespace GRINSTesting
       GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
       rayfire->init(*mesh);
 
-      libMesh::Elem* elem = mesh->elem(0);
+      libMesh::Elem* elem = mesh->elem_ptr(0);
       CPPUNIT_ASSERT(elem);
 
       elem->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
@@ -591,7 +591,7 @@ namespace GRINSTesting
       GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
       rayfire->init(*mesh);
 
-      libMesh::Elem* elem = mesh->elem(0);
+      libMesh::Elem* elem = mesh->elem_ptr(0);
       CPPUNIT_ASSERT(elem);
 
       elem->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
@@ -663,7 +663,7 @@ namespace GRINSTesting
       std::map<unsigned int,std::vector<unsigned int> >::iterator it = refine_elems.begin();
       for(; it != refine_elems.end(); it++)
         {
-          libMesh::Elem* elem = mesh->elem( it->first );
+          libMesh::Elem* elem = mesh->elem_ptr( it->first );
           CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(elem->id()) );
           elem->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
         }
@@ -679,7 +679,7 @@ namespace GRINSTesting
       it = refine_elems.begin();
       for(; it != refine_elems.end(); it++)
         {
-          libMesh::Elem* elem = mesh->elem( it->first );
+          libMesh::Elem* elem = mesh->elem_ptr( it->first );
 
           // make sure it was refined
           CPPUNIT_ASSERT_EQUAL( elem->refinement_flag(), libMesh::Elem::RefinementState::INACTIVE );
@@ -726,15 +726,15 @@ namespace GRINSTesting
           rayfire->reinit(*mesh);
         }
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(0)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(0)->child_ptr(1)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(1)->child_ptr(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(0)->child_ptr(1)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->child_ptr(0)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->child_ptr(0)->child_ptr(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->child_ptr(1)->child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(0)->child_ptr(1)->child_ptr(1)->id()) );
 
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(0)->child_ptr(2)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(0)->child_ptr(3)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->child_ptr(2)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(1)->child_ptr(1)->child_ptr(3)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->child_ptr(0)->child_ptr(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->child_ptr(0)->child_ptr(3)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->child_ptr(1)->child_ptr(2)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(1)->child_ptr(1)->child_ptr(3)->id()) );
 
     }
 
@@ -756,10 +756,10 @@ namespace GRINSTesting
       // coarsen specific elements along the rayfire
       for(unsigned int c=0; c<4; c++)
         {
-          mesh->elem(60)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
-          mesh->elem(25)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
-          mesh->elem(26)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
-          mesh->elem(9)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem_ptr(60)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem_ptr(25)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem_ptr(26)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
+          mesh->elem_ptr(9)->child_ptr(c)->set_refinement_flag(libMesh::Elem::RefinementState::COARSEN);
         }
 
       mr.coarsen_elements();
@@ -774,10 +774,10 @@ namespace GRINSTesting
       // and that their children are not
       for(unsigned int c=0; c<4; c++)
         {
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(60)->child_ptr(c)->id())) );
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(25)->child_ptr(c)->id())) );
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(26)->child_ptr(c)->id())) );
-          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem(9)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem_ptr(60)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem_ptr(25)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem_ptr(26)->child_ptr(c)->id())) );
+          CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(mesh->elem_ptr(9)->child_ptr(c)->id())) );
         }
     }
 
@@ -789,7 +789,7 @@ namespace GRINSTesting
       GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
       rayfire->init(*mesh);
 
-      libMesh::Elem* elem = mesh->elem(0);
+      libMesh::Elem* elem = mesh->elem_ptr(0);
       CPPUNIT_ASSERT(elem);
 
       elem->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
@@ -800,10 +800,10 @@ namespace GRINSTesting
       rayfire->reinit(*mesh);
 
       for (unsigned int c=0; c<children_in_rayfire.size(); c++)
-        CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(children_in_rayfire[c])->id()) );
+        CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(children_in_rayfire[c])->id()) );
 
       for (unsigned int c=0; c<children_not_in_rayfire.size(); c++)
-        CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(mesh->elem(0)->child_ptr(children_not_in_rayfire[c])->id()) );
+        CPPUNIT_ASSERT( !rayfire->map_to_rayfire_elem(mesh->elem_ptr(0)->child_ptr(children_not_in_rayfire[c])->id()) );
 
     }
 

--- a/test/unit/rayfire_test.C
+++ b/test/unit/rayfire_test.C
@@ -334,8 +334,8 @@ namespace GRINSTesting
       if (!rayfire_elem)
         libmesh_error_msg("Attempted to map an element that is not in the Rayfire");
 
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(0), (*(rayfire_elem->get_node(1)))(0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(1), (*(rayfire_elem->get_node(1)))(1),libMesh::TOLERANCE);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(0), (*(rayfire_elem->node_ptr(1)))(0),libMesh::TOLERANCE);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(calc_end_point(1), (*(rayfire_elem->node_ptr(1)))(1),libMesh::TOLERANCE);
     }
 
     GRINS::SharedPtr<libMesh::UnstructuredMesh> build_mesh( const GetPot& input )

--- a/test/unit/rayfire_test.C
+++ b/test/unit/rayfire_test.C
@@ -327,7 +327,7 @@ namespace GRINSTesting
       GRINS::SharedPtr<GRINS::RayfireMesh> rayfire = new GRINS::RayfireMesh(origin,theta);
       rayfire->init(*mesh);
 
-      const libMesh::Elem* original_elem = mesh->elem(exit_elem);
+      const libMesh::Elem* original_elem = mesh->elem_ptr(exit_elem);
 
       const libMesh::Elem* rayfire_elem = rayfire->map_to_rayfire_elem(original_elem->id());
 


### PR DESCRIPTION
Had these floating around, figured I should do a PR before they get lost.

These commits remove deprecated libMesh function calls in `RayfireMesh` (and associated tests) and replace them with their preferred versions.