### PR TITLE
Include libmesh header that provides the UniquePtr alias.

### DIFF
--- a/src/ic_handling/include/grins/ic_handling_base.h
+++ b/src/ic_handling/include/grins/ic_handling_base.h
@@ -34,6 +34,7 @@
 #include "libmesh/getpot.h"
 #include "libmesh/point.h"
 #include "libmesh/function_base.h"
+#include "libmesh/auto_ptr.h"
 
 // libMesh forward declarations
 namespace libMesh

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -44,6 +44,7 @@
 #include "libmesh/fe_base.h"
 #include "libmesh/system.h"
 #include "libmesh/mesh_base.h"
+#include "libmesh/auto_ptr.h"
 
 // libMesh forward declarations
 class GetPot;

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -28,6 +28,7 @@
 
 // libMesh
 #include "libmesh/fem_function_base.h"
+#include "libmesh/auto_ptr.h"
 
 // GRINS
 #include "grins/assembly_context.h"

--- a/src/qoi/include/grins/composite_qoi.h
+++ b/src/qoi/include/grins/composite_qoi.h
@@ -32,6 +32,7 @@
 // libMesh
 #include "libmesh/libmesh_common.h"
 #include "libmesh/diff_qoi.h"
+#include "libmesh/auto_ptr.h"
 
 // libMesh forward declarations
 class GetPot;

--- a/src/qoi/include/grins/parsed_boundary_qoi.h
+++ b/src/qoi/include/grins/parsed_boundary_qoi.h
@@ -32,6 +32,7 @@
 
 // libMesh
 #include "libmesh/fem_function_base.h"
+#include "libmesh/auto_ptr.h"
 
 namespace GRINS
 {

--- a/src/qoi/include/grins/parsed_interior_qoi.h
+++ b/src/qoi/include/grins/parsed_interior_qoi.h
@@ -32,6 +32,7 @@
 
 // libMesh
 #include "libmesh/fem_function_base.h"
+#include "libmesh/auto_ptr.h"
 
 namespace GRINS
 {

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -35,6 +35,7 @@
 //libMesh
 #include "libmesh/libmesh.h"
 #include "libmesh/mesh_refinement.h"
+#include "libmesh/auto_ptr.h"
 
 // libMesh forward declarations
 class GetPot;


### PR DESCRIPTION
In a separate commit, I will simply update all the UniquePtr instances
in GRINS to std::unique_ptrs.

Refs libMesh/libmesh#1525.