### PR TITLE
SpectroscopicAbsorption assemble QoI Derivatives

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 Version 0.9.0 (in progress)
    * C++11 compiler now required
+   * Minimum libMesh git hash for this release is: daf2f70
 
 Version 0.8.0
    * Minimum libMesh git hash for this release is: 8be0a4e

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In addition to a C++11 compiler, GRINS requires an up-to-date installation of th
 
 libMesh
 -------
-GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is 8be0a4e, as of GRINS [PR #499](https://github.com/grinsfem/grins/pull/499).
+GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is daf2f70, as of GRINS [PR #520](https://github.com/grinsfem/grins/pull/520).
 GRINS release 0.5.0 can use libMesh versions as old as 0.9.4. Subsequent to
 the 0.5.0 release requires at least libMesh 1.0.0.
 

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -147,8 +147,8 @@ namespace GRINS
     //! Absorption coefficient pressure derivative
     libMesh::Real d_kv_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
 
-    //! Absorption coefficient mass fraction derivative
-    libMesh::Real d_kv_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+    //! Absorption coefficient  derivative with respect to mass fraction of species species_index
+    libMesh::Real d_kv_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int species_index, unsigned int i);
 
     //! Linestrength [cm^-2 atm^-1]
     libMesh::Real Sw(libMesh::Real T, libMesh::Real P, unsigned int i);
@@ -177,8 +177,8 @@ namespace GRINS
     //! Collisional broadening pressure derivative
     libMesh::Real d_nuC_dP(libMesh::Real T, std::vector<libMesh::Real> Y, unsigned int i);
 
-    //! Collisional broadening mass fraction derivative
-    libMesh::Real d_nuC_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+    //! Collisional broadening derivative with respect to mass fraction of species species_index
+    libMesh::Real d_nuC_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int species_index, unsigned int i);
 
     //! Calculate the Voigt profile [cm^-1]
     /*!
@@ -196,8 +196,8 @@ namespace GRINS
     //! Voigt profile pressure derivative
     libMesh::Real d_voigt_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
 
-    //! Voigt profile mass fraction derivative
-    libMesh::Real d_voigt_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+    //! Voigt profile  derivative with respect to mass fraction of species species_index
+    libMesh::Real d_voigt_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int species_index, unsigned int i);
 
     //! Initialize the coeff matrix for calculating the Voigt profile
     void init_voigt();
@@ -211,8 +211,8 @@ namespace GRINS
     //! Voigt a parameter pressure derivative
     libMesh::Real d_voigt_a_dP(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
 
-    //! Voigt a parameter mass fraction derivative
-    libMesh::Real d_voigt_a_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int i);
+    //! Voigt a parameter  derivative with respect to mass fraction of species species_index
+    libMesh::Real d_voigt_a_dY(libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> Y, unsigned int species_index, unsigned int i);
 
     //! Voigt w parameter
     libMesh::Real voigt_w(libMesh::Real T, libMesh::Real P, unsigned int i);
@@ -229,8 +229,8 @@ namespace GRINS
     //! Derivative of pressure-shifted linecenter wavenumber
     libMesh::Real d_nu_dP(unsigned int i);
 
-    //! Mole fraction derivative with respect to mass fraction
-    libMesh::Real dX_dY(std::vector<libMesh::Real> Y);
+    //! Derivative of the mole fraction of the species of interest with respect to species_index
+    libMesh::Real dX_dY(std::vector<libMesh::Real> Y, unsigned int species_index);
 
     //! Partition Function derivative (finite difference)
     libMesh::Real dQ_dT(libMesh::Real T, unsigned int iso);

--- a/src/qoi/include/grins/composite_qoi.h
+++ b/src/qoi/include/grins/composite_qoi.h
@@ -124,6 +124,9 @@ namespace GRINS
                               const std::vector<libMesh::Number>& other_qoi,
                               const libMesh::QoISet& qoi_indices );
 
+    // Calls each QoI's finalize_derivative function
+    virtual void finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t qoi_index);
+
     //! Basic output for computed QoI's.
     void output_qoi( std::ostream& out ) const;
 

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -125,6 +125,10 @@ namespace GRINS
     //! User cannot call empty constructor
     IntegratedFunction();
 
+  protected:
+    //! Cache a non-const pointer to the MultiphysicsSystem object
+    MultiphysicsSystem * _multiphysics_system;
+
   };
 
   template<typename Function>

--- a/src/qoi/include/grins/qoi_base.h
+++ b/src/qoi/include/grins/qoi_base.h
@@ -114,6 +114,10 @@ namespace GRINS
      */
     virtual void thread_join( libMesh::Number& qoi, const libMesh::Number& other_qoi );
 
+    //! Finalize derivatives that require more than a simple sum.
+    //! Does nothing by default.
+    virtual void finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives);
+
     /*!
      * Basic output for computed QoI's. If fancier output is desired, override this method.
      */

--- a/src/qoi/include/grins/qoi_base.h
+++ b/src/qoi/include/grins/qoi_base.h
@@ -116,7 +116,7 @@ namespace GRINS
 
     //! Finalize derivatives that require more than a simple sum.
     //! Does nothing by default.
-    virtual void finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives);
+    virtual void finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t qoi_index);
 
     /*!
      * Basic output for computed QoI's. If fancier output is desired, override this method.

--- a/src/qoi/include/grins/spectroscopic_absorption.h
+++ b/src/qoi/include/grins/spectroscopic_absorption.h
@@ -61,6 +61,9 @@ namespace GRINS
                               libMesh::Number & sys_qoi,
                               libMesh::Number & local_qoi );
 
+    //! Override DifferentiableQoI's empty implementation to add chain rule (QoI is exponential)
+    virtual void finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t qoi_index);
+
   private:
 
     SpectroscopicAbsorption();

--- a/src/qoi/src/composite_qoi.C
+++ b/src/qoi/src/composite_qoi.C
@@ -203,6 +203,12 @@ namespace GRINS
     return;
   }
 
+  void CompositeQoI::finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t /*qoi_index*/)
+  {
+    for( unsigned int q = 0; q < _qois.size(); q++ )
+      (*_qois[q]).finalize_derivative(derivatives);
+  }
+
   void CompositeQoI::output_qoi( std::ostream& out ) const
   {
     for( std::vector<QoIBase*>::const_iterator qoi = _qois.begin();

--- a/src/qoi/src/composite_qoi.C
+++ b/src/qoi/src/composite_qoi.C
@@ -203,10 +203,10 @@ namespace GRINS
     return;
   }
 
-  void CompositeQoI::finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t /*qoi_index*/)
+  void CompositeQoI::finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t qoi_index)
   {
     for( unsigned int q = 0; q < _qois.size(); q++ )
-      (*_qois[q]).finalize_derivative(derivatives);
+      (*_qois[q]).finalize_derivative(derivatives,qoi_index);
   }
 
   void CompositeQoI::output_qoi( std::ostream& out ) const

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -65,7 +65,8 @@ namespace GRINS
   IntegratedFunction<Function>::IntegratedFunction(const IntegratedFunction & original) :
     QoIBase(original),
     _p_level(original._p_level),
-    _f(original._f)
+    _f(original._f),
+    _multiphysics_system(original._multiphysics_system)
   {
     // call RayfireMesh copy constructor
     this->_rayfire.reset(new RayfireMesh( *((original._rayfire).get())) );
@@ -83,6 +84,7 @@ namespace GRINS
    const MultiphysicsSystem & system,
    unsigned int /*qoi_num*/ )
   {
+    _multiphysics_system = &( const_cast<MultiphysicsSystem &>(system) );
     _rayfire->init(system.get_mesh());
   }
 

--- a/src/qoi/src/qoi_base.C
+++ b/src/qoi/src/qoi_base.C
@@ -58,6 +58,11 @@ namespace GRINS
     qoi += other_qoi;
   }
 
+  void QoIBase::finalize_derivative(libMesh::NumericVector<libMesh::Number> & /*derivatives*/)
+  {
+    // do nothing by default
+  }
+
   void QoIBase::output_qoi( std::ostream& out ) const
   {
     out << _qoi_name+" = "

--- a/src/qoi/src/qoi_base.C
+++ b/src/qoi/src/qoi_base.C
@@ -58,7 +58,7 @@ namespace GRINS
     qoi += other_qoi;
   }
 
-  void QoIBase::finalize_derivative(libMesh::NumericVector<libMesh::Number> & /*derivatives*/)
+  void QoIBase::finalize_derivative(libMesh::NumericVector<libMesh::Number> & /*derivatives*/, std::size_t /*qoi_index*/)
   {
     // do nothing by default
   }

--- a/src/qoi/src/spectroscopic_absorption.C
+++ b/src/qoi/src/spectroscopic_absorption.C
@@ -63,4 +63,18 @@ namespace GRINS
     QoIBase::_qoi_value = sys_qoi;
   }
 
+  void SpectroscopicAbsorption::finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t qoi_index)
+  {
+    if (!derivatives.closed())
+      derivatives.close();
+
+    // We recalculate the _qoi_value to make sure
+    // it is set and up-to-date
+    libMesh::QoISet qs;
+    qs.add_index(qoi_index);
+    _multiphysics_system->assemble_qoi(qs);
+
+    derivatives.scale(-100.0 * QoIBase::_qoi_value);
+  }
+
 } //namespace GRINS

--- a/test/unit/input_files/spectroscopic_absorption_qoi_fine.in
+++ b/test/unit/input_files/spectroscopic_absorption_qoi_fine.in
@@ -102,8 +102,8 @@
 [Mesh]
    [./Generation]
       dimension = '2'
-      n_elems_x = '10'
-      n_elems_y = '10'
+      n_elems_x = '3'
+      n_elems_y = '3'
       x_min = '0.0'
       x_max = '0.10'
       y_min = '0.0'

--- a/test/unit/spectroscopic_absorption_test.C
+++ b/test/unit/spectroscopic_absorption_test.C
@@ -258,11 +258,11 @@ namespace GRINSTesting
 
       libMesh::Real y_base = Y[0];
       std::vector<libMesh::Real> Y_analytic;
-      Y_analytic.push_back(absorb->dX_dY(Y));
-      Y_analytic.push_back(absorb->d_nuC_dY(T,P,Y,i));
-      Y_analytic.push_back(absorb->d_voigt_a_dY(T,P,Y,i));
-      Y_analytic.push_back(absorb->d_voigt_dY(T,P,Y,i));
-      Y_analytic.push_back(absorb->d_kv_dY(T,P,Y,i));
+      Y_analytic.push_back(absorb->dX_dY(Y,0));
+      Y_analytic.push_back(absorb->d_nuC_dY(T,P,Y,0,i));
+      Y_analytic.push_back(absorb->d_voigt_a_dY(T,P,Y,0,i));
+      Y_analytic.push_back(absorb->d_voigt_dY(T,P,Y,0,i));
+      Y_analytic.push_back(absorb->d_kv_dY(T,P,Y,0,i));
 
       std::vector<libMesh::Real> fd_plus;
       Y[0] = y_base + delta;


### PR DESCRIPTION
Finally, at long last, we have commit 3/2 of PR #505

Here we implement the `finalize_derivative()` function in `QoIBase` and `CompositeQoI`. By default, these implementations do nothing. This commit requires libMesh daf2f70

We then add a non-empty definition of `finalize_derivative()` to SpectroscopicAbsorption to give the correct derivative of the exponential QoI.

AbsorptionCoeff is updated so that derivatives are calculated with respect to all species within the flow, not just the absorbing species of interest.

Lastly, we add a CPPUnit test to verify the total QoI `assemble_qoi_derivative()` computation by comparing with a finite difference approximation.

With this PR, the SpectroscopicAbsorption QoI should give correct results for AMR.