### PR TITLE
HITRAN bugfix

### DIFF
--- a/src/qoi/include/grins/hitran.h
+++ b/src/qoi/include/grins/hitran.h
@@ -130,10 +130,10 @@ namespace GRINS
     std::vector<std::vector<libMesh::Real>> _qT;
 
     //! Find the index into _T corresponding to the given temperature
-    int _T_index(libMesh::Real T);
+    int T_index(libMesh::Real T);
 
     //! Search through the partition function data to get value for given temperature
-    libMesh::Real search_partition_function(libMesh::Real T, unsigned int iso);
+    libMesh::Real get_partition_function_value(libMesh::Real T, unsigned int iso);
 
     //! Linear interpolation helper function
     libMesh::Real interpolate_values( int index_r, libMesh::Real T_star, const std::vector<libMesh::Real> & y) const;

--- a/src/qoi/src/hitran.C
+++ b/src/qoi/src/hitran.C
@@ -145,7 +145,7 @@ namespace GRINS
 
     // cache the partition function values at the referece temperature
     for(unsigned int i=0; i<_qT.size(); i++)
-      _qT0.push_back(this->search_partition_function(_T0,i));
+      _qT0.push_back(this->get_partition_function_value(_T0,i));
 
     return;
   }
@@ -210,16 +210,16 @@ namespace GRINS
     if (T==_T0)
       qt = _qT0[iso];
     else
-      qt = this->search_partition_function(T,iso);
+      qt = this->get_partition_function_value(T,iso);
 
     return qt;
   }
 
-  libMesh::Real HITRAN::search_partition_function(libMesh::Real T, unsigned int iso)
+  libMesh::Real HITRAN::get_partition_function_value(libMesh::Real T, unsigned int iso)
   {
     libMesh::Real retval = -1.0;
 
-    int i = _T_index(T);
+    int i = T_index(T);
 
     if (i >= 0)
       retval = this->interpolate_values(i,T,_qT[iso]);
@@ -233,7 +233,7 @@ namespace GRINS
     return retval;
   }
 
-  int HITRAN::_T_index(libMesh::Real T)
+  int HITRAN::T_index(libMesh::Real T)
   {
     unsigned int index = std::ceil((T-_Tmin)/_Tstep) + 1;
     return index;

--- a/src/qoi/src/hitran.C
+++ b/src/qoi/src/hitran.C
@@ -235,7 +235,8 @@ namespace GRINS
 
   int HITRAN::T_index(libMesh::Real T)
   {
-    unsigned int index = std::ceil((T-_Tmin)/_Tstep) + 1;
+    unsigned int index = std::ceil((T-_Tmin)/_Tstep);
+    index = std::max(index,(unsigned int)1);
     return index;
   }
 

--- a/test/unit/hitran_test.C
+++ b/test/unit/hitran_test.C
@@ -65,39 +65,55 @@ namespace GRINSTesting
 
       GRINS::HITRAN hitran(data_file,partition_file,T_min,T_max,T_step);
 
+      libMesh::Real tolerance = 1.0e-9;
+
       // test getting arbitrary data values
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(0,hitran.isotopologue(0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(3,hitran.isotopologue(20),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(3682.70083,hitran.nu0(0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(3682.761088,hitran.nu0(20),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(1.062e-30,hitran.sw(0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(1.48e-30,hitran.sw(20),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0685,hitran.gamma_air(0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0679,hitran.gamma_air(20),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.084,hitran.gamma_self(0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.08,hitran.gamma_self(20),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(3253.949,hitran.elower(0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(1349.8942,hitran.elower(20),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.76,hitran.n_air(0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.75,hitran.n_air(20),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(-0.008269,hitran.delta_air(0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(-0.004588,hitran.delta_air(20),libMesh::TOLERANCE);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0,hitran.isotopologue(0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(3,hitran.isotopologue(20),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(3682.70083,hitran.nu0(0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(3682.761088,hitran.nu0(20),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(1.062e-30,hitran.sw(0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(1.48e-30,hitran.sw(20),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0685,hitran.gamma_air(0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0679,hitran.gamma_air(20),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.084,hitran.gamma_self(0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.08,hitran.gamma_self(20),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(3253.949,hitran.elower(0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(1349.8942,hitran.elower(20),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.76,hitran.n_air(0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.75,hitran.n_air(20),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(-0.008269,hitran.delta_air(0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(-0.004588,hitran.delta_air(20),tolerance);
 
 
       // these T values are explicitly given in the partition sum data
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(279.609573308,hitran.partition_function(290.02,0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(563.425588693,hitran.partition_function(290.02,1),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(593.852717624,hitran.partition_function(290.02,2),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(3461.78001223,hitran.partition_function(290.02,3),libMesh::TOLERANCE);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(279.609573308,hitran.partition_function(290.02,0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(563.425588693,hitran.partition_function(290.02,1),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(593.852717624,hitran.partition_function(290.02,2),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(3461.78001223,hitran.partition_function(290.02,3),tolerance);
+
+      // check T value on the ends
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(279.585269287,hitran.partition_function(290.0,0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(563.375898926,hitran.partition_function(290.0,1),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(593.800881348,hitran.partition_function(290.0,2),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(3461.47846875,hitran.partition_function(290.0,3),tolerance);
+      
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(304.559997559,hitran.partition_function(310.0,0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(614.489990234,hitran.partition_function(310.0,1),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(647.090026855,hitran.partition_function(310.0,2),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(3771.39990234,hitran.partition_function(310.0,3),tolerance);
+      
 
       // partition function values at the reference temperature T=296K
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(286.93557306,hitran.partition_function(296,0),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(578.40836146,hitran.partition_function(296,1),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(609.47975297,hitran.partition_function(296,2),libMesh::TOLERANCE);
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(3552.67876127,hitran.partition_function(296,3),libMesh::TOLERANCE);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(286.935573058,hitran.partition_function(296,0),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(578.408361459,hitran.partition_function(296,1),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(609.479752969,hitran.partition_function(296,2),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(3552.67876127,hitran.partition_function(296,3),tolerance);
 
       // this T value is not is the partition sum data, and must be (linearly) interpolated
-      CPPUNIT_ASSERT_DOUBLES_EQUAL(593.81384024,hitran.partition_function(290.005,2),libMesh::TOLERANCE);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(593.813840240,hitran.partition_function(290.005,2),tolerance);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(291.9025545935294,hitran.partition_function(300+1.0e-6,0),1.0e-13);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(291.9137901096000,hitran.partition_function(300.009,0),1.0e-13);
 
     }
   };


### PR DESCRIPTION
Main fix is where `HITRAN::T_index()` returned an index that was too high. It should return the index corresponding to the next data value higher than the given `T` but it was actually giving 2 indices higher for most cases.

Should use `std::floor(...) + 1` in all cases. Added additional tests with answer values obtained from `MATLAB interp1()` for verification. I also upped the tolerance for all tests because the previously returned incorrect values differed in the 8th digit and would not fail if using `libMesh::TOLERANCE = 1e-6`

Also updated private function names to match conventions and better describe their functionality.