### PR TITLE
Fix remaining clang instantiation warnings.

### DIFF
--- a/src/boundary_conditions/include/grins/dirichlet_bc_factory_abstract.h
+++ b/src/boundary_conditions/include/grins/dirichlet_bc_factory_abstract.h
@@ -33,6 +33,13 @@
 
 namespace GRINS
 {
+  // Specializations must be declared before any automatic instantiation.
+  template<> MultiphysicsSystem * BCFactoryAbstract<libMesh::DirichletBoundary>::_system;
+  template<> const GetPot* FactoryWithGetPot<libMesh::DirichletBoundary>::_input;
+  template<> const std::set<BoundaryID> * BCFactoryAbstract<libMesh::DirichletBoundary>::_bc_ids;
+  template<> const FEVariablesBase * BCFactoryAbstract<libMesh::DirichletBoundary>::_fe_var;
+  template<> std::string BCFactoryAbstract<libMesh::DirichletBoundary>::_section;
+
   class DirichletBCFactoryAbstract : public BCFactoryAbstract<libMesh::DirichletBoundary>
   {
   public:

--- a/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_base.h
+++ b/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_base.h
@@ -31,6 +31,9 @@
 
 namespace GRINS
 {
+  template <>
+  const FEVariablesBase* BCFactoryAbstract<libMesh::DirichletBoundary>::_fe_var;
+
   template<typename FunctionType>
   class DirichletBCFactoryFunctionBase : public DirichletBCFactoryAbstract
   {

--- a/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_old_style_base.h
+++ b/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_old_style_base.h
@@ -73,6 +73,24 @@ namespace GRINS
 
   };
 
+  // Specializations must be declared before any automatic instantiation.
+  template <>
+  std::string DirichletBCFactoryFunctionOldStyleBase<libMesh::FunctionBase<double> >::_value_var_old_style;
+  template <>
+  unsigned int DirichletBCFactoryFunctionOldStyleBase<libMesh::FunctionBase<double> >::_value_idx_old_style;
+  template <>
+  const std::vector<std::string> *
+  DirichletBCFactoryFunctionOldStyleBase<libMesh::FunctionBase<double> >::_var_names_old_style;
+
+  // Specializations must be declared before any automatic instantiation.
+  template <>
+  std::string DirichletBCFactoryFunctionOldStyleBase<libMesh::FEMFunctionBase<double> >::_value_var_old_style;
+  template <>
+  unsigned int DirichletBCFactoryFunctionOldStyleBase<libMesh::FEMFunctionBase<double> >::_value_idx_old_style;
+  template <>
+  const std::vector<std::string> *
+  DirichletBCFactoryFunctionOldStyleBase<libMesh::FEMFunctionBase<double> >::_var_names_old_style;
+
   template<typename FunctionType>
   inline
   void DirichletBCFactoryFunctionOldStyleBase<FunctionType>::check_state() const


### PR DESCRIPTION
This commit is along the same lines as #513, however these were just warnings while the others were actual compiler errors under clang. Anyone compiling GRINS with clang will probably appreciate having this patch (otherwise there are *a lot* of warnings) but I also think this code is pretty ugly/not maintainable so in the long run some kind of redesign might be the best solution...


These warnings were specific to the static data members of the class
and looked like the following:

../../src/boundary_conditions/include/grins/dirichlet_bc_factory_function_old_style_base.h:88:16: warning:
instantiation of variable 'GRINS::DirichletBCFactoryFunctionOldStyleBase<libMesh::FunctionBase<double> >::_var_names_old_style' required here, but no definition is
available [-Wundefined-var-template]
    if( !this->_var_names_old_style )
               ^
../../src/boundary_conditions/include/grins/prescribed_vector_value_dirichlet_old_style_bc_factory.h:40:5: note:
in instantiation of member function 'GRINS::DirichletBCFactoryFunctionOldStyleBase<libMesh::FunctionBase<double> >::check_state' requested here
    PrescribedVectorValueDirichletOldStyleBCFactory( const std::string& bc_type_name )
    ^
../../src/boundary_conditions/include/grins/dirichlet_bc_factory_function_old_style_base.h:72:44:
note: forward declaration of template entity is here
    static const std::vector<std::string>* _var_names_old_style;
                                           ^
../../src/boundary_conditions/include/grins/dirichlet_bc_factory_function_old_style_base.h:88:16:
note: add an explicit instantiation declaration to suppress this warning if 'GRINS::DirichletBCFactoryFunctionOldStyleBase<libMesh::FunctionBase<double> >::_var_names_old_style'
      is explicitly instantiated in another translation unit
    if( !this->_var_names_old_style )
               ^