### PR TITLE
SpectroscopicAbsorption QoI element_qoi_derivative

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -497,6 +497,7 @@ include_HEADERS += qoi/include/grins/qoi_options.h
 include_HEADERS += qoi/include/grins/hitran.h
 include_HEADERS += qoi/include/grins/absorption_coeff.h
 include_HEADERS += qoi/include/grins/spectroscopic_absorption.h
+include_HEADERS += qoi/include/grins/fem_function_and_derivative_base.h
 
 # src/solver headers
 include_HEADERS += solver/include/grins/solver.h

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -36,6 +36,7 @@
 #include "grins/single_variable.h"
 #include "grins/multicomponent_variable.h"
 #include "grins/variable_warehouse.h"
+#include "grins/fem_function_and_derivative_base.h"
 
 namespace GRINS
 {
@@ -59,7 +60,7 @@ namespace GRINS
     A chemistry library (Antioch or Cantera) is also required.
   */
   template<typename Chemistry>
-  class AbsorptionCoeff : public libMesh::FEMFunctionBase<libMesh::Real>
+  class AbsorptionCoeff : public FEMFunctionAndDerivativeBase<libMesh::Real>
   {
   public:
 
@@ -85,6 +86,13 @@ namespace GRINS
                              const libMesh::Point & p,
                              const libMesh::Real time,
                              libMesh::DenseVector<libMesh::Real> & output);
+
+    //! Calculate the derivative of the absorption coefficient at a QP with respect to all state variables
+    virtual void derivatives( libMesh::FEMContext & context,
+                              const libMesh::Point & qp_xyz,
+                              const libMesh::Real & JxW,
+                              const unsigned int qoi_index,
+                              const libMesh::Real time);
 
     //! Not used
     virtual libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Real> > clone() const;

--- a/src/qoi/include/grins/fem_function_and_derivative_base.h
+++ b/src/qoi/include/grins/fem_function_and_derivative_base.h
@@ -1,0 +1,52 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2016 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_FEM_FUNCTION_AND_DERIVATIVE_BASE_H
+#define GRINS_FEM_FUNCTION_AND_DERIVATIVE_BASE_H
+
+// libMesh
+#include "libmesh/fem_function_base.h"
+
+namespace GRINS
+{
+  /*!
+    Extends libMesh::FEMFunctionBase by adding a function for computing derivatives
+  */
+  template<typename Output>
+  class FEMFunctionAndDerivativeBase : public libMesh::FEMFunctionBase<Output>
+  {
+  public:
+
+    //! Function Derivative Evaluation
+    virtual void derivatives( libMesh::FEMContext & context,
+                              const libMesh::Point & qp_xyz,
+                              const libMesh::Real & JxW,
+                              const unsigned int qoi_index,
+                              const libMesh::Real time = 0.) = 0;
+
+  };
+
+}
+#endif //GRINS_FEM_FUNCTION_AND_DERIVATIVE_BASE_H

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -29,12 +29,12 @@
 // libMesh
 #include "libmesh/quadrature.h"
 #include "libmesh/exact_solution.h"
-#include "libmesh/fem_function_base.h"
 
 // GRINS
 #include "grins/qoi_base.h"
 #include "grins/variable_name_defaults.h"
 #include "grins/rayfire_mesh.h"
+#include "grins/fem_function_and_derivative_base.h"
 
 namespace GRINS
 {

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -118,6 +118,10 @@ namespace GRINS
     //! Compute the value of a QoI at a QP
     libMesh::Real qoi_value(Function & f, AssemblyContext & context, const libMesh::Point & xyz);
 
+    //! Compute derivatiuves at QP
+    void qoi_derivative(Function & f, AssemblyContext & context, const libMesh::Point & qp_xyz,
+                        const libMesh::Real JxW, const unsigned int qoi_index);
+
     //! User cannot call empty constructor
     IntegratedFunction();
 

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -60,13 +60,13 @@ namespace GRINS
     @param rayfire A RayfireMesh object (will be initialized in init()) <b>Ownership will be taken by an internal libMesh::UniquePtr</b>
     @param qoi_name Passed to the QoIBase
     */
-    IntegratedFunction(unsigned int p_level,SharedPtr<Function> f,RayfireMesh * rayfire,const std::string& qoi_name);
+    IntegratedFunction(unsigned int p_level, SharedPtr<Function> f, RayfireMesh * rayfire, const std::string & qoi_name);
 
     //! Constructor
     /*!
     Used by the QoIFactory. Passes GetPot through to RayfireMesh for construction
     */
-    IntegratedFunction(const GetPot & input,unsigned int p_level,SharedPtr<Function> f,const std::string & input_qoi_string,const std::string& qoi_name);
+    IntegratedFunction(const GetPot & input, unsigned int p_level, SharedPtr<Function> f, const std::string & input_qoi_string, const std::string & qoi_name);
 
     //! Copy Constructor
     /*!
@@ -82,18 +82,19 @@ namespace GRINS
     virtual bool assemble_on_sides() const;
 
     //! Compute the qoi value.
-    virtual void element_qoi( AssemblyContext& context,
+    virtual void element_qoi( AssemblyContext & context,
                               const unsigned int qoi_index );
 
     //! Compute the qoi derivative with respect to the solution.
     /*!
       Currently not implemented
     */
-    virtual void element_qoi_derivative( AssemblyContext& context,
+    virtual void element_qoi_derivative( AssemblyContext & context,
                                          const unsigned int qoi_index );
+
     //! Initializes the rayfire with the mesh from system
-    virtual void init( const GetPot& input,
-                       const MultiphysicsSystem& system,
+    virtual void init( const GetPot & input,
+                       const MultiphysicsSystem & system,
                        unsigned int qoi_num );
 
     //! Reinitialize the rayfire
@@ -115,7 +116,7 @@ namespace GRINS
     libMesh::UniquePtr<RayfireMesh> _rayfire;
 
     //! Compute the value of a QoI at a QP
-    libMesh::Real qoi_value(Function& f,AssemblyContext& context,const libMesh::Point& xyz);
+    libMesh::Real qoi_value(Function & f, AssemblyContext & context, const libMesh::Point & xyz);
 
     //! User cannot call empty constructor
     IntegratedFunction();

--- a/src/qoi/include/grins/spectroscopic_absorption.h
+++ b/src/qoi/include/grins/spectroscopic_absorption.h
@@ -45,14 +45,14 @@ namespace GRINS
 
     Expects all parameters given in standard SI units [m], [K], [Pa]
   */
-  class SpectroscopicAbsorption : public IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >
+  class SpectroscopicAbsorption : public IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >
   {
   public:
 
     /*!
       @param absorb AbsorptionCoeff object
     */
-    SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb);
+    SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb);
 
     virtual QoIBase * clone() const;
 

--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -161,6 +161,17 @@ namespace GRINS
   }
 
   template<typename Chemistry>
+  void AbsorptionCoeff<Chemistry>::derivatives( libMesh::FEMContext & /*context*/,
+                                                const libMesh::Point & /*qp_xyz*/,
+                                                const libMesh::Real & /*JxW*/,
+                                                const unsigned int /*qoi_index*/,
+                                                const libMesh::Real /*time*/)
+  {
+    // TODO
+    libmesh_not_implemented();
+  }
+
+  template<typename Chemistry>
   libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Real> > AbsorptionCoeff<Chemistry>::clone() const
   {
     libmesh_not_implemented();

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -31,6 +31,7 @@
 #include "grins/assembly_context.h"
 #include "grins/materials_parsing.h"
 #include "grins/rayfire_mesh.h"
+#include "grins/fem_function_and_derivative_base.h"
 
 // libMesh
 #include "libmesh/getpot.h"
@@ -40,7 +41,6 @@
 #include "libmesh/fe.h"
 #include "libmesh/fe_type.h"
 #include "libmesh/function_base.h"
-#include "libmesh/fem_function_base.h"
 
 namespace GRINS
 {
@@ -136,7 +136,7 @@ namespace GRINS
 
   // speciaizations of the qoi_value() function
   template<>
-  libMesh::Real IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >::qoi_value(libMesh::FEMFunctionBase<libMesh::Real> & f, AssemblyContext & context, const libMesh::Point & xyz)
+  libMesh::Real IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >::qoi_value(FEMFunctionAndDerivativeBase<libMesh::Real> & f, AssemblyContext & context, const libMesh::Point & xyz)
   {
     return f(context,xyz);
   }
@@ -148,6 +148,6 @@ namespace GRINS
   }
 
   template class IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >;
-  template class IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >;
+  template class IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >;
 
 } //namespace GRINS

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -127,11 +127,36 @@ namespace GRINS
   }
 
   template<typename Function>
-  void IntegratedFunction<Function>::element_qoi_derivative( AssemblyContext & /*context*/,
-                                                             const unsigned int /*qoi_index*/ )
+  void IntegratedFunction<Function>::element_qoi_derivative( AssemblyContext & context,
+                                                             const unsigned int qoi_index )
   {
-    //TODO
-    libmesh_not_implemented();
+    const libMesh::Elem& original_elem = context.get_elem();
+    const libMesh::Elem* rayfire_elem = _rayfire->map_to_rayfire_elem(original_elem.id());
+
+    // rayfire_elem will be NULL if the main_elem
+    // is not in the rayfire
+    if (rayfire_elem)
+      {
+        // create and init the quadrature base on the rayfire elem
+        libMesh::QGauss qbase(rayfire_elem->dim(),libMesh::Order(_p_level));
+        qbase.init(rayfire_elem->type(),libMesh::Order(_p_level));
+
+        // need the QP coordinates and JxW
+        libMesh::UniquePtr< libMesh::FEGenericBase<libMesh::Real> > fe = libMesh::FEGenericBase<libMesh::Real>::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
+
+        fe->attach_quadrature_rule( &qbase );
+        const std::vector<libMesh::Real> & JxW = fe->get_JxW();
+        const std::vector<libMesh::Point> & xyz = fe->get_xyz();
+
+        fe->reinit(rayfire_elem);
+
+        const unsigned int n_qpoints = fe->n_quadrature_points();
+
+        // FIXME the inverse_map() is ugly AF
+        for (unsigned int qp = 0; qp != n_qpoints; qp++)
+          this->qoi_derivative((*_f),context,xyz[qp],JxW[qp],qoi_index);
+
+      }
   }
 
   // speciaizations of the qoi_value() function
@@ -145,6 +170,21 @@ namespace GRINS
   libMesh::Real IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >::qoi_value(libMesh::FunctionBase<libMesh::Real> & f, AssemblyContext & /*context*/, const libMesh::Point & xyz)
   {
     return f(xyz);
+  }
+
+  // speciaizations of the qoi_derivative() function
+  template<>
+  void IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >::qoi_derivative( FEMFunctionAndDerivativeBase<libMesh::Real> & f, AssemblyContext & context,
+                                                                                         const libMesh::Point & qp_xyz, const libMesh::Real JxW, const unsigned int qoi_index)
+  {
+    f.derivatives(context,qp_xyz,JxW,qoi_index);
+  }
+
+  template<>
+  void IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >::qoi_derivative( libMesh::FunctionBase<libMesh::Real> & /*f*/, AssemblyContext & /*context*/,
+                                                                                  const libMesh::Point & /*qp_xyz*/, const libMesh::Real /*JxW*/, const unsigned int /*qoi_index*/)
+  {
+    // derivatives are always zero for FunctionBase
   }
 
   template class IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >;

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -45,7 +45,7 @@
 namespace GRINS
 {
   template<typename Function>
-  IntegratedFunction<Function>::IntegratedFunction(unsigned int p_level,SharedPtr<Function> f,RayfireMesh * rayfire,const std::string& qoi_name) :
+  IntegratedFunction<Function>::IntegratedFunction(unsigned int p_level, SharedPtr<Function> f, RayfireMesh * rayfire, const std::string & qoi_name) :
     QoIBase(qoi_name),
     _p_level(p_level),
     _f(f),
@@ -53,7 +53,7 @@ namespace GRINS
   {}
 
   template<typename Function>
-  IntegratedFunction<Function>::IntegratedFunction(const GetPot & input,unsigned int p_level,SharedPtr<Function> f,const std::string & input_qoi_string,const std::string& qoi_name) :
+  IntegratedFunction<Function>::IntegratedFunction(const GetPot & input, unsigned int p_level, SharedPtr<Function> f, const std::string & input_qoi_string, const std::string & qoi_name) :
     QoIBase(qoi_name),
     _p_level(p_level),
     _f(f)
@@ -79,8 +79,8 @@ namespace GRINS
 
   template<typename Function>
   void IntegratedFunction<Function>::init
-  (const GetPot& /*input*/,
-   const MultiphysicsSystem& system,
+  (const GetPot & /*input*/,
+   const MultiphysicsSystem & system,
    unsigned int /*qoi_num*/ )
   {
     _rayfire->init(system.get_mesh());
@@ -93,11 +93,11 @@ namespace GRINS
   }
 
   template<typename Function>
-  void IntegratedFunction<Function>::element_qoi( AssemblyContext& context,
+  void IntegratedFunction<Function>::element_qoi( AssemblyContext & context,
                                                   const unsigned int qoi_index )
   {
-    const libMesh::Elem& original_elem = context.get_elem();
-    const libMesh::Elem* rayfire_elem = _rayfire->map_to_rayfire_elem(original_elem.id());
+    const libMesh::Elem & original_elem = context.get_elem();
+    const libMesh::Elem * rayfire_elem = _rayfire->map_to_rayfire_elem(original_elem.id());
 
     // rayfire_elem will be NULL if the main_elem
     // is not in the rayfire
@@ -111,17 +111,14 @@ namespace GRINS
         libMesh::UniquePtr< libMesh::FEBase > fe = libMesh::FEBase::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
 
         fe->attach_quadrature_rule( &qbase );
-        fe->get_xyz();
-        fe->get_JxW();
+        const std::vector<libMesh::Real> & JxW = fe->get_JxW();
+        const std::vector<libMesh::Point> & xyz = fe->get_xyz();
 
         fe->reinit(rayfire_elem);
 
-        const std::vector<libMesh::Real>& JxW = fe->get_JxW();
-        const std::vector<libMesh::Point>& xyz = fe->get_xyz();
-
         const unsigned int n_qpoints = fe->n_quadrature_points();
 
-        libMesh::Number& qoi = context.get_qois()[qoi_index];
+        libMesh::Number & qoi = context.get_qois()[qoi_index];
 
         for (unsigned int qp = 0; qp != n_qpoints; ++qp)
           qoi += this->qoi_value((*_f),context,xyz[qp])*JxW[qp];
@@ -130,7 +127,7 @@ namespace GRINS
   }
 
   template<typename Function>
-  void IntegratedFunction<Function>::element_qoi_derivative( AssemblyContext& /*context*/,
+  void IntegratedFunction<Function>::element_qoi_derivative( AssemblyContext & /*context*/,
                                                              const unsigned int /*qoi_index*/ )
   {
     //TODO
@@ -139,13 +136,13 @@ namespace GRINS
 
   // speciaizations of the qoi_value() function
   template<>
-  libMesh::Real IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >::qoi_value(libMesh::FEMFunctionBase<libMesh::Real>& f,AssemblyContext& context,const libMesh::Point& xyz)
+  libMesh::Real IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >::qoi_value(libMesh::FEMFunctionBase<libMesh::Real> & f, AssemblyContext & context, const libMesh::Point & xyz)
   {
     return f(context,xyz);
   }
 
   template<>
-  libMesh::Real IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >::qoi_value(libMesh::FunctionBase<libMesh::Real>& f,AssemblyContext& /*context*/,const libMesh::Point& xyz)
+  libMesh::Real IntegratedFunction<libMesh::FunctionBase<libMesh::Real> >::qoi_value(libMesh::FunctionBase<libMesh::Real> & f, AssemblyContext & /*context*/, const libMesh::Point & xyz)
   {
     return f(xyz);
   }

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -108,7 +108,7 @@ namespace GRINS
         qbase.init(rayfire_elem->type(),libMesh::Order(_p_level));
 
         // need the QP coordinates and JxW
-        libMesh::UniquePtr< libMesh::FEBase > fe = libMesh::FEBase::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
+        libMesh::UniquePtr< libMesh::FEGenericBase<libMesh::Real> > fe = libMesh::FEGenericBase<libMesh::Real>::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
 
         fe->attach_quadrature_rule( &qbase );
         const std::vector<libMesh::Real> & JxW = fe->get_JxW();

--- a/src/qoi/src/qoi_factory.C
+++ b/src/qoi/src/qoi_factory.C
@@ -166,7 +166,7 @@ namespace GRINS
         std::string species;
         this->get_var_value<std::string>(input,species,"QoI/SpectroscopicAbsorption/species_of_interest","");
 
-        SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb;
+        SharedPtr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb;
 
         libMesh::Real thermo_pressure = -1.0;
         bool calc_thermo_pressure = input("QoI/SpectroscopicAbsorption/calc_thermo_pressure", false );

--- a/src/qoi/src/spectroscopic_absorption.C
+++ b/src/qoi/src/spectroscopic_absorption.C
@@ -42,8 +42,8 @@
 
 namespace GRINS
 {
-  SpectroscopicAbsorption::SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<libMesh::FEMFunctionBase<libMesh::Real> > absorb)
-    : IntegratedFunction<libMesh::FEMFunctionBase<libMesh::Real> >(input,2 /* QGauss order */,absorb,"SpectroscopicAbsorption",qoi_name)
+  SpectroscopicAbsorption::SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,SharedPtr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb)
+    : IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >(input,2 /* QGauss order */,absorb,"SpectroscopicAbsorption",qoi_name)
   {}
 
   QoIBase * SpectroscopicAbsorption::clone() const


### PR DESCRIPTION
This PR is part 2/2 of PR #505 

Here we plug into the AMR infrastructure. `FEMFunctionAndDerivativeBase` extends `FEMFunctionBase` to add a new function that supports calculating derivatives with respect to state variables.

`finalize_derivative()` was added to `libMesh` in libMesh/linMesh#1445 which we need to apply the chain rule to our QoI.

We include a CPPUnit test that checks a finite difference approximation of `element_qoi()` against the output of `element_qoi_derivative()`.

There will be 1 more PR that will add a test for `assemble_qoi()` and add support for calculating derivatives with respect to all species in the flow, not just the species of interest as we have here.