### PR TITLE
AbsorptionCoeff component derivatives

### DIFF
--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -130,13 +130,46 @@ namespace GRINS
     std::vector<std::vector<libMesh::Real> > _voigt_coeffs;
 
     //! Absorption coefficient [cm^-1]
-    libMesh::Real kv(libMesh::Real P,libMesh::Real T, libMesh::Real X, libMesh::Real M);
+    libMesh::Real kv(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Absorption coefficient temperature derivative
+    libMesh::Real d_kv_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Absorption coefficient pressure derivative
+    libMesh::Real d_kv_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Absorption coefficient mass fraction derivative
+    libMesh::Real d_kv_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Linestrength [cm^-2 atm^-1]
+    libMesh::Real Sw(libMesh::Real T, libMesh::Real P, unsigned int i);
+
+    //! Linestrength temperature derivative
+    libMesh::Real dS_dT(libMesh::Real T, libMesh::Real P, unsigned int i);
+
+    //! Linestrength pressure derivative
+    libMesh::Real dS_dP(libMesh::Real T, libMesh::Real P, unsigned int i);
 
     //! Doppler broadening [cm^-1]
-    libMesh::Real nu_D(libMesh::Real nu, libMesh::Real T,libMesh::Real M);
+    libMesh::Real nu_D(libMesh::Real T, libMesh::Real P, unsigned int i);
+
+    //! Doppler broadening temperature derivative
+    libMesh::Real d_nuD_dT(libMesh::Real T, libMesh::Real P, unsigned int i);
+
+    //! Doppler broadening pressure derivative
+    libMesh::Real d_nuD_dP(libMesh::Real T, unsigned int i);
 
     //! Collisional broadening [cm^-1]
-    libMesh::Real nu_C(libMesh::Real T,libMesh::Real X,libMesh::Real P,unsigned int index);
+    libMesh::Real nu_C(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Collisional broadening temperature derivative
+    libMesh::Real d_nuC_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Collisional broadening pressure derivative
+    libMesh::Real d_nuC_dP(libMesh::Real T, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Collisional broadening mass fraction derivative
+    libMesh::Real d_nuC_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
 
     //! Calculate the Voigt profile [cm^-1]
     /*!
@@ -146,10 +179,52 @@ namespace GRINS
       McLean A, Mitchell C, Swanston D\n
       Journal of Electron Spectroscopy and Related Phenomena 1994 vol: 69 (2) pp: 125-132
     */
-    libMesh::Real voigt(libMesh::Real nu_D, libMesh::Real nu_c, libMesh::Real nu);
+    libMesh::Real voigt(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Voigt profile temperature derivative
+    libMesh::Real d_voigt_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Voigt profile pressure derivative
+    libMesh::Real d_voigt_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Voigt profile mass fraction derivative
+    libMesh::Real d_voigt_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
 
     //! Initialize the coeff matrix for calculating the Voigt profile
     void init_voigt();
+
+    //! Voigt a parameter
+    libMesh::Real voigt_a(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Voigt a parameter temperature derivative
+    libMesh::Real d_voigt_a_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Voigt a parameter pressure derivative
+    libMesh::Real d_voigt_a_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Voigt a parameter mass fraction derivative
+    libMesh::Real d_voigt_a_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+
+    //! Voigt w parameter
+    libMesh::Real voigt_w(libMesh::Real T, libMesh::Real P, unsigned int i);
+
+    //! Voigt w parameter temperature derivative
+    libMesh::Real d_voigt_w_dT(libMesh::Real T, libMesh::Real P, unsigned int i);
+
+    //! Voigt w parameter pressure derivative
+    libMesh::Real d_voigt_w_dP(libMesh::Real T, libMesh::Real P, unsigned int i);
+
+    //! Pressure shift of linecenter wavenumber
+    libMesh::Real get_nu(libMesh::Real P, unsigned int i);
+
+    //! Derivative of pressure-shifted linecenter wavenumber
+    libMesh::Real d_nu_dP(unsigned int i);
+
+    //! Mole fraction derivative with respect to mass fraction
+    libMesh::Real dX_dY(std::vector<libMesh::Real> Y);
+
+    //! Partition Function derivative (finite difference)
+    libMesh::Real dQ_dT(libMesh::Real T, unsigned int iso);
 
     //! User should not call empty constructor
     AbsorptionCoeff();

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -88,7 +88,7 @@ namespace GRINS
     //! Not used
     virtual libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Real> > clone() const;
 
-  private:
+  protected:
     //! Antioch/Cantera object
     SharedPtr<Chemistry> _chemistry;
 

--- a/src/qoi/include/grins/hitran.h
+++ b/src/qoi/include/grins/hitran.h
@@ -100,6 +100,9 @@ namespace GRINS
     //! Return the data size
     unsigned int get_data_size();
 
+    //! Finite difference derivative for partition function
+    libMesh::Real partition_function_derivative(libMesh::Real T, unsigned int iso);
+
   protected:
     libMesh::Real _Tmin, _Tmax, _Tstep;
 

--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -52,7 +52,7 @@ namespace GRINS
       _Y_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<SpeciesMassFractionsVariable>("SpeciesMassFractions")),
       _T0(296), // [K]
       _Pref(1), // [atm]
-      _rad_coeff(1.43887752) // [cm K]
+      _rad_coeff(Constants::second_rad_const * 100) // [cm K]
   {
     // sanity checks
     if ( (nu_min>nu_max) || (desired_nu>nu_max) || (desired_nu<nu_min) )
@@ -140,7 +140,7 @@ namespace GRINS
     libMesh::Real M_mix = _chemistry->M_mix(Y); // [kg/mol]
     libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
 
-    P /= 101325.0; // convert to [atm]
+    P /= Constants::atmosphere_Pa; // convert to [atm]
 
     return this->kv(P,T,X,M);
 
@@ -196,7 +196,7 @@ namespace GRINS
         libMesh::Real S = sw0 * (QT0/QT) * std::exp(-E*_rad_coeff*( (1.0/T) - (1.0/_T0) )) * ( 1.0-std::exp(-_rad_coeff*nu/T) ) * pow(1.0-std::exp(-_rad_coeff*nu/_T0),-1.0);
 
         // convert linestrength units to [cm^-2 atm^-1]
-        libMesh::Real loschmidt = (101325.0*1.0e-6)/(T*Constants::Boltzmann);
+        libMesh::Real loschmidt = (Constants::atmosphere_Pa*1.0e-6)/(T*Constants::Boltzmann);
         S = S*loschmidt;
 
         // collisional FWHM [cm^-1]

--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -25,6 +25,8 @@
 
 // This class
 #include "grins/absorption_coeff.h"
+
+// GRINS
 #include "grins/variable_warehouse.h"
 #include "grins/physical_constants.h"
 #include "grins/math_constants.h"
@@ -36,6 +38,10 @@
 #if GRINS_HAVE_CANTERA
 #include "grins/cantera_mixture.h"
 #endif
+
+// libMesh
+#include "libmesh/fe.h"
+#include "libmesh/elem.h"
 
 namespace GRINS
 {
@@ -116,8 +122,12 @@ namespace GRINS
   template<typename Chemistry>
   libMesh::Real AbsorptionCoeff<Chemistry>::operator()(const libMesh::FEMContext& context, const libMesh::Point& qp_xyz, const libMesh::Real /*t*/)
   {
+    START_LOG("operator()","AbsorptionCoeff");
     libMesh::Real T,p,thermo_p; // temperature, hydrostatic pressure, thermodynamic pressure
     std::vector<libMesh::Real> Y(_chemistry->n_species()); // mass fractions
+    
+    for (unsigned int s=0; s<_chemistry->n_species(); s++)
+      context.point_value(_Y_var.species(s), qp_xyz, Y[s]);
 
     context.point_value(_T_var.T(), qp_xyz, T); // [K]
 
@@ -132,25 +142,20 @@ namespace GRINS
     libMesh::Real P = p + thermo_p; // total pressure [Pa]
     libmesh_assert_greater(P,0.0);
 
-    // all mass fractions needed to get M_mix
-    for (unsigned int s=0; s<_chemistry->n_species(); s++)
-      context.point_value(_Y_var.species(s), qp_xyz, Y[s]);
+    libMesh::Real kv = 0.0;
 
-    libMesh::Real M = _chemistry->M(_species_idx); // [kg/mol]
-    libMesh::Real M_mix = _chemistry->M_mix(Y); // [kg/mol]
-    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+    for (unsigned int i=_min_index; i<=_max_index; i++)
+      kv += this->kv(T,P,Y,i);
 
-    P /= Constants::atmosphere_Pa; // convert to [atm]
-
-    return this->kv(P,T,X,M);
-
+    STOP_LOG("operator()","AbsorptionCoeff");
+    return kv;
   }
 
   template<typename Chemistry>
-  void AbsorptionCoeff<Chemistry>::operator()( const libMesh::FEMContext& /*context*/,
-                                               const libMesh::Point& /*p*/,
+  void AbsorptionCoeff<Chemistry>::operator()( const libMesh::FEMContext & /*context*/,
+                                               const libMesh::Point & /*p*/,
                                                const libMesh::Real /*time*/,
-                                               libMesh::DenseVector<libMesh::Real>& /*output*/)
+                                               libMesh::DenseVector<libMesh::Real> & /*output*/)
   {
     libmesh_not_implemented();
   }
@@ -161,88 +166,247 @@ namespace GRINS
     libmesh_not_implemented();
   }
 
+
   template<typename Chemistry>
-  libMesh::Real AbsorptionCoeff<Chemistry>::kv(libMesh::Real P,libMesh::Real T,libMesh::Real X,libMesh::Real M)
+  libMesh::Real AbsorptionCoeff<Chemistry>::kv(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
   {
-    libMesh::Real kv = 0.0;
+    // linestrength
+    libMesh::Real S = this->Sw(T,P,i);
 
-    for (unsigned int i=_min_index; i<=_max_index; i++)
-      {
-        // isotopologue
-        unsigned int iso = _hitran->isotopologue(i);
+    // Voigt profile [cm^-1]
+    libMesh::Real phi_V = this->voigt(T,P,Y,i);
 
-        // linecenter wavenumber
-        libMesh::Real nu0 = _hitran->nu0(i);
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]); 
 
-        // linestrength
-        libMesh::Real sw0 = _hitran->sw(i);
-
-        // partition function at reference temp
-        libMesh::Real QT0 = _hitran->partition_function(_T0,iso);
-
-        // partition function at current temp
-        libMesh::Real QT = _hitran->partition_function(T,iso);
-
-        // lower state energy of transition
-        libMesh::Real E = _hitran->elower(i);
-
-        // air pressure-induced line shift
-        libMesh::Real d_air = _hitran->delta_air(i);
-
-        // pressure shift of the linecenter wavenumber
-        libMesh::Real nu = nu0 + d_air*(P/_Pref);
-
-        // linestrength
-        libMesh::Real S = sw0 * (QT0/QT) * std::exp(-E*_rad_coeff*( (1.0/T) - (1.0/_T0) )) * ( 1.0-std::exp(-_rad_coeff*nu/T) ) * pow(1.0-std::exp(-_rad_coeff*nu/_T0),-1.0);
-
-        // convert linestrength units to [cm^-2 atm^-1]
-        libMesh::Real loschmidt = (Constants::atmosphere_Pa*1.0e-6)/(T*Constants::Boltzmann);
-        S = S*loschmidt;
-
-        // collisional FWHM [cm^-1]
-        libMesh::Real nu_c = this->nu_C(T,X,P,i);
-
-        // Doppler FWHM [cm^-1]
-        libMesh::Real nu_D = this->nu_D(nu,T,M);
-
-        // Voigt profile [cm^-1]
-        libMesh::Real phi_V = this->voigt(nu_D,nu_c,nu);
-
-        // absorption coefficient [cm^-1]
-        kv += S*P*X*phi_V;
-      }
-
-    return kv;
+    // absorption coefficient [cm^-1]
+    return S*(P/Constants::atmosphere_Pa)*X*phi_V;
   }
 
   template<typename Chemistry>
-  libMesh::Real AbsorptionCoeff<Chemistry>::nu_D(libMesh::Real nu,libMesh::Real T,libMesh::Real M)
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_kv_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real dS = dS_dT(T,P,i);
+    libMesh::Real dV = d_voigt_dT(T,P,Y,i);
+
+    libMesh::Real S = this->Sw(T,P,i);
+    libMesh::Real V = this->voigt(T,P,Y,i);
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return X*(P/Constants::atmosphere_Pa) * ( S*dV + dS*V );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_kv_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real dS = dS_dP(T,P,i);
+    libMesh::Real dV = d_voigt_dP(T,P,Y,i);
+
+    libMesh::Real S = this->Sw(T,P,i);
+    libMesh::Real V = this->voigt(T,P,Y,i);
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return X * ( S*(P/Constants::atmosphere_Pa)*dV + S*(1.0/Constants::atmosphere_Pa)*V + dS*P*V );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_kv_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real dX = dX_dY(Y);
+    libMesh::Real dV = d_voigt_dY(T,P,Y,i);
+
+    libMesh::Real S = this->Sw(T,P,i);
+    libMesh::Real V = this->voigt(T,P,Y,i);
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+    
+    return S*(P/Constants::atmosphere_Pa) * ( X*dV + dX*V );
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::Sw(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    // isotopologue
+    unsigned int iso = _hitran->isotopologue(i);
+
+    // linecenter wavenumber
+    libMesh::Real nu = this->get_nu(P,i);
+
+    // linestrength
+    libMesh::Real sw0 = _hitran->sw(i);
+
+    // lower state energy of transition
+    libMesh::Real E = _hitran->elower(i);
+
+    // partition function at reference temp
+    libMesh::Real QT0 = _hitran->partition_function(_T0,iso);
+
+    // partition function at current temp
+    libMesh::Real QT = _hitran->partition_function(T,iso);
+
+    libMesh::Real a = sw0;
+    libMesh::Real b = (QT0/QT);
+    libMesh::Real c = std::exp(-E*_rad_coeff*( (1.0/T) - (1.0/_T0) ));
+    libMesh::Real d = ( 1.0-std::exp(-_rad_coeff*nu/T) );
+    libMesh::Real e = std::pow(1.0-std::exp(-_rad_coeff*nu/_T0),-1.0);
+
+    libMesh::Real S = a*b*c*d*e;
+
+    // convert linestrength units to [cm^-2 atm^-1]
+    libMesh::Real loschmidt = (Constants::atmosphere_Pa)/(T*Constants::Boltzmann*1.0e6);
+    S = S*loschmidt;
+
+    return S;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::dS_dT(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real iso = _hitran->isotopologue(i);
+    libMesh::Real sw = _hitran->sw(i);
+    libMesh::Real E = _hitran->elower(i);
+    libMesh::Real QT0 = _hitran->partition_function(_T0,iso);
+    libMesh::Real QT = _hitran->partition_function(T,iso);
+    libMesh::Real dQT = this->dQ_dT(T,iso);
+    libMesh::Real nu = this->get_nu(P,i);
+    
+    libMesh::Real constants = sw * QT0 * std::pow( (1.0-std::exp(-_rad_coeff*nu/_T0)), -1.0) * Constants::atmosphere_Pa/(Constants::Boltzmann*1.0e6);
+    libMesh::Real A  = 1.0/T;
+    libMesh::Real dA = -1.0/(T*T);
+
+    libMesh::Real B  = 1.0/QT;
+    libMesh::Real dB = -1.0/(QT*QT) * dQT;
+
+    libMesh::Real C  = std::exp(-_rad_coeff*E* (1.0/T - 1.0/_T0) );
+    libMesh::Real dC = std::exp(-_rad_coeff*E* (1.0/T - 1.0/_T0) ) * (_rad_coeff*E/(T*T));
+
+    libMesh::Real D  = 1.0 - std::exp(-_rad_coeff*nu/T);
+    libMesh::Real dD = -std::exp(-_rad_coeff*nu/T) * (_rad_coeff*nu/(T*T));
+
+    return constants * ( A*B*C*dD + A*B*dC*D + A*dB*C*D + dA*B*C*D );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::dS_dP(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real iso = _hitran->isotopologue(i);
+    libMesh::Real sw = _hitran->sw(i);
+    libMesh::Real E = _hitran->elower(i);
+    libMesh::Real QT0 = _hitran->partition_function(_T0,iso);
+    libMesh::Real QT = _hitran->partition_function(T,iso);
+    libMesh::Real nu = this->get_nu(P,i);
+    libMesh::Real dnu = this->d_nu_dP(i);
+
+    libMesh::Real constants = sw * QT0/QT * std::exp(-_rad_coeff*E*(1.0/T - 1.0/_T0)) * Constants::atmosphere_Pa/(Constants::Boltzmann*1.0e6 * T);
+
+    libMesh::Real A  = 1.0 - std::exp(-_rad_coeff*nu/T);
+    libMesh::Real dA = -std::exp(-_rad_coeff*nu/T) * (-_rad_coeff/T) * dnu;
+
+    libMesh::Real B  = std::pow( (1.0-std::exp(-_rad_coeff*nu/T)), -1.0);
+    libMesh::Real dB = -std::pow( (1.0-std::exp(-_rad_coeff*nu/T)), -2.0) * -std::exp(-_rad_coeff*nu/_T0) * (-_rad_coeff/_T0) * dnu;
+
+    return constants * ( A*dB + dA*B );
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::nu_D(libMesh::Real T, libMesh::Real P, unsigned int i)
   {
     libMesh::Real k = Constants::Boltzmann;
     libMesh::Real c = Constants::c_vacuum;
     libMesh::Real NA = Constants::Avogadro;
+    libMesh::Real M = _chemistry->M(_species_idx);
+    libMesh::Real nu = this->get_nu(P,i);
 
     return (nu/c)*std::sqrt( ( 8.0*k*T*std::log(2.0) )/( M/NA ) );
   }
 
   template<typename Chemistry>
-  libMesh::Real AbsorptionCoeff<Chemistry>::nu_C(libMesh::Real T,libMesh::Real X,libMesh::Real P, unsigned int index)
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuD_dT(libMesh::Real T, libMesh::Real P, unsigned int i)
   {
-    libMesh::Real g_self = _hitran->gamma_self(index);
-    libMesh::Real g_air = _hitran->gamma_air(index);
-    libMesh::Real n = _hitran->n_air(index);
+    libMesh::Real k = Constants::Boltzmann;
+    libMesh::Real c = Constants::c_vacuum;
+    libMesh::Real NA = Constants::Avogadro;
+    libMesh::Real M = _chemistry->M(_species_idx);
+    libMesh::Real nu = this->get_nu(P,i);
 
-    return 2.0*P*pow(_T0/T,n) * ( X*g_self + (1.0-X)*g_air );
+    return (nu/c) * std::sqrt( (8.0*k*std::log(2.0))/(M/NA) ) * 0.5 * 1.0/(std::sqrt(T));
   }
 
   template<typename Chemistry>
-  libMesh::Real AbsorptionCoeff<Chemistry>::voigt(libMesh::Real nu_D, libMesh::Real nu_c, libMesh::Real nu)
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuD_dP(libMesh::Real T, unsigned int i)
   {
-    //repeated term
-    libMesh::Real root_ln2 = std::sqrt(std::log(2.0));
+    libMesh::Real k = Constants::Boltzmann;
+    libMesh::Real c = Constants::c_vacuum;
+    libMesh::Real NA = Constants::Avogadro;
+    libMesh::Real M = _chemistry->M(_species_idx);
+    libMesh::Real dnu = this->d_nu_dP(i);
 
-    libMesh::Real a = root_ln2*nu_c/nu_D;
-    libMesh::Real w = 2*root_ln2*(_nu-nu)/nu_D;
+    return (1.0/c)*std::sqrt( ( 8.0*k*T*std::log(2.0) )/( M/NA ) ) * dnu;
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::nu_C(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real g_self = _hitran->gamma_self(i);
+    libMesh::Real g_air = _hitran->gamma_air(i);
+    libMesh::Real n = _hitran->n_air(i);
+
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return 2.0*(P/Constants::atmosphere_Pa)*std::pow(_T0/T,n)*( X*g_self + (1.0-X)*g_air );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuC_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real g_self = _hitran->gamma_self(i);
+    libMesh::Real g_air = _hitran->gamma_air(i);
+    libMesh::Real n = _hitran->n_air(i);
+
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return 2.0*(P/Constants::atmosphere_Pa) * n*std::pow(_T0/T,n-1.0)*(-_T0/(T*T)) * ( X*g_self + (1.0-X)*g_air );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuC_dP(libMesh::Real T, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real g_self = _hitran->gamma_self(i);
+    libMesh::Real g_air = _hitran->gamma_air(i);
+    libMesh::Real n = _hitran->n_air(i);
+
+    libMesh::Real M_mix = _chemistry->M_mix(Y);
+    libMesh::Real X = _chemistry->X(_species_idx,M_mix,Y[_species_idx]);
+
+    return 2.0*(1.0/Constants::atmosphere_Pa)*std::pow(_T0/T,n)*( X*g_self + (1.0-X)*g_air );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nuC_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real g_self = _hitran->gamma_self(i);
+    libMesh::Real g_air = _hitran->gamma_air(i);
+    libMesh::Real n = _hitran->n_air(i);
+    libMesh::Real dX = dX_dY(Y);
+
+    return 2.0*(P/Constants::atmosphere_Pa)*std::pow(_T0/T,n)*( dX*g_self - dX*g_air );
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::voigt(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+
+    libMesh::Real a = this->voigt_a(T,P,Y,i);
+    libMesh::Real w = this->voigt_w(T,P,i);
 
     // Voigt coefficient
     libMesh::Real V = 0.0;
@@ -254,12 +418,130 @@ namespace GRINS
         libMesh::Real Ci = _voigt_coeffs[2][i];
         libMesh::Real Di = _voigt_coeffs[3][i];
 
-        V += ( Ci*(a-Ai) + Di*(w-Bi) )/( (a-Ai)*(a-Ai) + (w-Bi)*(w-Bi) );
+        libMesh::Real aAi = a-Ai;
+        libMesh::Real wBi = w-Bi;
+        libMesh::Real aAi2 = std::pow(a-Ai,2.0);
+        libMesh::Real wBi2 = std::pow(w-Bi,2.0);
+
+        V += ( Ci*aAi + Di*wBi )/( aAi2 + wBi2 );
       }
 
-    libMesh::Real phi_V = (2.0*root_ln2)/(std::sqrt(Constants::pi)*nu_D)*V;
+    libMesh::Real phi_V = (2.0*std::sqrt(std::log(2.0)))/(std::sqrt(Constants::pi)*nu_D)*V;
 
     return phi_V;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_D = d_nuD_dT(T,P,i);
+
+    libMesh::Real a  = this->voigt_a(T,P,Y,i);
+    libMesh::Real da = this->d_voigt_a_dT(T,P,Y,i);
+
+    libMesh::Real w  = this->voigt_w(T,P,i);
+    libMesh::Real dw = this->d_voigt_w_dT(T,P,i); 
+
+    // Voigt coefficient
+    libMesh::Real V  = 0.0;
+    libMesh::Real dV = 0.0;
+
+    for(int i=0; i<4; i++)
+      {
+        libMesh::Real Ai = _voigt_coeffs[0][i];
+        libMesh::Real Bi = _voigt_coeffs[1][i];
+        libMesh::Real Ci = _voigt_coeffs[2][i];
+        libMesh::Real Di = _voigt_coeffs[3][i];
+
+        libMesh::Real aAi = a-Ai;
+        libMesh::Real wBi = w-Bi;
+        libMesh::Real aAi2 = std::pow(a-Ai,2.0);
+        libMesh::Real wBi2 = std::pow(w-Bi,2.0);
+
+        V  += ( Ci*aAi + Di*wBi )/( aAi2 + wBi2 );
+
+        dV += ( (aAi2+wBi2)*(Ci*da + Di*dw) - (Ci*aAi + Di*wBi)*(2.0*aAi*da + 2.0*wBi*dw) )/( std::pow(aAi2+wBi2,2.0) );
+      }
+
+    libMesh::Real constants = 2.0*std::sqrt(std::log(2.0))/std::sqrt(Constants::pi);
+    libMesh::Real C  = 1.0/nu_D;
+    libMesh::Real dC = -1.0/(nu_D*nu_D) * dnu_D;
+
+    return constants * ( C*dV + dC*V );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_D = d_nuD_dP(T,i);
+
+    libMesh::Real a  = this->voigt_a(T,P,Y,i);
+    libMesh::Real da = this->d_voigt_a_dP(T,P,Y,i);
+
+    libMesh::Real w  = this->voigt_w(T,P,i);
+    libMesh::Real dw = this->d_voigt_w_dP(T,P,i);
+
+    // Voigt coefficient
+    libMesh::Real V  = 0.0;
+    libMesh::Real dV = 0.0;
+
+    for(int i=0; i<4; i++)
+      {
+        libMesh::Real Ai = _voigt_coeffs[0][i];
+        libMesh::Real Bi = _voigt_coeffs[1][i];
+        libMesh::Real Ci = _voigt_coeffs[2][i];
+        libMesh::Real Di = _voigt_coeffs[3][i];
+
+        libMesh::Real aAi = a-Ai;
+        libMesh::Real wBi = w-Bi;
+        libMesh::Real aAi2 = std::pow(a-Ai,2.0);
+        libMesh::Real wBi2 = std::pow(w-Bi,2.0);
+
+        V  += ( Ci*aAi + Di*wBi )/( aAi2 + wBi2 );
+
+        dV += ( (aAi2+wBi2)*(Ci*da + Di*dw) - (Ci*aAi + Di*wBi)*(2.0*aAi*da + 2.0*wBi*dw) )/( std::pow(aAi2+wBi2,2.0) );
+      }
+
+    libMesh::Real constants = 2.0*std::sqrt(std::log(2.0))/std::sqrt(Constants::pi);
+    libMesh::Real C  = 1.0/nu_D;
+    libMesh::Real dC = -1.0/(nu_D*nu_D) * dnu_D;
+
+    return constants * ( C*dV + dC*V );
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+
+    libMesh::Real a  = this->voigt_a(T,P,Y,i);
+    libMesh::Real da = this->d_voigt_a_dY(T,P,Y,i);
+
+    libMesh::Real w  = this->voigt_w(T,P,i);
+
+    // Voigt coefficient
+    libMesh::Real dV = 0.0;
+
+    for(int i=0; i<4; i++)
+      {
+        libMesh::Real Ai = _voigt_coeffs[0][i];
+        libMesh::Real Bi = _voigt_coeffs[1][i];
+        libMesh::Real Ci = _voigt_coeffs[2][i];
+        libMesh::Real Di = _voigt_coeffs[3][i];
+
+        libMesh::Real aAi = a-Ai;
+        libMesh::Real wBi = w-Bi;
+        libMesh::Real aAi2 = std::pow(a-Ai,2.0);
+        libMesh::Real wBi2 = std::pow(w-Bi,2.0);
+
+        dV += ( (aAi2+wBi2)*(Ci*da) - (Ci*aAi + Di*wBi)*(2.0*aAi*da) )/( std::pow(aAi2+wBi2,2.0) );
+      }
+
+    libMesh::Real constants = 2.0*std::sqrt(std::log(2.0))/(std::sqrt(Constants::pi)*nu_D);
+
+    return constants * dV;
   }
 
   template<typename Chemistry>
@@ -284,6 +566,112 @@ namespace GRINS
     _voigt_coeffs[3][1] = -1.1858;
     _voigt_coeffs[3][2] = -0.0210;
     _voigt_coeffs[3][3] =  1.1858;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::voigt_a(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_c = this->nu_C(T,P,Y,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+
+    return std::sqrt(std::log(2.0))*nu_c/nu_D;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_a_dT(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_c = this->nu_C(T,P,Y,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_c = d_nuC_dT(T,P,Y,i);
+    libMesh::Real dnu_D = d_nuD_dT(T,P,i);
+
+    return std::sqrt(std::log(2.0)) * (nu_D*dnu_c - nu_c*dnu_D)/(nu_D*nu_D);
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_a_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_c = this->nu_C(T,P,Y,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_c = d_nuC_dP(T,Y,i);
+    libMesh::Real dnu_D = d_nuD_dP(T,i);
+
+    return std::sqrt(std::log(2.0)) * (nu_D*dnu_c - nu_c*dnu_D)/(nu_D*nu_D);
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_a_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i)
+  {
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_c = d_nuC_dY(T,P,Y,i);
+
+    return std::sqrt(std::log(2.0))/nu_D * dnu_c;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::voigt_w(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real nu = this->get_nu(P,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+
+    return 2.0*std::sqrt(std::log(2.0))*(_nu-nu)/nu_D;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_w_dT(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real nu = this->get_nu(P,i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_D = d_nuD_dT(T,P,i);
+
+    return 2.0*std::sqrt(std::log(2.0))*(_nu-nu)/(nu_D*nu_D) * -dnu_D;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_voigt_w_dP(libMesh::Real T, libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real nu = this->get_nu(P,i);
+    libMesh::Real dnu = d_nu_dP(i);
+    libMesh::Real nu_D = this->nu_D(T,P,i);
+    libMesh::Real dnu_D = d_nuD_dP(T,i);
+
+    return 2.0*std::sqrt(std::log(2.0)) * ( (nu_D)*(-dnu) - (_nu-nu)*(dnu_D) )/(nu_D*nu_D);
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::get_nu(libMesh::Real P, unsigned int i)
+  {
+    libMesh::Real nu = _hitran->nu0(i);
+    libMesh::Real d_air = _hitran->delta_air(i);
+
+    return nu + d_air*((P/Constants::atmosphere_Pa)/_Pref);
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::d_nu_dP(unsigned int i)
+  {
+    libMesh::Real d_air = _hitran->delta_air(i);
+    
+    return d_air/_Pref * 1.0/Constants::atmosphere_Pa;
+  }
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::dX_dY(std::vector<libMesh::Real> Y)
+  {
+    libMesh::Real MW = _chemistry->M(_species_idx);
+    libMesh::Real MW_mix = _chemistry->M_mix(Y);
+
+    libMesh::Real Ys = Y[_species_idx];
+
+    return 1.0/MW * ( MW_mix - Ys*(MW_mix*MW_mix)/MW );
+  }
+
+
+  template<typename Chemistry>
+  libMesh::Real AbsorptionCoeff<Chemistry>::dQ_dT(libMesh::Real T, unsigned int iso)
+  {
+    libMesh::Real deriv = _hitran->partition_function_derivative(T,iso);
+    return deriv;
   }
 
 #if GRINS_HAVE_ANTIOCH

--- a/src/qoi/src/hitran.C
+++ b/src/qoi/src/hitran.C
@@ -155,6 +155,34 @@ namespace GRINS
     return _data_size;
   }
 
+  libMesh::Real HITRAN::partition_function_derivative(libMesh::Real T, unsigned int iso)
+  {
+    libMesh::Real deriv = -1.0;
+    if (std::abs(T-_Tmin)<libMesh::TOLERANCE) // 1st order forward difference
+      {
+        libMesh::Real QT0 = this->partition_function(_Tmin,iso);
+        libMesh::Real QT1 = this->partition_function(_Tmin+_Tstep,iso);
+
+        deriv  = (QT1-QT0)/_Tstep;
+      }
+    else if (std::abs(T-_Tmax)<libMesh::TOLERANCE) // 1st order backward difference
+      {
+        libMesh::Real QT0 = this->partition_function(_Tmax-_Tstep,iso);
+        libMesh::Real QT1 = this->partition_function(_Tmax,iso);
+
+        deriv = (QT1-QT0)/_Tstep;
+      }
+    else // 2nd order central difference
+      {
+        libMesh::Real QT1 = this->partition_function(T+_Tstep,iso);
+        libMesh::Real QT0 = this->partition_function(T-_Tstep,iso);
+
+        deriv = (QT1-QT0)/(2.0*_Tstep);
+      }
+
+    return deriv;
+  }
+
   unsigned int HITRAN::isotopologue(unsigned int index)
   {
     libmesh_assert_less(index,_isotop.size());

--- a/src/utilities/include/grins/physical_constants.h
+++ b/src/utilities/include/grins/physical_constants.h
@@ -33,12 +33,12 @@ namespace GRINS
   namespace Constants
   {
     /*!
-     * Universal Gas Constant, R, expressed in J/(kmol-K)
+     * Universal Gas Constant, R, [J/(kmol-K)]
      */
     const libMesh::Real R_universal = 8314.4621;
 
     /*!
-     * Avogadro's number, particles per mole.
+     * Avogadro's number, [particles/mol]
      */
     const libMesh::Real Avogadro = 6.02214179e23;
 
@@ -51,6 +51,20 @@ namespace GRINS
      * Speed of light in a vacuum, [m/s]
      */
     const libMesh::Real c_vacuum = 299792458;
+
+    /*!
+     * 1 atmosphere in Pascals, [Pa/atm]
+     */
+    const libMesh::Real atmosphere_Pa = 101325.0;
+
+    /*!
+     * Second Radiation Constant hc/k, [m K]
+     * 
+     * h = Planck's Constant
+     * c = speed of light in a vacuum
+     * k = Boltzmann Constant
+     */
+    const libMesh::Real second_rad_const = 1.43877736e-2;
 
 
   } // namespace Constants

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -137,7 +137,8 @@ interface_driver_SOURCES = interface/interface_driver.C \
                            interface/species_test_base.h \
                            interface/thermochem_test_common.h \
                            interface/air_5sp.C \
-                           interface/antioch_mixture_builder_test.C
+                           interface/antioch_mixture_builder_test.C \
+                           interface/absorption_coeff_testing.h
 
 antioch_mixture_averaged_transport_evaluator_regression_SOURCES = interface/antioch_mixture_averaged_transport_evaluator_regression.C
 

--- a/test/interface/absorption_coeff_testing.h
+++ b/test/interface/absorption_coeff_testing.h
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_ABSORPTION_COEFF_TESTING_H
+#define GRINS_ABSORPTION_COEFF_TESTING_H
+
+// GRINS
+#include "grins/absorption_coeff.h"
+
+namespace GRINSTesting
+{
+  template<typename Chemistry>
+  class AbsorptionCoeffTesting : public GRINS::AbsorptionCoeff<Chemistry>
+  {
+  public:
+    /*!
+      This class is intended solely for use in unit testing the AbsorptionCoeff class.
+    */
+    AbsorptionCoeffTesting( GRINS::SharedPtr<Chemistry> & chem, GRINS::SharedPtr<GRINS::HITRAN> & hitran,
+                            libMesh::Real nu_min, libMesh::Real nu_max,
+                            libMesh::Real desired_nu, const std::string & species,
+                            libMesh::Real thermo_pressure);
+
+    friend class SpectroscopicAbsorptionTest;
+  };
+
+  template<typename Chemistry>
+  AbsorptionCoeffTesting<Chemistry>::AbsorptionCoeffTesting(GRINS::SharedPtr<Chemistry> & chem, GRINS::SharedPtr<GRINS::HITRAN> & hitran,
+                                                            libMesh::Real nu_min, libMesh::Real nu_max,
+                                                            libMesh::Real desired_nu, const std::string & species,
+                                                            libMesh::Real thermo_pressure)
+    : GRINS::AbsorptionCoeff<Chemistry>(chem,hitran,nu_min,nu_max,desired_nu,species,thermo_pressure)
+  {}
+}
+
+#endif //GRINS_ABSORPTION_COEFF_TESTING_H


### PR DESCRIPTION
This is part 1/2 of closed PR #505

Adds derivatives for each component of `AbsorptionCoeff`. Note this will not support AMR yet, as it does not contain the total QoI derivative. This will be added in a future PR.

For testing purposes, we created a subclass of `AbsorptionCoeff` named `AbsorptionCoeffTesting`. This class `friend`s the `SpectroscopicAbsorptionTest` class to allow access to the `protected` class functions of `AbsorptionCoeff`. We compare a central finite difference approximation of each component to its analytical derivative with respect to temperature, (hydrostatic) pressure, and mass fraction of the species of interest.