### PR TITLE
Eliminate deprecated code usage

### DIFF
--- a/src/boundary_conditions/src/default_bc_builder.C
+++ b/src/boundary_conditions/src/default_bc_builder.C
@@ -477,7 +477,7 @@ namespace GRINS
 
     for( unsigned int i = 0; i < elem_ids.size(); i++ )
       {
-        const libMesh::Elem* elem_ptr = mesh.elem(elem_ids[i]);
+        const libMesh::Elem* elem_ptr = mesh.elem_ptr(elem_ids[i]);
 
         libMesh::subdomain_id_type subdomain_id = elem_ptr->subdomain_id();
 

--- a/src/physics/src/averaged_fan_base.C
+++ b/src/physics/src/averaged_fan_base.C
@@ -126,7 +126,7 @@ namespace GRINS
                                          output_vec(1),
                                          output_vec(2));
 
-    const libMesh::Number U_B_size = U_B.size();
+    const libMesh::Number U_B_size = U_B.norm();
 
     // If there's no base velocity there's no fan
     if (!U_B_size)
@@ -151,7 +151,7 @@ namespace GRINS
     // Fan-wing-plane component of local relative velocity
     const libMesh::NumberVectorValue U_P = U - (U*N_R)*N_R - U_B;
 
-    const libMesh::Number U_P_size = U_P.size();
+    const libMesh::Number U_P_size = U_P.norm();
 
     // If there's no flow in the fan's frame of reference, there's no
     // lift or drag.  FIXME - should we account for drag in the

--- a/src/physics/src/averaged_turbine_base.C
+++ b/src/physics/src/averaged_turbine_base.C
@@ -54,7 +54,7 @@ namespace GRINS
   template<class Mu>
   void AveragedTurbineBase<Mu>::set_time_evolving_vars( libMesh::FEMSystem* system )
   {
-    system->time_evolving(this->fan_speed_var());
+    system->time_evolving(this->fan_speed_var(), 1);
 
     IncompressibleNavierStokesBase<Mu>::set_time_evolving_vars(system);
   }

--- a/src/physics/src/averaged_turbine_base.C
+++ b/src/physics/src/averaged_turbine_base.C
@@ -162,7 +162,7 @@ namespace GRINS
 
     const libMesh::NumberVectorValue U_B = U_B_1 * s;
 
-    const libMesh::Number U_B_size = U_B.size();
+    const libMesh::Number U_B_size = U_B.norm();
 
     // If there's no base velocity there's no fan
     if (!U_B_size)
@@ -186,7 +186,7 @@ namespace GRINS
     // Fan-wing-plane component of local relative velocity
     const libMesh::NumberVectorValue U_P = U - (U*N_R)*N_R - U_B;
 
-    const libMesh::Number U_P_size = U_P.size();
+    const libMesh::Number U_P_size = U_P.norm();
 
     // If there's no flow in the fan's frame of reference, there's no
     // lift or drag.  FIXME - should we account for drag in the

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -71,7 +71,7 @@ namespace GRINS
   void AxisymmetricHeatTransfer<Conductivity>::set_time_evolving_vars( libMesh::FEMSystem* system )
   {
     // Tell the system to march temperature forward in time
-    system->time_evolving(this->_temp_vars.T());
+    system->time_evolving(this->_temp_vars.T(), 1);
   }
 
   template< class Conductivity>

--- a/src/physics/src/convection_diffusion.C
+++ b/src/physics/src/convection_diffusion.C
@@ -67,7 +67,7 @@ namespace GRINS
 
   void ConvectionDiffusion::set_time_evolving_vars( libMesh::FEMSystem* system )
   {
-    system->time_evolving(_var.var());
+    system->time_evolving(_var.var(), 1);
   }
 
   void ConvectionDiffusion::init_context( AssemblyContext& context )

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -65,7 +65,7 @@ namespace GRINS
   void HeatConduction<K>::set_time_evolving_vars( libMesh::FEMSystem* system )
   {
     // Tell the system to march temperature forward in time
-    system->time_evolving(_temp_vars.T());
+    system->time_evolving(_temp_vars.T(), 1);
   }
 
   template<class K>

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -68,7 +68,7 @@ namespace GRINS
   void HeatTransferBase<K>::set_time_evolving_vars( libMesh::FEMSystem* system )
   {
     // Tell the system to march temperature forward in time
-    system->time_evolving(_temp_vars.T());
+    system->time_evolving(_temp_vars.T(), 1);
   }
 
   template<class K>

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -74,13 +74,13 @@ namespace GRINS
 
     // Tell the system to march velocity forward in time, but
     // leave p as a constraint only
-    system->time_evolving(_flow_vars.u());
+    system->time_evolving(_flow_vars.u(), 1);
 
     if (dim > 1)
-      system->time_evolving(_flow_vars.v());
+      system->time_evolving(_flow_vars.v(), 1);
 
     if (dim == 3)
-      system->time_evolving(_flow_vars.w());
+      system->time_evolving(_flow_vars.w(), 1);
   }
 
   template<class Mu>

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -117,19 +117,19 @@ namespace GRINS
   {
     const unsigned int dim = system->get_mesh().mesh_dimension();
 
-    system->time_evolving(_flow_vars.u());
+    system->time_evolving(_flow_vars.u(), 1);
 
     if (dim > 1)
-      system->time_evolving(_flow_vars.v());
+      system->time_evolving(_flow_vars.v(), 1);
 
     if (dim == 3)
-      system->time_evolving(_flow_vars.w());
+      system->time_evolving(_flow_vars.w(), 1);
 
-    system->time_evolving(_temp_vars.T());
-    system->time_evolving(_press_var.p());
+    system->time_evolving(_temp_vars.T(), 1);
+    system->time_evolving(_press_var.p(), 1);
 
     if( _enable_thermo_press_calc )
-      system->time_evolving(_p0_var->p0());
+      system->time_evolving(_p0_var->p0(), 1);
   }
 
   template<class Mu, class SH, class TC>

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -503,7 +503,8 @@ namespace GRINS
     AssemblyContext& assembly_context =
       libMesh::cast_ref<AssemblyContext&>( context );
 
-    std::vector<BoundaryID> ids = assembly_context.side_boundary_ids();
+    std::vector<BoundaryID> ids;
+    assembly_context.side_boundary_ids(ids);
 
     bool compute_jacobian = request_jacobian;
     if( !request_jacobian || _use_numerical_jacobians_only ) compute_jacobian = false;

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -108,22 +108,22 @@ namespace GRINS
 
     for( unsigned int i = 0; i < this->_n_species; i++ )
       {
-        system->time_evolving( _species_vars.species(i) );
+        system->time_evolving( _species_vars.species(i), 1 );
       }
 
-    system->time_evolving(_flow_vars.u());
+    system->time_evolving(_flow_vars.u(), 1);
 
     if (dim > 1)
-      system->time_evolving(_flow_vars.v());
+      system->time_evolving(_flow_vars.v(), 1);
 
     if (dim == 3)
-      system->time_evolving(_flow_vars.w());
+      system->time_evolving(_flow_vars.w(), 1);
 
-    system->time_evolving(_temp_vars.T());
-    system->time_evolving(_press_var.p());
+    system->time_evolving(_temp_vars.T(), 1);
+    system->time_evolving(_press_var.p(), 1);
 
     if( _enable_thermo_press_calc )
-      system->time_evolving(_p0_var->p0());
+      system->time_evolving(_p0_var->p0(), 1);
   }
 
   void ReactingLowMachNavierStokesAbstract::init_context( AssemblyContext& context )

--- a/src/physics/src/scalar_ode.C
+++ b/src/physics/src/scalar_ode.C
@@ -50,7 +50,7 @@ namespace GRINS
 
   void ScalarODE::set_time_evolving_vars( libMesh::FEMSystem* system )
   {
-    system->time_evolving(this->scalar_ode_var());
+    system->time_evolving(this->scalar_ode_var(), 1);
 
     // FIXME: this doesn't fit here at all, but it's the only time
     // we've clearly got a System to grab hold of with all it's

--- a/src/physics/src/solid_mechanics_abstract.C
+++ b/src/physics/src/solid_mechanics_abstract.C
@@ -56,13 +56,13 @@ namespace GRINS
   {
     // Tell the system to march displacement forward in time, for as
     // many displacement variables as the dimension we're tracking
-    system->time_evolving(_disp_vars.u());
+    system->time_evolving(_disp_vars.u(), 1);
 
     if( this->_disp_vars.dim() > 1 )
-      system->time_evolving(_disp_vars.v());
+      system->time_evolving(_disp_vars.v(), 1);
 
     if( this->_disp_vars.dim() > 2 )
-      system->time_evolving(_disp_vars.w());
+      system->time_evolving(_disp_vars.w(), 1);
   }
 
 } // end namespace GRINS

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -116,7 +116,7 @@ namespace GRINS
   {
     // Tell the system to march velocity forward in time, but
     // leave p as a constraint only
-    system->time_evolving(this->_turbulence_vars.nu());
+    system->time_evolving(this->_turbulence_vars.nu(), 1);
   }
 
   template<class Mu>

--- a/src/physics/src/velocity_drag_base.C
+++ b/src/physics/src/velocity_drag_base.C
@@ -68,7 +68,7 @@ namespace GRINS
     libMesh::NumberVectorValue& F,
     libMesh::NumberTensorValue *dFdU)
   {
-    const libMesh::Number Umag = U.size();
+    const libMesh::Number Umag = U.norm();
 
     const libMesh::Number coeff_val = _coefficient(point, time);
 

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -57,7 +57,7 @@ namespace GRINS
     _mesh_refinement->node_level_mismatch_limit() = _mesh_adaptivity_options.node_level_mismatch_limit();
     _mesh_refinement->edge_level_mismatch_limit() = _mesh_adaptivity_options.edge_level_mismatch_limit();
     _mesh_refinement->face_level_mismatch_limit() = _mesh_adaptivity_options.face_level_mismatch_limit();
-    _mesh_refinement->set_enforce_mismatch_limit_prior_to_refinement(_mesh_adaptivity_options.enforce_mismatch_limit_prior_to_refinement());
+    _mesh_refinement->enforce_mismatch_limit_prior_to_refinement() = _mesh_adaptivity_options.enforce_mismatch_limit_prior_to_refinement();
     _mesh_refinement->max_h_level() = _mesh_adaptivity_options.max_h_level();
   }
 

--- a/test/exact_soln/stokes_poiseuille_flow.sh
+++ b/test/exact_soln/stokes_poiseuille_flow.sh
@@ -13,7 +13,7 @@ ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT $PETSC_OPTIONS
 # Now run the test part to make sure we're getting the correct thing
 ${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app \
                  --input $INPUT vars='u v p' \
-                 norms='L2' tol='5.0e-9' \
+                 norms='L2' tol='1.0e-8' \
                  u_L2_error='1.0e-10' \
                  v_L2_error='1.0e-10' \
                  p_L2_error='1.0e-10' \

--- a/test/unit/integrated_function_test.C
+++ b/test/unit/integrated_function_test.C
@@ -273,13 +273,13 @@ namespace GRINSTesting
                     libmesh_error_msg("Exceeded maximum iterations");
 
                   for (unsigned int i=0; i<elems_in_rayfire.size(); i++)
-                    system->get_mesh().elem(elems_in_rayfire[i])->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+                    system->get_mesh().elem_ref(elems_in_rayfire[i]).set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
 
                   mr.refine_elements();
 
                   // ensure all elems marked for refinement were actually refined
                   for (unsigned int i=0; i<elems_in_rayfire.size(); i++)
-                    CPPUNIT_ASSERT( !( system->get_mesh().elem(elems_in_rayfire[i])->active() ) );
+                    CPPUNIT_ASSERT( !( system->get_mesh().elem_ref(elems_in_rayfire[i]).active() ) );
 
                   // need to manually reinit the reference rayfire
                   ref_rayfire->reinit(system->get_mesh());
@@ -371,7 +371,7 @@ namespace GRINSTesting
       CPPUNIT_ASSERT_EQUAL((unsigned int)3,num_rayfire_elems);
 
       for (unsigned int i=0; i<elems_in_rayfire.size(); i++)
-        system->get_mesh().elem(elems_in_rayfire[i])->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+        system->get_mesh().elem_ref(elems_in_rayfire[i]).set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
 
       mr.refine_elements();
 

--- a/test/unit/rayfireAMR_test.C
+++ b/test/unit/rayfireAMR_test.C
@@ -468,11 +468,11 @@ namespace GRINSTesting
 
       // refine elem 1 before rayfire init
       libMesh::MeshRefinement mr(*mesh);
-      mesh->elem(1)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
+      mesh->elem_ptr(1)->set_refinement_flag(libMesh::Elem::RefinementState::REFINE);
       mr.refine_elements();
 
-      CPPUNIT_ASSERT( !(mesh->elem(1)->active()) );
-      CPPUNIT_ASSERT( mesh->elem(1)->has_children() );
+      CPPUNIT_ASSERT( !(mesh->elem_ptr(1)->active()) );
+      CPPUNIT_ASSERT( mesh->elem_ptr(1)->has_children() );
 
       libMesh::Point origin(0.0,0.1);
       libMesh::Real theta = 0.0;
@@ -489,8 +489,8 @@ namespace GRINSTesting
       CPPUNIT_ASSERT( !(rayfire->map_to_rayfire_elem(1)) );
 
       // rayfire should contain children 0,1 of elem 1
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(1)->child(0)->id()) );
-      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem(1)->child(1)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ref(1).child_ptr(0)->id()) );
+      CPPUNIT_ASSERT( rayfire->map_to_rayfire_elem(mesh->elem_ref(1).child_ptr(1)->id()) );
     }
 
   private:


### PR DESCRIPTION
This gets rid of everything that libmesh/libmesh#1452 catches at compile time, at least.