### PR TITLE
libMesh::UniquePtr --> std::unique_ptr

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 Version 0.9.0 (in progress)
+   * C++11 compiler now required
 
 Version 0.8.0
    * Minimum libMesh git hash for this release is: 8be0a4e

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Dependencies
 Requirements
 ------------
 
-In addition to a modern C++ compiler, GRINS requires an up-to-date installation of the [libMesh](https://github.com/libMesh/libmesh.git) finite element library. If your C++ compiler does not support smart pointers, than the Boost C++ library is also required (header only).
+In addition to a C++11 compiler, GRINS requires an up-to-date installation of the [libMesh](https://github.com/libMesh/libmesh.git) finite element library. 
 
 libMesh
 -------

--- a/src/boundary_conditions/include/grins/bc_builder.h
+++ b/src/boundary_conditions/include/grins/bc_builder.h
@@ -92,7 +92,7 @@ namespace GRINS
 
     static bool is_new_bc_input_style( const GetPot& input );
 
-    static libMesh::UniquePtr<BCBuilder> build_builder( const GetPot& input );
+    static std::unique_ptr<BCBuilder> build_builder( const GetPot& input );
 
     bool is_dirichlet_bc_type( const std::string& bc_type );
 

--- a/src/boundary_conditions/include/grins/catalycity_factories.h
+++ b/src/boundary_conditions/include/grins/catalycity_factories.h
@@ -48,7 +48,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<CatalycityBase>
+    virtual std::unique_ptr<CatalycityBase>
     build_catalycity( const GetPot& input, const std::string& section )
     {
       std::string param_base = section+"/ConstantCatalycity/";
@@ -58,7 +58,7 @@ namespace GRINS
         libmesh_error_msg("ERROR: Could not find input "+gamma_str+" for ConstantCatalycity!\n");
 
       libMesh::Real gamma = input(gamma_str, std::numeric_limits<libMesh::Real>::max());
-      libMesh::UniquePtr<CatalycityBase> catalycity( new ConstantCatalycity( gamma ) );
+      std::unique_ptr<CatalycityBase> catalycity( new ConstantCatalycity( gamma ) );
       catalycity->set_parameters(input,param_base);
       return catalycity;
     }
@@ -78,7 +78,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<CatalycityBase>
+    virtual std::unique_ptr<CatalycityBase>
     build_catalycity( const GetPot& input, const std::string& section )
     {
       std::string param_base = section+"/ArrheniusCatalycity/";
@@ -94,7 +94,7 @@ namespace GRINS
       libMesh::Real gamma = input(gamma_str, std::numeric_limits<libMesh::Real>::max());
       libMesh::Real Ta = input(Ta_str, std::numeric_limits<libMesh::Real>::max());
 
-      libMesh::UniquePtr<CatalycityBase> catalycity( new ArrheniusCatalycity( gamma, Ta ) );
+      std::unique_ptr<CatalycityBase> catalycity( new ArrheniusCatalycity( gamma, Ta ) );
       catalycity->set_parameters(input,param_base);
       return catalycity;
     }
@@ -113,7 +113,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<CatalycityBase>
+    virtual std::unique_ptr<CatalycityBase>
     build_catalycity( const GetPot& input, const std::string& section )
     {
       std::string param_base = section+"/PowerLawCatalycity/";
@@ -134,7 +134,7 @@ namespace GRINS
       libMesh::Real Tref = input(Tref_str, std::numeric_limits<libMesh::Real>::max());
       libMesh::Real alpha = input(alpha_str, std::numeric_limits<libMesh::Real>::max());
 
-      libMesh::UniquePtr<CatalycityBase> catalycity( new PowerLawCatalycity( gamma, Tref, alpha ) );
+      std::unique_ptr<CatalycityBase> catalycity( new PowerLawCatalycity( gamma, Tref, alpha ) );
       catalycity->set_parameters(input,param_base);
       return catalycity;
     }

--- a/src/boundary_conditions/include/grins/catalycity_factories_old_style.h
+++ b/src/boundary_conditions/include/grins/catalycity_factories_old_style.h
@@ -48,7 +48,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
+    virtual std::unique_ptr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
                                                                            const std::string& section,
                                                                            const std::string& reactant_str,
                                                                            const std::string& bc_id_string )
@@ -58,7 +58,7 @@ namespace GRINS
         libmesh_error_msg("ERROR: Could not find input "+gamma_str+" for ConstantCatalycity!\n");
 
       libMesh::Real gamma = input(gamma_str, std::numeric_limits<libMesh::Real>::max());
-      return libMesh::UniquePtr<CatalycityBase>( new ConstantCatalycity( gamma ) );
+      return std::unique_ptr<CatalycityBase>( new ConstantCatalycity( gamma ) );
     }
   };
 
@@ -74,7 +74,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
+    virtual std::unique_ptr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
                                                                            const std::string& section,
                                                                            const std::string& reactant_str,
                                                                            const std::string& bc_id_string )
@@ -90,7 +90,7 @@ namespace GRINS
       libMesh::Real gamma = input(gamma_str, std::numeric_limits<libMesh::Real>::max());
       libMesh::Real Ta = input(Ta_str, std::numeric_limits<libMesh::Real>::max());
 
-      return libMesh::UniquePtr<CatalycityBase>( new ArrheniusCatalycity( gamma, Ta ) );
+      return std::unique_ptr<CatalycityBase>( new ArrheniusCatalycity( gamma, Ta ) );
     }
   };
 
@@ -106,7 +106,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
+    virtual std::unique_ptr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
                                                                            const std::string& section,
                                                                            const std::string& reactant_str,
                                                                            const std::string& bc_id_string )
@@ -127,7 +127,7 @@ namespace GRINS
       libMesh::Real Tref = input(Tref_str, std::numeric_limits<libMesh::Real>::max());
       libMesh::Real alpha = input(alpha_str, std::numeric_limits<libMesh::Real>::max());
 
-      return libMesh::UniquePtr<CatalycityBase>( new PowerLawCatalycity( gamma, Tref, alpha ) );
+      return std::unique_ptr<CatalycityBase>( new PowerLawCatalycity( gamma, Tref, alpha ) );
     }
   };
 

--- a/src/boundary_conditions/include/grins/catalycity_factories_old_style.h
+++ b/src/boundary_conditions/include/grins/catalycity_factories_old_style.h
@@ -49,9 +49,9 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
-                                                                           const std::string& section,
-                                                                           const std::string& reactant_str,
-                                                                           const std::string& bc_id_string )
+                                                                        const std::string& section,
+                                                                        const std::string& reactant_str,
+                                                                        const std::string& bc_id_string )
     {
       std::string gamma_str = section+"/gamma_"+reactant_str+"_"+bc_id_string;
       if( !input.have_variable(gamma_str) )
@@ -75,9 +75,9 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
-                                                                           const std::string& section,
-                                                                           const std::string& reactant_str,
-                                                                           const std::string& bc_id_string )
+                                                                        const std::string& section,
+                                                                        const std::string& reactant_str,
+                                                                        const std::string& bc_id_string )
     {
       std::string gamma_str = section+"/gamma0_"+reactant_str+"_"+bc_id_string;
       if( !input.have_variable(gamma_str) )
@@ -107,9 +107,9 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
-                                                                           const std::string& section,
-                                                                           const std::string& reactant_str,
-                                                                           const std::string& bc_id_string )
+                                                                        const std::string& section,
+                                                                        const std::string& reactant_str,
+                                                                        const std::string& bc_id_string )
     {
       std::string gamma_str = section+"/gamma0_"+reactant_str+"_"+bc_id_string;
       if( !input.have_variable(gamma_str) )

--- a/src/boundary_conditions/include/grins/catalycity_factory_abstract.h
+++ b/src/boundary_conditions/include/grins/catalycity_factory_abstract.h
@@ -49,7 +49,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<CatalycityBase> build_catalycity( const GetPot& input,
+    virtual std::unique_ptr<CatalycityBase> build_catalycity( const GetPot& input,
                                                                  const std::string& section ) =0;
 
     //! Helper function to reduce code duplication
@@ -62,15 +62,15 @@ namespace GRINS
 
   private:
 
-    virtual libMesh::UniquePtr<CatalycityBase> create();
+    virtual std::unique_ptr<CatalycityBase> create();
   };
 
   inline
-  libMesh::UniquePtr<CatalycityBase> CatalycityFactoryAbstract::create()
+  std::unique_ptr<CatalycityBase> CatalycityFactoryAbstract::create()
   {
     this->check_state();
 
-    libMesh::UniquePtr<CatalycityBase> new_catalycity = this->build_catalycity( *_input, _section );
+    std::unique_ptr<CatalycityBase> new_catalycity = this->build_catalycity( *_input, _section );
 
     this->reset_state();
 

--- a/src/boundary_conditions/include/grins/catalycity_factory_abstract.h
+++ b/src/boundary_conditions/include/grins/catalycity_factory_abstract.h
@@ -50,7 +50,7 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<CatalycityBase> build_catalycity( const GetPot& input,
-                                                                 const std::string& section ) =0;
+                                                              const std::string& section ) =0;
 
     //! Helper function to reduce code duplication
     virtual void check_state() const;

--- a/src/boundary_conditions/include/grins/catalycity_factory_old_style_base.h
+++ b/src/boundary_conditions/include/grins/catalycity_factory_old_style_base.h
@@ -48,10 +48,10 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<CatalycityBase> build_catalycity( const GetPot& input,
+    virtual std::unique_ptr<CatalycityBase> build_catalycity( const GetPot& input,
                                                                  const std::string& section );
 
-    virtual libMesh::UniquePtr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
+    virtual std::unique_ptr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
                                                                            const std::string& section,
                                                                            const std::string& reactant_str,
                                                                            const std::string& bc_id_string ) =0;

--- a/src/boundary_conditions/include/grins/catalycity_factory_old_style_base.h
+++ b/src/boundary_conditions/include/grins/catalycity_factory_old_style_base.h
@@ -49,12 +49,12 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<CatalycityBase> build_catalycity( const GetPot& input,
-                                                                 const std::string& section );
+                                                              const std::string& section );
 
     virtual std::unique_ptr<CatalycityBase> build_catalycity_old_style( const GetPot& input,
-                                                                           const std::string& section,
-                                                                           const std::string& reactant_str,
-                                                                           const std::string& bc_id_string ) =0;
+                                                                        const std::string& section,
+                                                                        const std::string& reactant_str,
+                                                                        const std::string& bc_id_string ) =0;
     virtual void check_state() const;
 
     virtual void reset_state();

--- a/src/boundary_conditions/include/grins/catalytic_wall_base.h
+++ b/src/boundary_conditions/include/grins/catalytic_wall_base.h
@@ -33,7 +33,7 @@
 
 // libMesh
 #include "libmesh/libmesh_common.h"
-#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+#include "libmesh/auto_ptr.h" // std::unique_ptr
 
 namespace libMesh
 {
@@ -103,7 +103,7 @@ namespace GRINS
     SharedPtr<CatalycityBase> _gamma_ptr;
 
     //! Deprecated
-    libMesh::UniquePtr<CatalycityBase> _gamma_s;
+    std::unique_ptr<CatalycityBase> _gamma_s;
 
     //! \f$ \sqrt{ \frac{R_s}{2\pi} } \f$
     const libMesh::Real _C;

--- a/src/boundary_conditions/include/grins/constant_function_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/constant_function_dirichlet_bc_factory.h
@@ -59,7 +59,7 @@ namespace GRINS
       the user must've set at least one. The section arguments
       corresponds to the section to parse for the variables in the
       input file, e.g. input(section+"/"+var_names[0]). */
-    virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+    virtual std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
     build_func( const GetPot& input,
                 MultiphysicsSystem& system,
                 std::vector<std::string>& var_names,

--- a/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_base.h
+++ b/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_base.h
@@ -60,17 +60,17 @@ namespace GRINS
       be to *remove* variables from the list. For example, for some
       symmetry conditions, we only want to enforce zero on certain
       components of the solution while leaving others untouched. */
-    virtual libMesh::UniquePtr<FunctionType>
+    virtual std::unique_ptr<FunctionType>
     build_func( const GetPot& input,
                 MultiphysicsSystem& system,
                 std::vector<std::string>& var_names,
                 const std::string& section ) =0;
 
     //! Dispatch, based on FunctionType, to the correct DirchletBoundary construction
-    libMesh::UniquePtr<libMesh::DirichletBoundary>
+    std::unique_ptr<libMesh::DirichletBoundary>
     make_dirichlet_boundary( const std::set<BoundaryID>& bc_ids,
                              const libMesh::System& system,
-                             libMesh::UniquePtr<FunctionType>& func,
+                             std::unique_ptr<FunctionType>& func,
                              const std::vector<VariableIndex>& var_indices );
 
     //! Helper function that can be overridded in subclasses
@@ -80,7 +80,7 @@ namespace GRINS
 
   private:
 
-    virtual libMesh::UniquePtr<libMesh::DirichletBoundary> create();
+    virtual std::unique_ptr<libMesh::DirichletBoundary> create();
 
   };
 

--- a/src/boundary_conditions/include/grins/homogeneous_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/homogeneous_dirichlet_bc_factory.h
@@ -46,13 +46,13 @@ namespace GRINS
   protected:
 
     //! All the variables are 0, so just return 0 function.
-    virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+    virtual std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
     build_func( const GetPot& /*input*/,
                 MultiphysicsSystem& /*system*/,
                 std::vector<std::string>& /*var_names*/,
                 const std::string& /*section*/ )
     {
-      return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::ZeroFunction<libMesh::Number> );
+      return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::ZeroFunction<libMesh::Number> );
     }
 
   };

--- a/src/boundary_conditions/include/grins/isothermal_dirichlet_old_style_bc_factory.h
+++ b/src/boundary_conditions/include/grins/isothermal_dirichlet_old_style_bc_factory.h
@@ -46,7 +46,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+    virtual std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
     build_func( const GetPot& input,
                 MultiphysicsSystem& system,
                 std::vector<std::string>& var_names,
@@ -54,7 +54,7 @@ namespace GRINS
 
   };
 
-  libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+  std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
   inline
   IsothermalDirichletOldStyleBCFactory::build_func( const GetPot& input,
                                                     MultiphysicsSystem& /*system*/,
@@ -73,7 +73,7 @@ namespace GRINS
 
     libMesh::Number value = input(input_var, 0.0);
 
-    return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::ConstFunction<libMesh::Number>(value) );
+    return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::ConstFunction<libMesh::Number>(value) );
   }
 
 } // end namespace GRINS

--- a/src/boundary_conditions/include/grins/neumann_bc_abstract.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_abstract.h
@@ -30,7 +30,7 @@
 
 // libMesh
 #include "libmesh/libmesh_common.h"
-#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+#include "libmesh/auto_ptr.h" // std::unique_ptr
 
 namespace GRINS
 {

--- a/src/boundary_conditions/include/grins/neumann_bc_factory_abstract.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_factory_abstract.h
@@ -57,13 +57,13 @@ namespace GRINS
       is deferred to subclasses of this factory and should
       be implemented in the build_neumann_func method.
 
-      Note that an empty libMesh::UniquePtr<NeumannBCContainer>
+      Note that an empty std::unique_ptr<NeumannBCContainer>
       may be returned from create() if the parsed boundary condition
       type is a homogeneous one.  This is allowed since we force
       the user to specify boundary conditions for every
       Variable, for every boundary in the hopes of reducing input
       file errors at runtime. */
-    virtual libMesh::UniquePtr<NeumannBCContainer> create();
+    virtual std::unique_ptr<NeumannBCContainer> create();
 
   protected:
 

--- a/src/boundary_conditions/include/grins/neumann_bc_function_base.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_function_base.h
@@ -92,7 +92,7 @@ namespace GRINS
     //! Function object for the actual Neumann flux
     /*! Subclasses should initialize this function appropriately at construction
       time. */
-    libMesh::UniquePtr<FunctionType> _func;
+    std::unique_ptr<FunctionType> _func;
 
   };
 

--- a/src/boundary_conditions/include/grins/neumann_bc_parsed.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_parsed.h
@@ -61,7 +61,7 @@ namespace GRINS
     {
       libmesh_assert_equal_to( expressions.size(), vars.size() );
 
-      libMesh::UniquePtr<libMesh::CompositeFunction<FEShape> >
+      std::unique_ptr<libMesh::CompositeFunction<FEShape> >
         composite_func( new libMesh::CompositeFunction<FEShape> );
 
       for( unsigned int i = 0; i < vars.size(); i++ )
@@ -103,7 +103,7 @@ namespace GRINS
     {
       libmesh_assert_equal_to( expressions.size(), vars.size() );
 
-      libMesh::UniquePtr<libMesh::CompositeFEMFunction<FEShape> >
+      std::unique_ptr<libMesh::CompositeFEMFunction<FEShape> >
         composite_func( new libMesh::CompositeFEMFunction<FEShape> );
 
       for( unsigned int i = 0; i < vars.size(); i++ )

--- a/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
@@ -54,7 +54,7 @@ namespace GRINS
       the user must've set at least one. The section arguments
       corresponds to the section to parse for the variables in the
       input file, e.g. input(section+"/"+var_names[0]). */
-    virtual libMesh::UniquePtr<FunctionType>
+    virtual std::unique_ptr<FunctionType>
     build_func( const GetPot& input,
                 MultiphysicsSystem& system,
                 std::vector<std::string>& var_names,

--- a/src/boundary_conditions/include/grins/parsed_function_dirichlet_old_style_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_dirichlet_old_style_bc_factory.h
@@ -47,7 +47,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<FunctionType>
+    virtual std::unique_ptr<FunctionType>
     build_func( const GetPot& input,
                 MultiphysicsSystem& system,
                 std::vector<std::string>& var_names,

--- a/src/boundary_conditions/include/grins/parsed_function_factory_helper.h
+++ b/src/boundary_conditions/include/grins/parsed_function_factory_helper.h
@@ -44,10 +44,10 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<FunctionType> build_parsed_func( const MultiphysicsSystem& system,
+    std::unique_ptr<FunctionType> build_parsed_func( const MultiphysicsSystem& system,
                                                         const std::string& expression );
 
-    libMesh::UniquePtr<FunctionType> build_composite_func();
+    std::unique_ptr<FunctionType> build_composite_func();
 
   };
 

--- a/src/boundary_conditions/include/grins/parsed_function_factory_helper.h
+++ b/src/boundary_conditions/include/grins/parsed_function_factory_helper.h
@@ -45,7 +45,7 @@ namespace GRINS
   protected:
 
     std::unique_ptr<FunctionType> build_parsed_func( const MultiphysicsSystem& system,
-                                                        const std::string& expression );
+                                                     const std::string& expression );
 
     std::unique_ptr<FunctionType> build_composite_func();
 

--- a/src/boundary_conditions/include/grins/prescribed_vector_value_dirichlet_old_style_bc_factory.h
+++ b/src/boundary_conditions/include/grins/prescribed_vector_value_dirichlet_old_style_bc_factory.h
@@ -47,7 +47,7 @@ namespace GRINS
 
     virtual std::string var_input_string() =0;
 
-    virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+    virtual std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
     build_func( const GetPot& input,
                 MultiphysicsSystem& system,
                 std::vector<std::string>& var_names,

--- a/src/boundary_conditions/include/grins/symmetry_type_bc_factories.h
+++ b/src/boundary_conditions/include/grins/symmetry_type_bc_factories.h
@@ -53,14 +53,14 @@ namespace GRINS
     virtual void trim_var_names( std::vector<std::string>& var_names ) =0;
 
     //! All the variables are 0, so just return 0 function.
-    virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+    virtual std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
     build_func( const GetPot& /*input*/,
                 MultiphysicsSystem& /*system*/,
                 std::vector<std::string>& var_names,
                 const std::string& /*section*/ )
     {
       this->trim_var_names(var_names);
-      return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::ZeroFunction<libMesh::Number> );
+      return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::ZeroFunction<libMesh::Number> );
     }
 
   };

--- a/src/boundary_conditions/src/bc_builder.C
+++ b/src/boundary_conditions/src/bc_builder.C
@@ -42,17 +42,17 @@ namespace GRINS
                                              MultiphysicsSystem& system,
                                              std::vector<SharedPtr<NeumannBCContainer> >& neumann_bcs )
   {
-    libMesh::UniquePtr<BCBuilder>
+    std::unique_ptr<BCBuilder>
       bc_builder = BCBuilder::build_builder(input);
 
     bc_builder->build_bcs(input,system,neumann_bcs);
   }
 
-  libMesh::UniquePtr<BCBuilder> BCBuilder::build_builder( const GetPot& input )
+  std::unique_ptr<BCBuilder> BCBuilder::build_builder( const GetPot& input )
   {
     bool is_new_style = BCBuilder::is_new_bc_input_style( input );
 
-    libMesh::UniquePtr<BCBuilder> bc_builder;
+    std::unique_ptr<BCBuilder> bc_builder;
 
     if( is_new_style )
       bc_builder.reset( new DefaultBCBuilder );
@@ -97,7 +97,7 @@ namespace GRINS
     // if it needs to
     DirichletBCFactoryAbstract::set_section( section );
 
-    libMesh::UniquePtr<libMesh::DirichletBoundary>
+    std::unique_ptr<libMesh::DirichletBoundary>
       dbc = DirichletBCFactoryAbstract::build( bc_type );
 
     dof_map.add_dirichlet_boundary( *dbc );
@@ -127,7 +127,7 @@ namespace GRINS
     // if it needs to
     NeumannBCFactoryAbstract::set_section( section );
 
-    libMesh::UniquePtr<NeumannBCContainer>
+    std::unique_ptr<NeumannBCContainer>
       nbc = NeumannBCFactoryAbstract::build(bc_type);
 
     // Get nothing if it's a homogeneous Neumann BC

--- a/src/boundary_conditions/src/catalycity_factory_old_style_base.C
+++ b/src/boundary_conditions/src/catalycity_factory_old_style_base.C
@@ -28,7 +28,7 @@
 namespace GRINS
 {
   std::unique_ptr<CatalycityBase> CatalycityFactoryOldStyleBase::build_catalycity( const GetPot& input,
-                                                                                      const std::string& section )
+                                                                                   const std::string& section )
   {
     // State of _reactant_str, _bc_id_str verified in check_state() call in create()
     return this->build_catalycity_old_style( input, section, _reactant_str, _bc_id_str );

--- a/src/boundary_conditions/src/catalycity_factory_old_style_base.C
+++ b/src/boundary_conditions/src/catalycity_factory_old_style_base.C
@@ -27,7 +27,7 @@
 
 namespace GRINS
 {
-  libMesh::UniquePtr<CatalycityBase> CatalycityFactoryOldStyleBase::build_catalycity( const GetPot& input,
+  std::unique_ptr<CatalycityBase> CatalycityFactoryOldStyleBase::build_catalycity( const GetPot& input,
                                                                                       const std::string& section )
   {
     // State of _reactant_str, _bc_id_str verified in check_state() call in create()

--- a/src/boundary_conditions/src/catalytic_wall_neumann_bc_factory_base.C
+++ b/src/boundary_conditions/src/catalytic_wall_neumann_bc_factory_base.C
@@ -112,7 +112,7 @@ namespace GRINS
 
     std::string catalycity_type = input(catalycity_input_str, "none");
 
-    libMesh::UniquePtr<CatalycityBase> catalycity_ptr = CatalycityFactoryAbstract::build(catalycity_type);
+    std::unique_ptr<CatalycityBase> catalycity_ptr = CatalycityFactoryAbstract::build(catalycity_type);
 
     // We need to return a SharedPtr
     return SharedPtr<CatalycityBase>( catalycity_ptr.release() );

--- a/src/boundary_conditions/src/catalytic_wall_neumann_bc_old_style_factory_base.C
+++ b/src/boundary_conditions/src/catalytic_wall_neumann_bc_old_style_factory_base.C
@@ -142,7 +142,7 @@ namespace GRINS
     std::string catalycity_type = input(catalycity_input_str, "none");
     catalycity_type += "_old_style";
 
-    libMesh::UniquePtr<CatalycityBase> catalycity_ptr = CatalycityFactoryOldStyleBase::build(catalycity_type);
+    std::unique_ptr<CatalycityBase> catalycity_ptr = CatalycityFactoryOldStyleBase::build(catalycity_type);
 
     // We need to return a SharedPtr
     return SharedPtr<CatalycityBase>( catalycity_ptr.release() );

--- a/src/boundary_conditions/src/constant_function_dirichlet_bc_factory.C
+++ b/src/boundary_conditions/src/constant_function_dirichlet_bc_factory.C
@@ -46,7 +46,7 @@
 
 namespace GRINS
 {
-  libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+  std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
   ConstantFunctionDirichletBCFactory::build_func( const GetPot& input,
                                                   MultiphysicsSystem& system,
                                                   std::vector<std::string>& var_names,
@@ -55,7 +55,7 @@ namespace GRINS
     libmesh_assert( !var_names.empty() );
 
     //! This is really a "composite" function. We'll cast in the helper functions.
-    libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > all_funcs;
+    std::unique_ptr<libMesh::FunctionBase<libMesh::Number> > all_funcs;
 
     // We're given the active variables in var_names. Let's first check
     // which ones the user actually set in the input file.
@@ -264,7 +264,7 @@ namespace GRINS
     /*! \todo We should have a ChemsitryWarehouse or something to just grab this from one place
       instead of rebuilding. */
     ChemistryBuilder chem_builder;
-    libMesh::UniquePtr<ChemistryType> chem_ptr;
+    std::unique_ptr<ChemistryType> chem_ptr;
     chem_builder.build_chemistry(input,material,chem_ptr);
 
     const ChemistryType & chem = *chem_ptr;

--- a/src/boundary_conditions/src/dirichlet_bc_factory_function_base.C
+++ b/src/boundary_conditions/src/dirichlet_bc_factory_function_base.C
@@ -32,7 +32,7 @@
 namespace GRINS
 {
   template<typename FunctionType>
-  libMesh::UniquePtr<libMesh::DirichletBoundary> DirichletBCFactoryFunctionBase<FunctionType>::create()
+  std::unique_ptr<libMesh::DirichletBoundary> DirichletBCFactoryFunctionBase<FunctionType>::create()
   {
     // Make sure all necessary state has been setup
     this->check_state();
@@ -43,7 +43,7 @@ namespace GRINS
     // variables.
     std::vector<std::string> local_var_names = this->get_var_names();
 
-    libMesh::UniquePtr<FunctionType>
+    std::unique_ptr<FunctionType>
       func = this->build_func( *(this->_input), *(this->_system),
                                local_var_names, this->_section );
 
@@ -52,7 +52,7 @@ namespace GRINS
     std::vector<VariableIndex> local_var_indices;
     this->build_var_indices(*(this->_system), local_var_names, local_var_indices);
 
-    libMesh::UniquePtr<libMesh::DirichletBoundary> new_dbc =
+    std::unique_ptr<libMesh::DirichletBoundary> new_dbc =
       this->make_dirichlet_boundary( *(this->_bc_ids), *(this->_system),
                                      func, local_var_indices );
 
@@ -63,25 +63,25 @@ namespace GRINS
   }
 
   template<>
-  libMesh::UniquePtr<libMesh::DirichletBoundary>
+  std::unique_ptr<libMesh::DirichletBoundary>
   DirichletBCFactoryFunctionBase<libMesh::FunctionBase<libMesh::Number> >::make_dirichlet_boundary
   ( const std::set<BoundaryID>& bc_ids,
     const libMesh::System& /*system*/,
-    libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >& func,
+    std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >& func,
     const std::vector<VariableIndex>& var_indices )
   {
-    return libMesh::UniquePtr<libMesh::DirichletBoundary>(new libMesh::DirichletBoundary(bc_ids, var_indices, func.get()));
+    return std::unique_ptr<libMesh::DirichletBoundary>(new libMesh::DirichletBoundary(bc_ids, var_indices, func.get()));
   }
 
   template<>
-  libMesh::UniquePtr<libMesh::DirichletBoundary>
+  std::unique_ptr<libMesh::DirichletBoundary>
   DirichletBCFactoryFunctionBase<libMesh::FEMFunctionBase<libMesh::Number> >::make_dirichlet_boundary
   ( const std::set<BoundaryID>& bc_ids,
     const libMesh::System& system,
-    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >& func,
+    std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >& func,
     const std::vector<VariableIndex>& var_indices )
   {
-    return libMesh::UniquePtr<libMesh::DirichletBoundary>( new libMesh::DirichletBoundary(bc_ids, var_indices, system, func.get()) );
+    return std::unique_ptr<libMesh::DirichletBoundary>( new libMesh::DirichletBoundary(bc_ids, var_indices, system, func.get()) );
   }
 }
 

--- a/src/boundary_conditions/src/gas_recombination_catalytic_wall_neumann_bc_factory_impl.C
+++ b/src/boundary_conditions/src/gas_recombination_catalytic_wall_neumann_bc_factory_impl.C
@@ -66,7 +66,7 @@ namespace GRINS
     if( thermochem_lib == "cantera" )
       {
 #ifdef GRINS_HAVE_CANTERA
-        libMesh::UniquePtr<CanteraMixture> chem_uptr;
+        std::unique_ptr<CanteraMixture> chem_uptr;
         chem_builder.build_chemistry(input,material,chem_uptr);
 
         /*! \todo Update the API for the catalytic walls to take a unique_ptr to avoid this garbage.*/
@@ -81,7 +81,7 @@ namespace GRINS
     else if( thermochem_lib == "antioch" )
       {
 #ifdef GRINS_HAVE_ANTIOCH
-        libMesh::UniquePtr<AntiochChemistry> chem_uptr;
+        std::unique_ptr<AntiochChemistry> chem_uptr;
         chem_builder.build_chemistry(input,material,chem_uptr);
 
         /*! \todo Update the API for the catalytic walls to take a unique_ptr to avoid this garbage.*/

--- a/src/boundary_conditions/src/gas_solid_catalytic_wall_neumann_bc_factory_impl.C
+++ b/src/boundary_conditions/src/gas_solid_catalytic_wall_neumann_bc_factory_impl.C
@@ -67,7 +67,7 @@ namespace GRINS
     if( thermochem_lib == "cantera" )
       {
 #ifdef GRINS_HAVE_CANTERA
-        libMesh::UniquePtr<CanteraMixture> chem_uptr;
+        std::unique_ptr<CanteraMixture> chem_uptr;
         chem_builder.build_chemistry(input,material,chem_uptr);
 
         /*! \todo Update the API for the catalytic walls to take a unique_ptr to avoid this garbage.*/
@@ -82,7 +82,7 @@ namespace GRINS
     else if( thermochem_lib == "antioch" )
       {
 #ifdef GRINS_HAVE_ANTIOCH
-        libMesh::UniquePtr<AntiochChemistry> chem_uptr;
+        std::unique_ptr<AntiochChemistry> chem_uptr;
         chem_builder.build_chemistry(input,material,chem_uptr);
 
         /*! \todo Update the API for the catalytic walls to take a unique_ptr to avoid this garbage.*/

--- a/src/boundary_conditions/src/neumann_bc_factory_abstract.C
+++ b/src/boundary_conditions/src/neumann_bc_factory_abstract.C
@@ -30,9 +30,9 @@
 
 namespace GRINS
 {
-  libMesh::UniquePtr<NeumannBCContainer> NeumannBCFactoryAbstract::create()
+  std::unique_ptr<NeumannBCContainer> NeumannBCFactoryAbstract::create()
   {
-    libMesh::UniquePtr<NeumannBCContainer> container;
+    std::unique_ptr<NeumannBCContainer> container;
 
     // Only build the container if the Neumann BC is *not* homogeneous
     // Otherwise, we just return and empty (NULL) UniquePtr.

--- a/src/boundary_conditions/src/parsed_function_dirichlet_bc_factory.C
+++ b/src/boundary_conditions/src/parsed_function_dirichlet_bc_factory.C
@@ -36,7 +36,7 @@
 namespace GRINS
 {
   template<typename FunctionType>
-  libMesh::UniquePtr<FunctionType>
+  std::unique_ptr<FunctionType>
   ParsedFunctionDirichletBCFactory<FunctionType>::build_func( const GetPot& input,
                                                               MultiphysicsSystem& system,
                                                               std::vector<std::string>& var_names,
@@ -45,7 +45,7 @@ namespace GRINS
     libmesh_assert( !var_names.empty() );
 
     //! This is really a "composite" function.
-    libMesh::UniquePtr<FunctionType> all_funcs;
+    std::unique_ptr<FunctionType> all_funcs;
     all_funcs.reset( this->build_composite_func().release() );
 
     typedef typename TypeFrom<FunctionType>::to_composite composite_type;

--- a/src/boundary_conditions/src/parsed_function_dirichlet_old_style_bc_factory.C
+++ b/src/boundary_conditions/src/parsed_function_dirichlet_old_style_bc_factory.C
@@ -34,7 +34,7 @@
 namespace GRINS
 {
   template<typename FunctionType>
-  libMesh::UniquePtr<FunctionType>
+  std::unique_ptr<FunctionType>
   ParsedFunctionDirichletOldStyleBCFactory<FunctionType>::build_func( const GetPot& input,
                                                                       MultiphysicsSystem& system,
                                                                       std::vector<std::string>& var_names,
@@ -47,7 +47,7 @@ namespace GRINS
     std::string section_str = section+"/"+DirichletBCFactoryFunctionOldStyleBase<FunctionType>::_value_var_old_style;
     std::string expression = input(section_str,"DIE!",DirichletBCFactoryFunctionOldStyleBase<FunctionType>::_value_idx_old_style);
 
-    libMesh::UniquePtr<FunctionType> all_funcs = this->build_composite_func();
+    std::unique_ptr<FunctionType> all_funcs = this->build_composite_func();
 
     typedef typename TypeFrom<FunctionType>::to_composite composite_type;
     composite_type * composite_func =

--- a/src/boundary_conditions/src/parsed_function_factory_helper.C
+++ b/src/boundary_conditions/src/parsed_function_factory_helper.C
@@ -34,33 +34,33 @@
 namespace GRINS
 {
   template<>
-  libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+  std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
   ParsedFunctionFactoryHelper<libMesh::FunctionBase<libMesh::Number> >::build_parsed_func
   ( const MultiphysicsSystem& /*system*/, const std::string& expression )
   {
-    return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::ParsedFunction<libMesh::Number>(expression) );
+    return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::ParsedFunction<libMesh::Number>(expression) );
   }
 
   template<>
-  libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
+  std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >
   ParsedFunctionFactoryHelper<libMesh::FEMFunctionBase<libMesh::Number> >::build_parsed_func
   ( const MultiphysicsSystem& system, const std::string& expression )
   {
-    return libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >( new libMesh::ParsedFEMFunction<libMesh::Number>(system,expression) );
+    return std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >( new libMesh::ParsedFEMFunction<libMesh::Number>(system,expression) );
   }
 
   template<>
-  libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+  std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
   ParsedFunctionFactoryHelper<libMesh::FunctionBase<libMesh::Number> >::build_composite_func()
   {
-    return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::CompositeFunction<libMesh::Number> );
+    return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >( new libMesh::CompositeFunction<libMesh::Number> );
   }
 
   template<>
-  libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
+  std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >
   ParsedFunctionFactoryHelper<libMesh::FEMFunctionBase<libMesh::Number> >::build_composite_func()
   {
-    return libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >( new libMesh::CompositeFEMFunction<libMesh::Number> );
+    return std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >( new libMesh::CompositeFEMFunction<libMesh::Number> );
   }
 
 } // end namespace GRINS

--- a/src/boundary_conditions/src/prescribed_vector_value_dirichlet_old_style_bc_factory.C
+++ b/src/boundary_conditions/src/prescribed_vector_value_dirichlet_old_style_bc_factory.C
@@ -47,7 +47,7 @@
 
 namespace GRINS
 {
-  libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+  std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
   PrescribedVectorValueDirichletOldStyleBCFactory::build_func( const GetPot& input,
                                                                MultiphysicsSystem& system,
                                                                std::vector<std::string>& var_names,
@@ -66,12 +66,12 @@ namespace GRINS
     if( var_names.size() > n_comps )
       libmesh_error_msg("ERROR: Insufficient number of variable components in "+input_string+"!");
 
-    libMesh::UniquePtr<libMesh::CompositeFunction<libMesh::Number> >
+    std::unique_ptr<libMesh::CompositeFunction<libMesh::Number> >
       remapped_func( new libMesh::CompositeFunction<libMesh::Number> );
 
     this->add_funcs(input,system,input_string,var_names,*(remapped_func.get()));
 
-    return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >(remapped_func.release());
+    return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >(remapped_func.release());
   }
 
   void PrescribedVectorValueDirichletOldStyleBCFactory::add_funcs( const GetPot& input,
@@ -178,7 +178,7 @@ namespace GRINS
     /*! \todo We should have a ChemsitryWarehouse or something to just
       grab this from one place instead of rebuilding. */
     ChemistryBuilder chem_builder;
-    libMesh::UniquePtr<ChemistryType> chem_ptr;
+    std::unique_ptr<ChemistryType> chem_ptr;
     chem_builder.build_chemistry(input,material,chem_ptr);
 
     const ChemistryType & chem = *chem_ptr;

--- a/src/common/include/grins/factory_abstract.h
+++ b/src/common/include/grins/factory_abstract.h
@@ -32,7 +32,7 @@
 
 // libMesh
 #include "libmesh/libmesh_common.h" // libmesh_error_msg()
-#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+#include "libmesh/auto_ptr.h" // std::unique_ptr
 
 namespace GRINS
 {
@@ -49,10 +49,10 @@ namespace GRINS
     virtual ~FactoryAbstract(){}
 
     //! Use this method to build objects of type Base.
-    static libMesh::UniquePtr<Base> build(const std::string & name);
+    static std::unique_ptr<Base> build(const std::string & name);
 
     //! Subclasses implement the actual construction of the Base object in create().
-    virtual libMesh::UniquePtr<Base> create () = 0;
+    virtual std::unique_ptr<Base> create () = 0;
 
   protected:
 
@@ -83,7 +83,7 @@ namespace GRINS
 
   template <class Base>
   inline
-  libMesh::UniquePtr<Base> FactoryAbstract<Base>::build(const std::string & name)
+  std::unique_ptr<Base> FactoryAbstract<Base>::build(const std::string & name)
   {
     FactoryAbstract<Base>& factory = get_factory(name);
     return factory.create();

--- a/src/constraints/include/grins/constraint_builder.h
+++ b/src/constraints/include/grins/constraint_builder.h
@@ -46,7 +46,7 @@ namespace GRINS
 
     virtual ~ConstraintBuilder(){};
 
-    static libMesh::UniquePtr<libMesh::System::Constraint>
+    static std::unique_ptr<libMesh::System::Constraint>
     build_constraint_object( const GetPot& input,
                              MultiphysicsSystem& system );
   };

--- a/src/constraints/src/constrained_points.C
+++ b/src/constraints/src/constrained_points.C
@@ -148,7 +148,7 @@ namespace GRINS
     libMesh::MeshBase & mesh = _sys.get_mesh();
     const unsigned int sys_num = _sys.number();
 
-    libMesh::UniquePtr<libMesh::PointLocatorBase> locator =
+    std::unique_ptr<libMesh::PointLocatorBase> locator =
       mesh.sub_point_locator();
 
     for (std::vector<ConstrainedPoint>::const_iterator

--- a/src/constraints/src/constraint_builder.C
+++ b/src/constraints/src/constraint_builder.C
@@ -34,7 +34,7 @@
 
 namespace GRINS
 {
-  libMesh::UniquePtr<libMesh::System::Constraint>
+  std::unique_ptr<libMesh::System::Constraint>
   ConstraintBuilder::build_constraint_object( const GetPot& input,
                                               MultiphysicsSystem& system )
   {
@@ -45,7 +45,7 @@ namespace GRINS
     // If we ever want to add more constraint object options, we'll
     // also need a MultiConstraint object to hold them.
 
-    return libMesh::UniquePtr<libMesh::System::Constraint>
+    return std::unique_ptr<libMesh::System::Constraint>
       (new ConstrainedPoints(input, system));
   }
 } // end namespace GRINS

--- a/src/ic_handling/include/grins/ic_handling_base.h
+++ b/src/ic_handling/include/grins/ic_handling_base.h
@@ -83,7 +83,7 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > _ic_func;
+    std::unique_ptr<libMesh::FunctionBase<libMesh::Number> > _ic_func;
 
     std::string _physics_name;
 

--- a/src/ic_handling/src/ic_handling_base.C
+++ b/src/ic_handling/src/ic_handling_base.C
@@ -180,14 +180,14 @@ namespace GRINS
       {
       case(PARSED):
         {
-          _ic_func = libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+          _ic_func = std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
             (new libMesh::ParsedFunction<libMesh::Number>(ic_value_string));
         }
         break;
 
       case(CONSTANT):
         {
-          _ic_func = libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+          _ic_func = std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
             (new libMesh::ConstFunction<libMesh::Number>
              (StringUtilities::string_to_T<libMesh::Number>(ic_value_string)));
         }

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -114,7 +114,7 @@ namespace GRINS
       libMesh::ParameterMultiAccessor<libMesh::Number>& param_pointer );
 
     //! Override FEMSystem::build_context in order to use our own AssemblyContext
-    virtual libMesh::UniquePtr<libMesh::DiffContext> build_context();
+    virtual std::unique_ptr<libMesh::DiffContext> build_context();
 
     //! Context initialization. Calls each physics implementation of init_context()
     virtual void init_context( libMesh::DiffContext &context );
@@ -215,11 +215,11 @@ namespace GRINS
     /*! Store each NeumannBCContainer for each set of BoundaryIDs and Variables,
       as specified in the input file. The container knows what BoundaryIDs and
       Variables it applies to. We use SharedPtr here because
-      libMesh::UniquePtr may still actually be an AutoPtr. */
+      std::unique_ptr may still actually be an AutoPtr. */
     std::vector<SharedPtr<NeumannBCContainer> > _neumann_bcs;
 
     //! Constraint application object
-    libMesh::UniquePtr<libMesh::System::Constraint> _constraint;
+    std::unique_ptr<libMesh::System::Constraint> _constraint;
 
     // Useful typedef to pointer-to-member functions so we can call all
     // residual and caching functions using a single function (_general_residual)

--- a/src/physics/include/grins/parsed_velocity_source_base.h
+++ b/src/physics/include/grins/parsed_velocity_source_base.h
@@ -60,7 +60,7 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >
     velocity_source_function;
 
   private:

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -238,8 +238,8 @@ namespace GRINS
 
     /*! \todo This is straight up copied from libMesh. Need to make this available from libMesh. */
     std::unique_ptr<libMesh::FEGenericBase<libMesh::Real> > build_new_fe( const libMesh::Elem* elem,
-                                                                             const libMesh::FEGenericBase<libMesh::Real>* fe,
-                                                                             const libMesh::Point p );
+                                                                          const libMesh::FEGenericBase<libMesh::Real>* fe,
+                                                                          const libMesh::Point p );
 
     void parse_enabled_subdomains( const GetPot& input,
                                    const std::string& physics_name );

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -237,7 +237,7 @@ namespace GRINS
   protected:
 
     /*! \todo This is straight up copied from libMesh. Need to make this available from libMesh. */
-    libMesh::UniquePtr<libMesh::FEGenericBase<libMesh::Real> > build_new_fe( const libMesh::Elem* elem,
+    std::unique_ptr<libMesh::FEGenericBase<libMesh::Real> > build_new_fe( const libMesh::Elem* elem,
                                                                              const libMesh::FEGenericBase<libMesh::Real>* fe,
                                                                              const libMesh::Point p );
 

--- a/src/physics/include/grins/physics_factory_base.h
+++ b/src/physics/include/grins/physics_factory_base.h
@@ -53,17 +53,17 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
+    virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name ) =0;
 
   private:
 
-    virtual libMesh::UniquePtr<Physics> create();
+    virtual std::unique_ptr<Physics> create();
 
   };
 
   inline
-  libMesh::UniquePtr<Physics> PhysicsFactoryBase::create()
+  std::unique_ptr<Physics> PhysicsFactoryBase::create()
   {
     // Make sure user set the physics name
     if( _physics_name == std::string("DIE!") )
@@ -72,7 +72,7 @@ namespace GRINS
     if( !_input )
       libmesh_error_msg("ERROR: must call set_getpot() before building Physics!");
 
-    libMesh::UniquePtr<Physics> new_physics = this->build_physics( *_input, _physics_name );
+    std::unique_ptr<Physics> new_physics = this->build_physics( *_input, _physics_name );
 
     // Reset the _physics_name for error checking
     _physics_name = std::string("DIE!");

--- a/src/physics/include/grins/physics_factory_base.h
+++ b/src/physics/include/grins/physics_factory_base.h
@@ -54,7 +54,7 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
-                                                       const std::string& physics_name ) =0;
+                                                    const std::string& physics_name ) =0;
 
   private:
 

--- a/src/physics/include/grins/physics_factory_basic.h
+++ b/src/physics/include/grins/physics_factory_basic.h
@@ -41,10 +41,10 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
+    virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name )
     {
-      return libMesh::UniquePtr<Physics>( new DerivedPhysics(physics_name,input) );
+      return std::unique_ptr<Physics>( new DerivedPhysics(physics_name,input) );
     }
 
   };

--- a/src/physics/include/grins/physics_factory_basic.h
+++ b/src/physics/include/grins/physics_factory_basic.h
@@ -42,7 +42,7 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
-                                                       const std::string& physics_name )
+                                                    const std::string& physics_name )
     {
       return std::unique_ptr<Physics>( new DerivedPhysics(physics_name,input) );
     }

--- a/src/physics/include/grins/physics_factory_heat_transfer.h
+++ b/src/physics/include/grins/physics_factory_heat_transfer.h
@@ -46,7 +46,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
+    virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name );
 
     void cond_error_msg( const std::string& physics, const std::string& conductivity ) const;
@@ -55,7 +55,7 @@ namespace GRINS
 
   template<template<typename> class DerivedPhysics>
   inline
-  libMesh::UniquePtr<Physics>
+  std::unique_ptr<Physics>
   PhysicsFactoryHeatTransfer<DerivedPhysics>::build_physics
   ( const GetPot& input, const std::string& physics_name )
   {
@@ -64,7 +64,7 @@ namespace GRINS
     std::string conductivity;
     PhysicsFactoryHelper::parse_conductivity_model(input,core_physics,conductivity);
 
-    libMesh::UniquePtr<Physics> new_physics;
+    std::unique_ptr<Physics> new_physics;
 
     if( conductivity == "constant" )
       new_physics.reset( new DerivedPhysics<ConstantConductivity>(physics_name,input) );

--- a/src/physics/include/grins/physics_factory_heat_transfer.h
+++ b/src/physics/include/grins/physics_factory_heat_transfer.h
@@ -47,7 +47,7 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
-                                                       const std::string& physics_name );
+                                                    const std::string& physics_name );
 
     void cond_error_msg( const std::string& physics, const std::string& conductivity ) const;
 

--- a/src/physics/include/grins/physics_factory_incompressible_flow.h
+++ b/src/physics/include/grins/physics_factory_incompressible_flow.h
@@ -48,7 +48,7 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
-                                                       const std::string& physics_name );
+                                                    const std::string& physics_name );
 
     void visc_error_msg( const std::string& physics, const std::string& viscosity ) const;
 

--- a/src/physics/include/grins/physics_factory_incompressible_flow.h
+++ b/src/physics/include/grins/physics_factory_incompressible_flow.h
@@ -47,7 +47,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
+    virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name );
 
     void visc_error_msg( const std::string& physics, const std::string& viscosity ) const;
@@ -56,7 +56,7 @@ namespace GRINS
 
   template<template<typename> class DerivedPhysics>
   inline
-  libMesh::UniquePtr<Physics>
+  std::unique_ptr<Physics>
   PhysicsFactoryIncompressibleFlow<DerivedPhysics>::build_physics
   ( const GetPot& input, const std::string& physics_name )
   {
@@ -65,7 +65,7 @@ namespace GRINS
     std::string viscosity;
     PhysicsFactoryHelper::parse_viscosity_model(input,core_physics,viscosity);
 
-    libMesh::UniquePtr<Physics> new_physics;
+    std::unique_ptr<Physics> new_physics;
 
     if( viscosity == "constant" )
       new_physics.reset( new DerivedPhysics<ConstantViscosity>(physics_name,input) );

--- a/src/physics/include/grins/physics_factory_incompressible_turb_flow.h
+++ b/src/physics/include/grins/physics_factory_incompressible_turb_flow.h
@@ -46,7 +46,7 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
-                                                       const std::string& physics_name );
+                                                    const std::string& physics_name );
 
     void visc_error_msg( const std::string& physics, const std::string& viscosity ) const;
 
@@ -55,7 +55,7 @@ namespace GRINS
   template<template<typename> class DerivedPhysics>
   inline
   std::unique_ptr<Physics> PhysicsFactoryIncompressibleTurbFlow<DerivedPhysics>::build_physics( const GetPot& input,
-                                                                                                   const std::string& physics_name )
+                                                                                                const std::string& physics_name )
   {
     std::string core_physics = this->find_core_physics_name(physics_name);
 

--- a/src/physics/include/grins/physics_factory_incompressible_turb_flow.h
+++ b/src/physics/include/grins/physics_factory_incompressible_turb_flow.h
@@ -45,7 +45,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
+    virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name );
 
     void visc_error_msg( const std::string& physics, const std::string& viscosity ) const;
@@ -54,7 +54,7 @@ namespace GRINS
 
   template<template<typename> class DerivedPhysics>
   inline
-  libMesh::UniquePtr<Physics> PhysicsFactoryIncompressibleTurbFlow<DerivedPhysics>::build_physics( const GetPot& input,
+  std::unique_ptr<Physics> PhysicsFactoryIncompressibleTurbFlow<DerivedPhysics>::build_physics( const GetPot& input,
                                                                                                    const std::string& physics_name )
   {
     std::string core_physics = this->find_core_physics_name(physics_name);
@@ -62,7 +62,7 @@ namespace GRINS
     std::string viscosity;
     PhysicsFactoryHelper::parse_turb_viscosity_model(input,core_physics,viscosity);
 
-    libMesh::UniquePtr<Physics> new_physics;
+    std::unique_ptr<Physics> new_physics;
 
     if( viscosity == "constant" )
       new_physics.reset( new DerivedPhysics<ConstantViscosity>(physics_name,input) );

--- a/src/physics/include/grins/physics_factory_one_d_stress_solids.h
+++ b/src/physics/include/grins/physics_factory_one_d_stress_solids.h
@@ -45,14 +45,14 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
+    virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name );
 
   };
 
   template<template<typename> class DerivedPhysics>
   inline
-  libMesh::UniquePtr<Physics> PhysicsFactoryOneDStressSolids<DerivedPhysics>::build_physics( const GetPot& input,
+  std::unique_ptr<Physics> PhysicsFactoryOneDStressSolids<DerivedPhysics>::build_physics( const GetPot& input,
                                                                                              const std::string& physics_name )
   {
     std::string core_physics = this->find_core_physics_name(physics_name);
@@ -65,7 +65,7 @@ namespace GRINS
                                                      model,
                                                      strain_energy );
 
-    libMesh::UniquePtr<Physics> new_physics;
+    std::unique_ptr<Physics> new_physics;
 
     if( model == std::string("hookes_law") )
       {

--- a/src/physics/include/grins/physics_factory_one_d_stress_solids.h
+++ b/src/physics/include/grins/physics_factory_one_d_stress_solids.h
@@ -46,14 +46,14 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
-                                                       const std::string& physics_name );
+                                                    const std::string& physics_name );
 
   };
 
   template<template<typename> class DerivedPhysics>
   inline
   std::unique_ptr<Physics> PhysicsFactoryOneDStressSolids<DerivedPhysics>::build_physics( const GetPot& input,
-                                                                                             const std::string& physics_name )
+                                                                                          const std::string& physics_name )
   {
     std::string core_physics = this->find_core_physics_name(physics_name);
 

--- a/src/physics/include/grins/physics_factory_plane_stress_solids.h
+++ b/src/physics/include/grins/physics_factory_plane_stress_solids.h
@@ -48,14 +48,14 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
+    virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name );
 
   };
 
   template<template<typename> class DerivedPhysics>
   inline
-  libMesh::UniquePtr<Physics>
+  std::unique_ptr<Physics>
   PhysicsFactoryPlaneStressSolids<DerivedPhysics>::build_physics
   ( const GetPot& input, const std::string& physics_name )
   {
@@ -69,7 +69,7 @@ namespace GRINS
                                                      model,
                                                      strain_energy );
 
-    libMesh::UniquePtr<Physics> new_physics;
+    std::unique_ptr<Physics> new_physics;
 
     if( model == std::string("hookes_law") )
       new_physics.reset( new DerivedPhysics<HookesLaw>

--- a/src/physics/include/grins/physics_factory_plane_stress_solids.h
+++ b/src/physics/include/grins/physics_factory_plane_stress_solids.h
@@ -49,7 +49,7 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
-                                                       const std::string& physics_name );
+                                                    const std::string& physics_name );
 
   };
 

--- a/src/physics/include/grins/physics_factory_reacting_flows.h
+++ b/src/physics/include/grins/physics_factory_reacting_flows.h
@@ -51,7 +51,7 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
-                                                       const std::string& physics_name );
+                                                    const std::string& physics_name );
 
     void grins_antioch_model_error_msg( const std::string& viscosity_model,
                                         const std::string& conductivity_model,

--- a/src/physics/include/grins/physics_factory_reacting_flows.h
+++ b/src/physics/include/grins/physics_factory_reacting_flows.h
@@ -50,7 +50,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
+    virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name );
 
     void grins_antioch_model_error_msg( const std::string& viscosity_model,
@@ -63,13 +63,13 @@ namespace GRINS
                                   const std::string & material,
                                   const std::string & thermo_model, const std::string & diffusivity_model,
                                   const std::string & conductivity_model, const std::string & viscosity_model,
-                                  libMesh::UniquePtr<Physics> & new_physics );
+                                  std::unique_ptr<Physics> & new_physics );
 
     void build_const_physics( const GetPot & input, const std::string & physics_name,
                               const std::string & material,
                               const std::string & thermo_model, const std::string & diffusivity_model,
                               const std::string & conductivity_model, const std::string & viscosity_model,
-                              libMesh::UniquePtr<Physics> & new_physics );
+                              std::unique_ptr<Physics> & new_physics );
 
 #ifdef GRINS_HAVE_ANTIOCH
     template<typename KineticsThermo,typename Thermo>
@@ -78,7 +78,7 @@ namespace GRINS
                                               const std::string & diffusivity_model,
                                               const std::string & conductivity_model,
                                               const std::string & viscosity_model,
-                                              libMesh::UniquePtr<Physics> & new_physics )
+                                              std::unique_ptr<Physics> & new_physics )
     {
       if( (diffusivity_model == AntiochOptions::constant_lewis_diffusivity_model()) &&
           (conductivity_model == AntiochOptions::eucken_conductivity_model()) &&
@@ -121,7 +121,7 @@ namespace GRINS
     template<typename KineticsThermo,typename Thermo>
     void build_const_physics_with_thermo( const GetPot & input, const std::string & physics_name,
                                           const std::string & material, const std::string & conductivity_model,
-                                          libMesh::UniquePtr<Physics> & new_physics )
+                                          std::unique_ptr<Physics> & new_physics )
     {
       if( conductivity_model == AntiochOptions::constant_conductivity_model() )
         {
@@ -145,11 +145,11 @@ namespace GRINS
 
     template<typename KineticsThermo,typename Thermo,typename Viscosity,typename Conductivity,typename Diffusivity>
     void build_mix_avged_physics_ptr( const GetPot& input, const std::string& physics_name,
-                                      const std::string & material, libMesh::UniquePtr<Physics> & new_physics )
+                                      const std::string & material, std::unique_ptr<Physics> & new_physics )
     {
       AntiochMixtureAveragedTransportMixtureBuilder mix_builder;
 
-      libMesh::UniquePtr<AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> >
+      std::unique_ptr<AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> >
         gas_mixture = mix_builder.build_mixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity>(input,material);
 
       new_physics.reset(new DerivedPhysics<AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity>,
@@ -159,11 +159,11 @@ namespace GRINS
 
     template<typename KineticsThermo,typename Thermo,typename Conductivity>
     void build_const_physics_ptr( const GetPot& input, const std::string& physics_name,
-                                  const std::string & material, libMesh::UniquePtr<Physics> & new_physics )
+                                  const std::string & material, std::unique_ptr<Physics> & new_physics )
     {
       AntiochConstantTransportMixtureBuilder mix_builder;
 
-      libMesh::UniquePtr<GRINS::AntiochConstantTransportMixture<KineticsThermo,Conductivity> >
+      std::unique_ptr<GRINS::AntiochConstantTransportMixture<KineticsThermo,Conductivity> >
         gas_mixture = mix_builder.build_mixture<KineticsThermo,Conductivity>(input,material);
 
       new_physics.reset(new DerivedPhysics<AntiochConstantTransportMixture<KineticsThermo,Conductivity>,

--- a/src/physics/include/grins/physics_factory_variable_density_flow.h
+++ b/src/physics/include/grins/physics_factory_variable_density_flow.h
@@ -48,7 +48,7 @@ namespace GRINS
   protected:
 
     virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
-                                                       const std::string& physics_name );
+                                                    const std::string& physics_name );
 
     void prop_error_msg( const std::string& physics,
                          const std::string& conductivity,
@@ -60,7 +60,7 @@ namespace GRINS
   template<template<typename,typename,typename> class DerivedPhysics>
   inline
   std::unique_ptr<Physics> PhysicsFactoryVariableDensityFlow<DerivedPhysics>::build_physics( const GetPot& input,
-                                                                                                const std::string& physics_name )
+                                                                                             const std::string& physics_name )
   {
     std::string core_physics = this->find_core_physics_name(physics_name);
 

--- a/src/physics/include/grins/physics_factory_variable_density_flow.h
+++ b/src/physics/include/grins/physics_factory_variable_density_flow.h
@@ -47,7 +47,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Physics> build_physics( const GetPot& input,
+    virtual std::unique_ptr<Physics> build_physics( const GetPot& input,
                                                        const std::string& physics_name );
 
     void prop_error_msg( const std::string& physics,
@@ -59,7 +59,7 @@ namespace GRINS
 
   template<template<typename,typename,typename> class DerivedPhysics>
   inline
-  libMesh::UniquePtr<Physics> PhysicsFactoryVariableDensityFlow<DerivedPhysics>::build_physics( const GetPot& input,
+  std::unique_ptr<Physics> PhysicsFactoryVariableDensityFlow<DerivedPhysics>::build_physics( const GetPot& input,
                                                                                                 const std::string& physics_name )
   {
     std::string core_physics = this->find_core_physics_name(physics_name);
@@ -73,7 +73,7 @@ namespace GRINS
     std::string specific_heat;
     PhysicsFactoryHelper::parse_specific_heat_model(input,core_physics,specific_heat);
 
-    libMesh::UniquePtr<Physics> new_physics;
+    std::unique_ptr<Physics> new_physics;
 
     if(  conductivity == "constant" && viscosity == "constant" && specific_heat == "constant" )
       new_physics.reset( new DerivedPhysics<ConstantViscosity,ConstantSpecificHeat,ConstantConductivity>

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes.h
@@ -37,7 +37,7 @@ namespace GRINS
   public:
 
     ReactingLowMachNavierStokes(const PhysicsName& physics_name, const GetPot& input,
-                                libMesh::UniquePtr<Mixture> & gas_mix);
+                                std::unique_ptr<Mixture> & gas_mix);
 
     virtual ~ReactingLowMachNavierStokes(){};
 

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
@@ -39,7 +39,7 @@ namespace GRINS
 
     ReactingLowMachNavierStokesBase(const PhysicsName& physics_name,
                                     const GetPot& input,
-                                    libMesh::UniquePtr<Mixture> & gas_mix )
+                                    std::unique_ptr<Mixture> & gas_mix )
       : ReactingLowMachNavierStokesAbstract(physics_name,input),
         _gas_mixture(gas_mix.release()) /*! \todo Use std::move when we mandate C++11 */
     {}
@@ -61,7 +61,7 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<Mixture> _gas_mixture;
+    std::unique_ptr<Mixture> _gas_mixture;
 
   private:
 

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
@@ -36,7 +36,7 @@ namespace GRINS
   public:
 
     ReactingLowMachNavierStokesSPGSMStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input,
-                                                   libMesh::UniquePtr<Mixture> & gas_mix);
+                                                   std::unique_ptr<Mixture> & gas_mix);
     virtual ~ReactingLowMachNavierStokesSPGSMStabilization(){};
 
     virtual void element_time_derivative( bool compute_jacobian,

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_base.h
@@ -40,7 +40,7 @@ namespace GRINS
   public:
 
     ReactingLowMachNavierStokesStabilizationBase( const GRINS::PhysicsName& physics_name, const GetPot& input,
-                                                  libMesh::UniquePtr<Mixture> & gas_mix);
+                                                  std::unique_ptr<Mixture> & gas_mix);
 
     virtual ~ReactingLowMachNavierStokesStabilizationBase(){};
 

--- a/src/physics/include/grins/scalar_ode.h
+++ b/src/physics/include/grins/scalar_ode.h
@@ -83,7 +83,7 @@ namespace GRINS
 
     // ParsedFEMFunctions evaluating the mass, time derivative, and
     // constraint components of an ODE.
-    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >
     time_deriv_function,
       constraint_function,
       mass_residual_function;

--- a/src/physics/include/grins/spalart_allmaras.h
+++ b/src/physics/include/grins/spalart_allmaras.h
@@ -79,10 +79,10 @@ namespace GRINS
                                 AssemblyContext & context );
 
     // A distance function to get distances from boundaries to qps
-    libMesh::UniquePtr<DistanceFunction> distance_function;
+    std::unique_ptr<DistanceFunction> distance_function;
 
     // Boundary mesh objected that will be updated using the wall ids
-    libMesh::UniquePtr<libMesh::SerialMesh> boundary_mesh;
+    std::unique_ptr<libMesh::SerialMesh> boundary_mesh;
 
     // Registers all parameters in this physics and in its property
     // classes

--- a/src/physics/include/grins/velocity_penalty_base.h
+++ b/src/physics/include/grins/velocity_penalty_base.h
@@ -65,10 +65,10 @@ namespace GRINS
 
     bool _quadratic_scaling;
 
-    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >
     normal_vector_function;
 
-    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >
     base_velocity_function;
 
   private:

--- a/src/physics/src/elastic_cable.C
+++ b/src/physics/src/elastic_cable.C
@@ -137,7 +137,7 @@ namespace GRINS
           w_coeffs = &context.get_elem_solution( this->_disp_vars.w() );
 
         // Build new FE for the current point. We need this to build tensors at point.
-        libMesh::UniquePtr<libMesh::FEGenericBase<libMesh::Real> > fe_new =  this->build_new_fe( &context.get_elem(), this->get_fe(context), point );
+        std::unique_ptr<libMesh::FEGenericBase<libMesh::Real> > fe_new =  this->build_new_fe( &context.get_elem(), this->get_fe(context), point );
 
         const std::vector<std::vector<libMesh::Real> >& dphi_dxi =  fe_new->get_dphidxi();
 

--- a/src/physics/src/elastic_membrane.C
+++ b/src/physics/src/elastic_membrane.C
@@ -411,7 +411,7 @@ namespace GRINS
           w_coeffs = &context.get_elem_solution( this->_disp_vars.w() );
 
         // Build new FE for the current point. We need this to build tensors at point.
-        libMesh::UniquePtr<libMesh::FEGenericBase<libMesh::Real> > fe_new =
+        std::unique_ptr<libMesh::FEGenericBase<libMesh::Real> > fe_new =
           this->build_new_fe( &context.get_elem(), this->get_fe(context),
                               point );
 

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -195,11 +195,11 @@ namespace GRINS
     return;
   }
 
-  libMesh::UniquePtr<libMesh::DiffContext> MultiphysicsSystem::build_context()
+  std::unique_ptr<libMesh::DiffContext> MultiphysicsSystem::build_context()
   {
     AssemblyContext* context = new AssemblyContext(*this);
 
-    libMesh::UniquePtr<libMesh::DiffContext> ap(context);
+    std::unique_ptr<libMesh::DiffContext> ap(context);
 
     libMesh::DifferentiablePhysics* phys = libMesh::FEMSystem::get_physics();
 

--- a/src/physics/src/physics.C
+++ b/src/physics/src/physics.C
@@ -141,8 +141,8 @@ namespace GRINS
   }
 
   std::unique_ptr<libMesh::FEGenericBase<libMesh::Real> > Physics::build_new_fe( const libMesh::Elem* elem,
-                                                                                    const libMesh::FEGenericBase<libMesh::Real>* fe,
-                                                                                    const libMesh::Point p )
+                                                                                 const libMesh::FEGenericBase<libMesh::Real>* fe,
+                                                                                 const libMesh::Point p )
   {
     using namespace libMesh;
     FEType fe_type = fe->get_fe_type();

--- a/src/physics/src/physics.C
+++ b/src/physics/src/physics.C
@@ -140,7 +140,7 @@ namespace GRINS
     return;
   }
 
-  libMesh::UniquePtr<libMesh::FEGenericBase<libMesh::Real> > Physics::build_new_fe( const libMesh::Elem* elem,
+  std::unique_ptr<libMesh::FEGenericBase<libMesh::Real> > Physics::build_new_fe( const libMesh::Elem* elem,
                                                                                     const libMesh::FEGenericBase<libMesh::Real>* fe,
                                                                                     const libMesh::Point p )
   {
@@ -154,7 +154,7 @@ namespace GRINS
 
     unsigned int elem_dim = elem ? elem->dim() : 0;
 
-    UniquePtr<FEGenericBase<libMesh::Real> >
+    std::unique_ptr<FEGenericBase<libMesh::Real> >
       fe_new(FEGenericBase<libMesh::Real>::build(elem_dim, fe_type));
 
     // Map the physical co-ordinates to the master co-ordinates using the inverse_map from fe_interface.h

--- a/src/physics/src/physics_builder.C
+++ b/src/physics/src/physics_builder.C
@@ -66,7 +66,7 @@ namespace GRINS
         std::string physics_name_prefix = PhysicsNaming::extract_physics(physics_name);
 
         // Now build the actual Physics object
-        libMesh::UniquePtr<Physics> physics_ptr = PhysicsFactoryBase::build(physics_name_prefix);
+        std::unique_ptr<Physics> physics_ptr = PhysicsFactoryBase::build(physics_name_prefix);
 
         // Clear out the suffix now that we're done
         PhysicsNaming::clear_suffix();

--- a/src/physics/src/physics_factory_reacting_flows.C
+++ b/src/physics/src/physics_factory_reacting_flows.C
@@ -25,7 +25,7 @@ namespace GRINS
 {
   template<template<typename,typename> class DerivedPhysics>
   std::unique_ptr<Physics> PhysicsFactoryReactingFlows<DerivedPhysics>::build_physics( const GetPot& input,
-                                                                                          const std::string& physics_name )
+                                                                                       const std::string& physics_name )
   {
     std::string core_physics = this->find_core_physics_name(physics_name);
 

--- a/src/physics/src/physics_factory_reacting_flows.C
+++ b/src/physics/src/physics_factory_reacting_flows.C
@@ -24,7 +24,7 @@
 namespace GRINS
 {
   template<template<typename,typename> class DerivedPhysics>
-  libMesh::UniquePtr<Physics> PhysicsFactoryReactingFlows<DerivedPhysics>::build_physics( const GetPot& input,
+  std::unique_ptr<Physics> PhysicsFactoryReactingFlows<DerivedPhysics>::build_physics( const GetPot& input,
                                                                                           const std::string& physics_name )
   {
     std::string core_physics = this->find_core_physics_name(physics_name);
@@ -36,12 +36,12 @@ namespace GRINS
                                                        core_physics,
                                                        thermochem_lib );
 
-    libMesh::UniquePtr<Physics> new_physics;
+    std::unique_ptr<Physics> new_physics;
 
     if( thermochem_lib == "cantera" )
       {
 #ifdef GRINS_HAVE_CANTERA
-        libMesh::UniquePtr<CanteraMixture> gas_mix( new CanteraMixture(input,material) );
+        std::unique_ptr<CanteraMixture> gas_mix( new CanteraMixture(input,material) );
 
         new_physics.reset(new DerivedPhysics<CanteraMixture,CanteraEvaluator>(physics_name,input,gas_mix));
 #else
@@ -115,7 +115,7 @@ namespace GRINS
   build_mix_avged_physics( const GetPot & input, const std::string & physics_name, const std::string & material,
                            const std::string & thermo_model, const std::string & diffusivity_model,
                            const std::string & conductivity_model, const std::string & viscosity_model,
-                           libMesh::UniquePtr<Physics> & new_physics )
+                           std::unique_ptr<Physics> & new_physics )
   {
     if( (thermo_model == AntiochOptions::stat_mech_thermo_model()) )
       {
@@ -146,7 +146,7 @@ namespace GRINS
   build_const_physics( const GetPot & input, const std::string & physics_name, const std::string & material,
                        const std::string & thermo_model, const std::string & diffusivity_model,
                        const std::string & conductivity_model, const std::string & viscosity_model,
-                       libMesh::UniquePtr<Physics> & new_physics )
+                       std::unique_ptr<Physics> & new_physics )
   {
     // First check the things we must have for constant transport models
     if( viscosity_model != AntiochOptions::constant_viscosity_model() )

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -41,7 +41,7 @@ namespace GRINS
   template<typename Mixture, typename Evaluator>
   ReactingLowMachNavierStokes<Mixture,Evaluator>::ReactingLowMachNavierStokes(const PhysicsName& physics_name,
                                                                               const GetPot& input,
-                                                                              libMesh::UniquePtr<Mixture> & gas_mix)
+                                                                              std::unique_ptr<Mixture> & gas_mix)
     : ReactingLowMachNavierStokesBase<Mixture>(physics_name,input,gas_mix),
     _p_pinning(input,physics_name),
     _rho_index(0),

--- a/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
@@ -35,7 +35,7 @@ namespace GRINS
 {
   template<typename Mixture, typename Evaluator>
   ReactingLowMachNavierStokesSPGSMStabilization<Mixture,Evaluator>::ReactingLowMachNavierStokesSPGSMStabilization
-  ( const GRINS::PhysicsName& physics_name, const GetPot& input,libMesh::UniquePtr<Mixture> & gas_mix )
+  ( const GRINS::PhysicsName& physics_name, const GetPot& input,std::unique_ptr<Mixture> & gas_mix )
     : ReactingLowMachNavierStokesStabilizationBase<Mixture,Evaluator>(physics_name,input,gas_mix)
   {}
 

--- a/src/physics/src/reacting_low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_stab_base.C
@@ -35,7 +35,7 @@ namespace GRINS
 
   template<typename Mixture, typename Evaluator>
   ReactingLowMachNavierStokesStabilizationBase<Mixture,Evaluator>::ReactingLowMachNavierStokesStabilizationBase
-  ( const std::string& physics_name,const GetPot& input,libMesh::UniquePtr<Mixture> & gas_mix )
+  ( const std::string& physics_name,const GetPot& input,std::unique_ptr<Mixture> & gas_mix )
     : ReactingLowMachNavierStokesBase<Mixture>(physics_name,input,gas_mix),
     _stab_helper( physics_name+"StabHelper", input )
   {}

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -165,7 +165,7 @@ namespace GRINS
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     // Auto pointer to distance fcn evaluated at quad points
-    libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> > distance_qp;
+    std::unique_ptr< libMesh::DenseVector<libMesh::Real> > distance_qp;
 
     // Fill the vector of distances to quadrature points
     distance_qp = this->distance_function->interpolate(&elem_pointer, context.get_element_qrule().get_points());

--- a/src/physics/src/spalart_allmaras_spgsm_stab.C
+++ b/src/physics/src/spalart_allmaras_spgsm_stab.C
@@ -96,7 +96,7 @@ namespace GRINS
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     // Auto pointer to distance fcn evaluated at quad points
-    libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> > distance_qp;
+    std::unique_ptr< libMesh::DenseVector<libMesh::Real> > distance_qp;
 
     // Fill the vector of distances to quadrature points
     distance_qp = this->distance_function->interpolate(&elem_pointer, context.get_element_qrule().get_points());
@@ -172,7 +172,7 @@ namespace GRINS
     unsigned int n_qpoints = context.get_element_qrule().n_points();
 
     // Auto pointer to distance fcn evaluated at quad points
-    libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> > distance_qp;
+    std::unique_ptr< libMesh::DenseVector<libMesh::Real> > distance_qp;
 
     // Fill the vector of distances to quadrature points
     distance_qp = this->distance_function->interpolate(&elem_pointer, context.get_element_qrule().get_points());

--- a/src/properties/include/grins/antioch_chemistry.h
+++ b/src/properties/include/grins/antioch_chemistry.h
@@ -36,7 +36,7 @@
 
 // libMesh
 #include "libmesh/libmesh_common.h"
-#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+#include "libmesh/auto_ptr.h" // std::unique_ptr
 
 // Antioch
 #include "antioch/vector_utils_decl.h"
@@ -64,7 +64,7 @@ namespace GRINS
     AntiochChemistry( const GetPot& input, const std::string& material );
 
     //! User passes in built ChemicalMixture and this class takes ownership
-    AntiochChemistry( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture );
+    AntiochChemistry( std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture );
 
     virtual ~AntiochChemistry(){}
 
@@ -112,7 +112,7 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > _antioch_gas;
+    std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > _antioch_gas;
 
   private:
 

--- a/src/properties/include/grins/antioch_constant_transport_mixture.h
+++ b/src/properties/include/grins/antioch_constant_transport_mixture.h
@@ -63,12 +63,12 @@ namespace GRINS
     AntiochConstantTransportMixture( const GetPot & input, const std::string & material );
 
     //! Constructor with user-built objects
-    AntiochConstantTransportMixture( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
-                                     libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
-                                     libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
-                                     libMesh::UniquePtr<ConstantViscosity> & visc,
-                                     libMesh::UniquePtr<Conductivity> & cond,
-                                     libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > & diff,
+    AntiochConstantTransportMixture( std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
+                                     std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
+                                     std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
+                                     std::unique_ptr<ConstantViscosity> & visc,
+                                     std::unique_ptr<Conductivity> & cond,
+                                     std::unique_ptr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > & diff,
                                      libMesh::Real min_T = -std::numeric_limits<libMesh::Real>::max(),
                                      bool clip_negative_rho = false );
 
@@ -88,12 +88,12 @@ namespace GRINS
     /*! \todo Template on viscosity model, as we did for conductivity,
       to support parsed versions. This is going to require we update the
       API for the transport wrappers. */
-    libMesh::UniquePtr<ConstantViscosity> _mu;
+    std::unique_ptr<ConstantViscosity> _mu;
 
     //! Thermal conductivity
-    libMesh::UniquePtr<Conductivity> _conductivity;
+    std::unique_ptr<Conductivity> _conductivity;
 
-    libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > _diffusivity;
+    std::unique_ptr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > _diffusivity;
 
     /* Below we will specialize the specialized_build_* functions to the appropriate type.
        This way, we can control how the cached transport objects get constructed
@@ -107,14 +107,14 @@ namespace GRINS
     AntiochConstantTransportMixture();
 
     void specialized_build_conductivity( const GetPot & input, const std::string & material,
-                                         libMesh::UniquePtr<ConstantConductivity> & conductivity,
+                                         std::unique_ptr<ConstantConductivity> & conductivity,
                                          conductivity_type<ConstantConductivity> )
     {
       conductivity.reset( new ConstantConductivity(input,material) );
     }
 
     void specialized_build_conductivity( const GetPot & input, const std::string & material,
-                                         libMesh::UniquePtr<ConstantPrandtlConductivity> & conductivity,
+                                         std::unique_ptr<ConstantPrandtlConductivity> & conductivity,
                                          conductivity_type<ConstantPrandtlConductivity> )
     {
       conductivity.reset( new ConstantPrandtlConductivity(input,material) );

--- a/src/properties/include/grins/antioch_constant_transport_mixture_builder.h
+++ b/src/properties/include/grins/antioch_constant_transport_mixture_builder.h
@@ -51,75 +51,75 @@ namespace GRINS
     ~AntiochConstantTransportMixtureBuilder(){}
 
     template<typename KineticsThermoCurveFit,typename Conductivity>
-    libMesh::UniquePtr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
+    std::unique_ptr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
     build_mixture( const GetPot & input, const std::string & material );
 
-    libMesh::UniquePtr<ConstantViscosity>
+    std::unique_ptr<ConstantViscosity>
     build_constant_viscosity( const GetPot & input, const std::string & material )
     {
-      return libMesh::UniquePtr<ConstantViscosity>( new ConstantViscosity(input,material) );
+      return std::unique_ptr<ConstantViscosity>( new ConstantViscosity(input,material) );
     }
 
     template<typename Conductivity>
-    libMesh::UniquePtr<Conductivity>
+    std::unique_ptr<Conductivity>
     build_constant_conductivity( const GetPot & input, const std::string & material )
     {
       return specialized_build_conductivity( input, material, conductivity_type<Conductivity>() );
     }
 
-    libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> >
+    std::unique_ptr<Antioch::ConstantLewisDiffusivity<libMesh::Real> >
     build_constant_lewis_diff( const GetPot & input, const std::string & material )
     {
       libMesh::Real Le = MaterialsParsing::parse_lewis_number(input,material);
-      return libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> >
+      return std::unique_ptr<Antioch::ConstantLewisDiffusivity<libMesh::Real> >
         ( new Antioch::ConstantLewisDiffusivity<libMesh::Real>(Le) );
     }
 
   private:
 
-    libMesh::UniquePtr<ConstantConductivity>
+    std::unique_ptr<ConstantConductivity>
     specialized_build_conductivity( const GetPot & input, const std::string & material,
                                     conductivity_type<ConstantConductivity> )
     {
-      return libMesh::UniquePtr<ConstantConductivity>( new ConstantConductivity(input,material) );
+      return std::unique_ptr<ConstantConductivity>( new ConstantConductivity(input,material) );
     }
 
-    libMesh::UniquePtr<ConstantPrandtlConductivity>
+    std::unique_ptr<ConstantPrandtlConductivity>
     specialized_build_conductivity( const GetPot & input, const std::string & material,
                                     conductivity_type<ConstantPrandtlConductivity> )
     {
-      return libMesh::UniquePtr<ConstantPrandtlConductivity>( new ConstantPrandtlConductivity(input,material) );
+      return std::unique_ptr<ConstantPrandtlConductivity>( new ConstantPrandtlConductivity(input,material) );
     }
 
   };
 
   template<typename KineticsThermoCurveFit,typename Conductivity>
   inline
-  libMesh::UniquePtr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
+  std::unique_ptr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
   AntiochConstantTransportMixtureBuilder::build_mixture( const GetPot & input, const std::string & material )
   {
-    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix =
+    std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix =
       this->build_chem_mix(input,material);
 
-    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > reaction_set =
+    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > reaction_set =
       this->build_reaction_set(input,material,*chem_mix);
 
-    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > kinetics_thermo =
+    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > kinetics_thermo =
       this->build_nasa_thermo_mix<KineticsThermoCurveFit>(input,material,*chem_mix);
 
-    libMesh::UniquePtr<ConstantViscosity> visc =
+    std::unique_ptr<ConstantViscosity> visc =
       this->build_constant_viscosity(input,material);
 
-    libMesh::UniquePtr<Conductivity> cond =
+    std::unique_ptr<Conductivity> cond =
       this->build_constant_conductivity<Conductivity>(input,material);
 
-    libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > diff =
+    std::unique_ptr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > diff =
       this->build_constant_lewis_diff(input,material);
 
     libMesh::Real min_T = this->parse_min_T(input,material);
     bool clip_negative_rho = this->parse_clip_negative_rho(input,material);
 
-    return libMesh::UniquePtr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
+    return std::unique_ptr<AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity> >
       ( new AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity>
         (chem_mix, reaction_set, kinetics_thermo, visc, cond, diff, min_T, clip_negative_rho) );
   }

--- a/src/properties/include/grins/antioch_evaluator.h
+++ b/src/properties/include/grins/antioch_evaluator.h
@@ -96,12 +96,12 @@ namespace GRINS
     const AntiochMixture<KineticsThermoCurveFit> & _chem;
 
     //! Primary thermo object.
-    libMesh::UniquePtr<Thermo> _thermo;
+    std::unique_ptr<Thermo> _thermo;
 
     //! For some Thermo types, we also need to cache a NASAEvaluator.
-    libMesh::UniquePtr<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit> > _nasa_evaluator;
+    std::unique_ptr<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit> > _nasa_evaluator;
 
-    libMesh::UniquePtr<AntiochKinetics<KineticsThermoCurveFit> > _kinetics;
+    std::unique_ptr<AntiochKinetics<KineticsThermoCurveFit> > _kinetics;
 
     // Temperature should be clipped to positive values for
     // stability's sake
@@ -111,7 +111,7 @@ namespace GRINS
     // requested.  Some reaction equations give us NaNs at 0K too.
     const libMesh::Real _minimum_T;
 
-    libMesh::UniquePtr<Antioch::TempCache<libMesh::Real> > _temp_cache;
+    std::unique_ptr<Antioch::TempCache<libMesh::Real> > _temp_cache;
 
     //! Helper method for managing _temp_cache
     /*! T *MUST* be pass-by-reference because of the structure
@@ -130,14 +130,14 @@ namespace GRINS
     AntiochEvaluator();
 
     void specialized_build_thermo( const AntiochMixture<KineticsThermoCurveFit> & mixture,
-                                   libMesh::UniquePtr<Antioch::StatMechThermodynamics<libMesh::Real> >& thermo,
+                                   std::unique_ptr<Antioch::StatMechThermodynamics<libMesh::Real> >& thermo,
                                    thermo_type<Antioch::StatMechThermodynamics<libMesh::Real> > )
     {
       thermo.reset( new Antioch::StatMechThermodynamics<libMesh::Real>( mixture.chemical_mixture() ) );
     }
 
     void specialized_build_thermo( const AntiochMixture<KineticsThermoCurveFit> & mixture,
-                                   libMesh::UniquePtr<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit>, libMesh::Real> > & thermo,
+                                   std::unique_ptr<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit>, libMesh::Real> > & thermo,
                                    thermo_type<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit>, libMesh::Real> > )
     {
       _nasa_evaluator.reset( new Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit>( mixture.nasa_mixture() ) );

--- a/src/properties/include/grins/antioch_mixture.h
+++ b/src/properties/include/grins/antioch_mixture.h
@@ -74,9 +74,9 @@ namespace GRINS
     //! Constructor with user-built objects
     /*! This constructor expects the user to pass in a ChemicalMixture, ReactionSet, and NASAThermoMixture
       object already built; this class will take ownership of the pointer. */
-    AntiochMixture( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
-                    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
-                    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
+    AntiochMixture( std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
+                    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
+                    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
                     libMesh::Real min_T = -std::numeric_limits<libMesh::Real>::max(),
                     bool clip_negative_rho = false );
 
@@ -105,9 +105,9 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > _reaction_set;
+    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > _reaction_set;
 
-    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > _nasa_mixture;
+    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > _nasa_mixture;
 
     std::vector<libMesh::Real> _h_stat_mech_ref_correction;
 

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
@@ -77,7 +77,7 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<Antioch::MixtureAveragedTransportEvaluator<Diffusivity,Viscosity,Conductivity,libMesh::Real> > _wilke_evaluator;
+    std::unique_ptr<Antioch::MixtureAveragedTransportEvaluator<Diffusivity,Viscosity,Conductivity,libMesh::Real> > _wilke_evaluator;
 
     const Antioch::MixtureDiffusion<Diffusivity,libMesh::Real>& _diffusivity;
 

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
@@ -90,13 +90,13 @@ namespace GRINS
     AntiochMixtureAveragedTransportMixture( const GetPot& input, const std::string& material );
 
     //! Constructor with user-built objects
-    AntiochMixtureAveragedTransportMixture( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
-                                            libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
-                                            libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & kinetics_thermo_mix,
-                                            libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> > & trans_mix,
-                                            libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > & wilke_mix,
-                                            libMesh::UniquePtr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> > & visc,
-                                            libMesh::UniquePtr<Antioch::MixtureDiffusion<Diffusivity,libMesh::Real> > & diff,
+    AntiochMixtureAveragedTransportMixture( std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
+                                            std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
+                                            std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & kinetics_thermo_mix,
+                                            std::unique_ptr<Antioch::TransportMixture<libMesh::Real> > & trans_mix,
+                                            std::unique_ptr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > & wilke_mix,
+                                            std::unique_ptr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> > & visc,
+                                            std::unique_ptr<Antioch::MixtureDiffusion<Diffusivity,libMesh::Real> > & diff,
                                             libMesh::Real min_T = -std::numeric_limits<libMesh::Real>::max(),
                                             bool clip_negative_rho = false );
 
@@ -114,20 +114,20 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> > _trans_mixture;
+    std::unique_ptr<Antioch::TransportMixture<libMesh::Real> > _trans_mixture;
 
-    libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > _wilke_mixture;
+    std::unique_ptr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > _wilke_mixture;
 
-    libMesh::UniquePtr<Thermo> _thermo;
+    std::unique_ptr<Thermo> _thermo;
 
     //! For some Thermo types, we also need to cache a NASAEvaluator.
-    libMesh::UniquePtr<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit> > _nasa_evaluator;
+    std::unique_ptr<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit> > _nasa_evaluator;
 
-    libMesh::UniquePtr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> > _viscosity;
+    std::unique_ptr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> > _viscosity;
 
-    libMesh::UniquePtr<Antioch::MixtureConductivity<Conductivity,libMesh::Real> > _conductivity;
+    std::unique_ptr<Antioch::MixtureConductivity<Conductivity,libMesh::Real> > _conductivity;
 
-    libMesh::UniquePtr<Antioch::MixtureDiffusion<Diffusivity,libMesh::Real> > _diffusivity;
+    std::unique_ptr<Antioch::MixtureDiffusion<Diffusivity,libMesh::Real> > _diffusivity;
 
     /* Below we will specialize the specialized_build_* functions to the appropriate type.
        This way, we can control how the cached transport objects get constructed
@@ -149,13 +149,13 @@ namespace GRINS
 
     AntiochMixtureAveragedTransportMixture();
 
-    void specialized_build_thermo( libMesh::UniquePtr<Antioch::StatMechThermodynamics<libMesh::Real> > & thermo,
+    void specialized_build_thermo( std::unique_ptr<Antioch::StatMechThermodynamics<libMesh::Real> > & thermo,
                                    thermo_type<Antioch::StatMechThermodynamics<libMesh::Real> > )
     {
       thermo.reset( new Antioch::StatMechThermodynamics<libMesh::Real>( *(this->_antioch_gas.get()) ) );
     }
 
-    void specialized_build_thermo( libMesh::UniquePtr<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit>,libMesh::Real> > & thermo,
+    void specialized_build_thermo( std::unique_ptr<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit>,libMesh::Real> > & thermo,
                                    thermo_type<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit>,libMesh::Real> > )
     {
       _nasa_evaluator.reset( new Antioch::NASAEvaluator<libMesh::Real,KineticsThermoCurveFit>(this->nasa_mixture()) );
@@ -164,7 +164,7 @@ namespace GRINS
 
     void specialized_build_viscosity( const GetPot& input,
                                       const std::string& material,
-                                      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> > & viscosity,
+                                      std::unique_ptr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> > & viscosity,
                                       viscosity_type<Antioch::SutherlandViscosity<libMesh::Real> > )
     {
       viscosity.reset( new Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -178,7 +178,7 @@ namespace GRINS
 
     void specialized_build_viscosity( const GetPot& input,
                                       const std::string& material,
-                                      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> > & viscosity,
+                                      std::unique_ptr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> > & viscosity,
                                       viscosity_type<Antioch::BlottnerViscosity<libMesh::Real> > )
     {
       viscosity.reset( new Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -193,7 +193,7 @@ namespace GRINS
 #ifdef ANTIOCH_HAVE_GSL
     void specialized_build_viscosity( const GetPot& /*input*/,
                                       const std::string& /*material*/,
-                                      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> > & viscosity,
+                                      std::unique_ptr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> > & viscosity,
                                       viscosity_type<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner> > )
     {
       viscosity.reset( new Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -202,7 +202,7 @@ namespace GRINS
     }
 #endif // ANTIOCH_HAVE_GSL
 
-    void specialized_build_conductivity( libMesh::UniquePtr<Antioch::MixtureConductivity<Antioch::EuckenThermalConductivity<Thermo>,libMesh::Real> > & conductivity,
+    void specialized_build_conductivity( std::unique_ptr<Antioch::MixtureConductivity<Antioch::EuckenThermalConductivity<Thermo>,libMesh::Real> > & conductivity,
                                          conductivity_type<Antioch::EuckenThermalConductivity<Thermo> > )
     {
       conductivity.reset( new Antioch::MixtureConductivity<Antioch::EuckenThermalConductivity<Thermo>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -211,7 +211,7 @@ namespace GRINS
     }
 
 #ifdef ANTIOCH_HAVE_GSL
-    void specialized_build_conductivity( libMesh::UniquePtr<Antioch::MixtureConductivity<Antioch::KineticsTheoryThermalConductivity<Thermo,libMesh::Real>,libMesh::Real> > & conductivity,
+    void specialized_build_conductivity( std::unique_ptr<Antioch::MixtureConductivity<Antioch::KineticsTheoryThermalConductivity<Thermo,libMesh::Real>,libMesh::Real> > & conductivity,
                                          conductivity_type<Antioch::KineticsTheoryThermalConductivity<Thermo,libMesh::Real> > )
     {
       conductivity.reset( new Antioch::MixtureConductivity<Antioch::KineticsTheoryThermalConductivity<Thermo,libMesh::Real>,libMesh::Real>(*(_trans_mixture.get())) );
@@ -222,7 +222,7 @@ namespace GRINS
 
     void specialized_build_diffusivity( const GetPot& input,
                                         const std::string& material,
-                                        libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> > & diffusivity,
+                                        std::unique_ptr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> > & diffusivity,
                                         diffusivity_type<Antioch::ConstantLewisDiffusivity<libMesh::Real> > )
     {
       libMesh::Real Le = MaterialsParsing::parse_lewis_number(input,material);
@@ -236,7 +236,7 @@ namespace GRINS
 #ifdef ANTIOCH_HAVE_GSL
     void specialized_build_diffusivity( const GetPot& /*input*/,
                                         const std::string& /*material*/,
-                                        libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> > & diffusivity,
+                                        std::unique_ptr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> > & diffusivity,
                                         diffusivity_type<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > )
     {
       diffusivity.reset( new Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real>(*(_trans_mixture.get())) );

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_mixture_builder.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_mixture_builder.h
@@ -43,39 +43,39 @@ namespace GRINS
     ~AntiochMixtureAveragedTransportMixtureBuilder(){}
 
     template<typename KineticsThermoCurveFit, typename Thermo, typename Viscosity, typename Conductivity, typename Diffusivity>
-    libMesh::UniquePtr<AntiochMixtureAveragedTransportMixture<KineticsThermoCurveFit,Thermo,Viscosity,Conductivity,Diffusivity> >
+    std::unique_ptr<AntiochMixtureAveragedTransportMixture<KineticsThermoCurveFit,Thermo,Viscosity,Conductivity,Diffusivity> >
     build_mixture( const GetPot & input, const std::string & material );
 
   private:
 
-    libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> >
+    std::unique_ptr<Antioch::TransportMixture<libMesh::Real> >
     build_transport_mixture( const GetPot& input, const std::string& material,
                              const Antioch::ChemicalMixture<libMesh::Real> & chem_mix );
 
-    libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> >
+    std::unique_ptr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> >
     build_mix_avg_trans_mixture( const Antioch::TransportMixture<libMesh::Real> & trans_mix )
-    { return libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> >
+    { return std::unique_ptr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> >
         ( new Antioch::MixtureAveragedTransportMixture<libMesh::Real>(trans_mix) ); }
 
     template<typename Viscosity>
-    libMesh::UniquePtr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> >
+    std::unique_ptr<Antioch::MixtureViscosity<Viscosity,libMesh::Real> >
     build_viscosity( const GetPot& input, const std::string& material,
                      const Antioch::TransportMixture<libMesh::Real> & trans_mix )
     { return specialized_build_viscosity( input, material, trans_mix, viscosity_type<Viscosity>() ); }
 
     template<typename Diffusivity>
-    libMesh::UniquePtr<Antioch::MixtureDiffusion<Diffusivity,libMesh::Real> >
+    std::unique_ptr<Antioch::MixtureDiffusion<Diffusivity,libMesh::Real> >
     build_diffusivity( const GetPot& input, const std::string& material,
                        const Antioch::TransportMixture<libMesh::Real> & trans_mix )
     { return specialized_build_diffusivity( input, material, trans_mix, diffusivity_type<Diffusivity>() ); }
 
-    libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> >
+    std::unique_ptr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> >
     specialized_build_viscosity( const GetPot& input,
                                  const std::string& material,
                                  const Antioch::TransportMixture<libMesh::Real> & trans_mix,
                                  viscosity_type<Antioch::SutherlandViscosity<libMesh::Real> > )
     {
-      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> >
+      std::unique_ptr<Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real> >
         viscosity( new Antioch::MixtureViscosity<Antioch::SutherlandViscosity<libMesh::Real>,libMesh::Real>(trans_mix) );
 
       std::string sutherland_data = input("Materials/"+material+"/GasMixture/Antioch/sutherland_data", "default");
@@ -87,13 +87,13 @@ namespace GRINS
       return viscosity;
     }
 
-    libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> >
+    std::unique_ptr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> >
     specialized_build_viscosity( const GetPot& input,
                                  const std::string& material,
                                  const Antioch::TransportMixture<libMesh::Real> & trans_mix,
                                  viscosity_type<Antioch::BlottnerViscosity<libMesh::Real> > )
     {
-      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> >
+      std::unique_ptr<Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real> >
         viscosity( new Antioch::MixtureViscosity<Antioch::BlottnerViscosity<libMesh::Real>,libMesh::Real>(trans_mix) );
 
       std::string blottner_data = input("Materials/"+material+"/GasMixture/Antioch/blottner_data", "default");
@@ -106,13 +106,13 @@ namespace GRINS
     }
 
 #ifdef ANTIOCH_HAVE_GSL
-    libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
+    std::unique_ptr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
     specialized_build_viscosity( const GetPot& /*input*/,
                                  const std::string& /*material*/,
                                  const Antioch::TransportMixture<libMesh::Real> & trans_mix,
                                  viscosity_type<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner> > )
     {
-      libMesh::UniquePtr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
+      std::unique_ptr<Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
         viscosity( new Antioch::MixtureViscosity<Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real>(trans_mix) );
 
       Antioch::build_kinetics_theory_viscosity<libMesh::Real,Antioch::GSLSpliner>( *(viscosity.get()) );
@@ -122,7 +122,7 @@ namespace GRINS
 #endif // ANTIOCH_HAVE_GSL
 
 
-    libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> >
+    std::unique_ptr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> >
     specialized_build_diffusivity( const GetPot& input,
                                    const std::string& material,
                                    const Antioch::TransportMixture<libMesh::Real> & trans_mix,
@@ -130,7 +130,7 @@ namespace GRINS
     {
       libMesh::Real Le = MaterialsParsing::parse_lewis_number(input,material);
 
-      libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> >
+      std::unique_ptr<Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real> >
         diffusivity( new Antioch::MixtureDiffusion<Antioch::ConstantLewisDiffusivity<libMesh::Real>,libMesh::Real>(trans_mix) );
 
       Antioch::build_constant_lewis_diffusivity<libMesh::Real>( *(diffusivity.get()), Le);
@@ -139,13 +139,13 @@ namespace GRINS
     }
 
 #ifdef ANTIOCH_HAVE_GSL
-    libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
+    std::unique_ptr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
     specialized_build_diffusivity( const GetPot& /*input*/,
                                    const std::string& /*material*/,
                                    const Antioch::TransportMixture<libMesh::Real> & trans_mix,
                                    diffusivity_type<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > )
     {
-      return libMesh::UniquePtr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
+      return std::unique_ptr<Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real> >
         ( new Antioch::MixtureDiffusion<Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner>,libMesh::Real>(trans_mix) );
     }
 #endif // ANTIOCH_HAVE_GSL
@@ -155,35 +155,35 @@ namespace GRINS
 
   template<typename KT, typename T, typename V, typename C, typename D>
   inline
-  libMesh::UniquePtr<AntiochMixtureAveragedTransportMixture<KT,T,V,C,D> >
+  std::unique_ptr<AntiochMixtureAveragedTransportMixture<KT,T,V,C,D> >
   AntiochMixtureAveragedTransportMixtureBuilder::
   build_mixture( const GetPot & input, const std::string & material )
   {
-    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix =
+    std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix =
       this->build_chem_mix(input,material);
 
-    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > reaction_set =
+    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > reaction_set =
       this->build_reaction_set(input,material,*chem_mix);
 
-    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KT> > kinetics_thermo =
+    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KT> > kinetics_thermo =
       this->build_nasa_thermo_mix<KT>(input,material,*chem_mix);
 
-    libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> > trans_mix =
+    std::unique_ptr<Antioch::TransportMixture<libMesh::Real> > trans_mix =
       this->build_transport_mixture(input,material,*chem_mix);
 
-    libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > wilke_mix =
+    std::unique_ptr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > wilke_mix =
       this->build_mix_avg_trans_mixture(*trans_mix);
 
-    libMesh::UniquePtr<Antioch::MixtureViscosity<V,libMesh::Real> > visc =
+    std::unique_ptr<Antioch::MixtureViscosity<V,libMesh::Real> > visc =
       this->build_viscosity<V>(input,material,*trans_mix);
 
-    libMesh::UniquePtr<Antioch::MixtureDiffusion<D,libMesh::Real> > diff =
+    std::unique_ptr<Antioch::MixtureDiffusion<D,libMesh::Real> > diff =
       this->build_diffusivity<D>(input,material,*trans_mix);
 
     libMesh::Real min_T = this->parse_min_T(input,material);
     bool clip_negative_rho = this->parse_clip_negative_rho(input,material);
 
-    return libMesh::UniquePtr<AntiochMixtureAveragedTransportMixture<KT,T,V,C,D> >
+    return std::unique_ptr<AntiochMixtureAveragedTransportMixture<KT,T,V,C,D> >
       ( new AntiochMixtureAveragedTransportMixture<KT,T,V,C,D>
         (chem_mix, reaction_set, kinetics_thermo, trans_mix, wilke_mix, visc, diff, min_T, clip_negative_rho) );
   }

--- a/src/properties/include/grins/antioch_mixture_builder_base.h
+++ b/src/properties/include/grins/antioch_mixture_builder_base.h
@@ -44,7 +44,7 @@
 #include "antioch/nasa_mixture_parsing.h"
 
 // libMesh
-#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+#include "libmesh/auto_ptr.h" // std::unique_ptr
 #include "libmesh/getpot.h"
 
 // C++
@@ -65,21 +65,21 @@ namespace GRINS
     AntiochMixtureBuilderBase(){}
     ~AntiochMixtureBuilderBase(){}
 
-    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> >
+    std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> >
     build_chem_mix( const GetPot & input, const std::string & material );
 
-    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> >
+    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> >
     build_reaction_set( const GetPot & input, const std::string & material,
                         const Antioch::ChemicalMixture<libMesh::Real> & chem_mix );
 
     template<typename KineticsThermoCurveFit>
-    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> >
+    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> >
     build_nasa_thermo_mix( const GetPot & input, const std::string & material,
                            const Antioch::ChemicalMixture<libMesh::Real> & chem_mix );
 
 
     template<typename KineticsThermoCurveFit>
-    libMesh::UniquePtr<AntiochMixture<KineticsThermoCurveFit> >
+    std::unique_ptr<AntiochMixture<KineticsThermoCurveFit> >
     build_antioch_mixture(const GetPot & input, const std::string & material );
 
     libMesh::Real parse_min_T( const GetPot & input, const std::string & material )
@@ -111,11 +111,11 @@ namespace GRINS
 
   template<typename KineticsThermoCurveFit>
   inline
-  libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> >
+  std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> >
   AntiochMixtureBuilderBase::build_nasa_thermo_mix( const GetPot & input, const std::string & material,
                                                     const Antioch::ChemicalMixture<libMesh::Real> & chem_mix )
   {
-    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> >
+    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> >
       nasa_mixture( new Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit>(chem_mix) );
 
     this->parse_nasa_data( *nasa_mixture, input, material);
@@ -125,22 +125,22 @@ namespace GRINS
 
   template<typename KineticsThermoCurveFit>
   inline
-  libMesh::UniquePtr<AntiochMixture<KineticsThermoCurveFit> >
+  std::unique_ptr<AntiochMixture<KineticsThermoCurveFit> >
   AntiochMixtureBuilderBase::build_antioch_mixture(const GetPot & input, const std::string & material )
   {
-    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mixture =
+    std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > chem_mixture =
       this->build_chem_mix(input,material);
 
-    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > reaction_set =
+    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > reaction_set =
       this->build_reaction_set(input,material,*chem_mixture);
 
-    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > nasa_mixture =
+    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > nasa_mixture =
       this->build_nasa_thermo_mix<KineticsThermoCurveFit>(input,material,*chem_mixture);
 
     libMesh::Real min_T = this->parse_min_T(input,material);
     bool clip_negative_rho = this->parse_clip_negative_rho(input,material);
 
-    return libMesh::UniquePtr<AntiochMixture<KineticsThermoCurveFit> >
+    return std::unique_ptr<AntiochMixture<KineticsThermoCurveFit> >
       ( new AntiochMixture<KineticsThermoCurveFit>
         (chem_mixture,reaction_set,nasa_mixture,min_T,clip_negative_rho) );
   }

--- a/src/properties/include/grins/cantera_mixture.h
+++ b/src/properties/include/grins/cantera_mixture.h
@@ -40,7 +40,7 @@
 #include "libmesh/restore_warnings.h"
 
 // libMesh
-#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+#include "libmesh/auto_ptr.h" // std::unique_ptr
 
 // GRINS
 #include "grins/parameter_user.h"
@@ -100,9 +100,9 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<Cantera::IdealGasMix> _cantera_gas;
+    std::unique_ptr<Cantera::IdealGasMix> _cantera_gas;
 
-    libMesh::UniquePtr<Cantera::Transport> _cantera_transport;
+    std::unique_ptr<Cantera::Transport> _cantera_transport;
 
     std::string parse_mixture( const GetPot& input, const std::string& material );
 

--- a/src/properties/include/grins/chemistry_builder.h
+++ b/src/properties/include/grins/chemistry_builder.h
@@ -27,7 +27,7 @@
 #define GRINS_CHEMISTRY_BUILDER_H
 
 // libMesh
-#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+#include "libmesh/auto_ptr.h" // std::unique_ptr
 #include "libmesh/getpot.h"
 
 // C++
@@ -43,7 +43,7 @@ namespace GRINS
 
     template<typename ChemistryType>
     void build_chemistry( const GetPot & input,const std::string & material,
-                          libMesh::UniquePtr<ChemistryType> & chem_ptr );
+                          std::unique_ptr<ChemistryType> & chem_ptr );
   };
 
 } // end namespace GRINS

--- a/src/properties/src/antioch_chemistry.C
+++ b/src/properties/src/antioch_chemistry.C
@@ -80,7 +80,7 @@ namespace GRINS
   }
 
   AntiochChemistry::AntiochChemistry
-  ( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture )
+  ( std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture )
     : ParameterUser("AntiochChemistry")
   {
     /*! \todo Use std::move when we have C++11 */

--- a/src/properties/src/antioch_constant_transport_mixture.C
+++ b/src/properties/src/antioch_constant_transport_mixture.C
@@ -67,7 +67,7 @@ namespace GRINS
     std::unique_ptr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > & diff,
     libMesh::Real min_T,
     bool clip_negative_rho )
-  : AntiochMixture<KineticsThermoCurveFit>(chem_mixture,reaction_set,nasa_mixture,min_T,clip_negative_rho)
+    : AntiochMixture<KineticsThermoCurveFit>(chem_mixture,reaction_set,nasa_mixture,min_T,clip_negative_rho)
   {
     /*! \todo Use std::move() when we have C++11 */
     _mu.reset( visc.release() );

--- a/src/properties/src/antioch_constant_transport_mixture.C
+++ b/src/properties/src/antioch_constant_transport_mixture.C
@@ -59,12 +59,12 @@ namespace GRINS
   template<typename KineticsThermoCurveFit,typename Conductivity>
   AntiochConstantTransportMixture<KineticsThermoCurveFit,Conductivity>::
   AntiochConstantTransportMixture
-  ( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
-    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
-    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
-    libMesh::UniquePtr<ConstantViscosity> & visc,
-    libMesh::UniquePtr<Conductivity> & cond,
-    libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > & diff,
+  ( std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
+    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
+    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
+    std::unique_ptr<ConstantViscosity> & visc,
+    std::unique_ptr<Conductivity> & cond,
+    std::unique_ptr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > & diff,
     libMesh::Real min_T,
     bool clip_negative_rho )
   : AntiochMixture<KineticsThermoCurveFit>(chem_mixture,reaction_set,nasa_mixture,min_T,clip_negative_rho)

--- a/src/properties/src/antioch_mixture.C
+++ b/src/properties/src/antioch_mixture.C
@@ -81,9 +81,9 @@ namespace GRINS
 
   template <typename KineticsThermoCurveFit>
   AntiochMixture<KineticsThermoCurveFit>::AntiochMixture
-  ( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
-    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
-    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
+  ( std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
+    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
+    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KineticsThermoCurveFit> > & nasa_mixture,
     libMesh::Real min_T,
     bool clip_negative_rho )
     : AntiochChemistry(chem_mixture),

--- a/src/properties/src/antioch_mixture_averaged_transport_mixture.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_mixture.C
@@ -80,13 +80,13 @@ namespace GRINS
 
   template<typename KT, typename T, typename V, typename C, typename D>
   AntiochMixtureAveragedTransportMixture<KT,T,V,C,D>::AntiochMixtureAveragedTransportMixture
-  ( libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
-    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
-    libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,KT> > & kinetics_thermo_mix,
-    libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> > & trans_mix,
-    libMesh::UniquePtr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > & wilke_mix,
-    libMesh::UniquePtr<Antioch::MixtureViscosity<V,libMesh::Real> > & visc,
-    libMesh::UniquePtr<Antioch::MixtureDiffusion<D,libMesh::Real> > & diff,
+  ( std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > & chem_mixture,
+    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > & reaction_set,
+    std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,KT> > & kinetics_thermo_mix,
+    std::unique_ptr<Antioch::TransportMixture<libMesh::Real> > & trans_mix,
+    std::unique_ptr<Antioch::MixtureAveragedTransportMixture<libMesh::Real> > & wilke_mix,
+    std::unique_ptr<Antioch::MixtureViscosity<V,libMesh::Real> > & visc,
+    std::unique_ptr<Antioch::MixtureDiffusion<D,libMesh::Real> > & diff,
     libMesh::Real min_T,
     bool clip_negative_rho )
   : AntiochMixture<KT>(chem_mixture,reaction_set,kinetics_thermo_mix,min_T,clip_negative_rho)

--- a/src/properties/src/antioch_mixture_averaged_transport_mixture_builder.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_mixture_builder.C
@@ -31,7 +31,7 @@
 
 namespace GRINS
 {
-  libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> >
+  std::unique_ptr<Antioch::TransportMixture<libMesh::Real> >
   AntiochMixtureAveragedTransportMixtureBuilder::
   build_transport_mixture( const GetPot & input, const std::string & material,
                            const Antioch::ChemicalMixture<libMesh::Real> & chem_mix )
@@ -45,7 +45,7 @@ namespace GRINS
     bool verbose_transport_read =
       input( "Materials/"+material+"/GasMixture/Antioch/verbose_transport_read", false );
 
-    return libMesh::UniquePtr<Antioch::TransportMixture<libMesh::Real> >
+    return std::unique_ptr<Antioch::TransportMixture<libMesh::Real> >
       ( new Antioch::TransportMixture<libMesh::Real>( chem_mix,
                                                       transport_data_filename,
                                                       verbose_transport_read,

--- a/src/properties/src/antioch_mixture_builder_base.C
+++ b/src/properties/src/antioch_mixture_builder_base.C
@@ -38,7 +38,7 @@
 
 namespace GRINS
 {
-  libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> >
+  std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> >
   AntiochMixtureBuilderBase::build_chem_mix( const GetPot & input, const std::string & material )
   {
     std::vector<std::string> species_list;
@@ -59,7 +59,7 @@ namespace GRINS
       electronic_data_filename = Antioch::DefaultInstallFilename::electronic_data();
 
     // By default, Antioch is using its ASCII parser. We haven't added more options yet.
-    return libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> >
+    return std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> >
       ( new Antioch::ChemicalMixture<libMesh::Real>( species_list,
                                                      verbose_antioch_read,
                                                      species_data_filename,
@@ -67,11 +67,11 @@ namespace GRINS
                                                      electronic_data_filename ) );
   }
 
-  libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> >
+  std::unique_ptr<Antioch::ReactionSet<libMesh::Real> >
   AntiochMixtureBuilderBase::build_reaction_set( const GetPot & input, const std::string & material,
                                                  const Antioch::ChemicalMixture<libMesh::Real> & chem_mix )
   {
-    libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> >
+    std::unique_ptr<Antioch::ReactionSet<libMesh::Real> >
       reaction_set( new Antioch::ReactionSet<libMesh::Real>(chem_mix) );
 
     std::string kinetics_data_filename = MaterialsParsing::parse_chemical_kinetics_datafile_name( input, material );

--- a/src/properties/src/chemistry_builder.C
+++ b/src/properties/src/chemistry_builder.C
@@ -43,7 +43,7 @@ namespace GRINS
 #ifdef GRINS_HAVE_CANTERA
   template<>
   void ChemistryBuilder::build_chemistry(const GetPot & input,const std::string & material,
-                                         libMesh::UniquePtr<CanteraMixture> & chem_ptr )
+                                         std::unique_ptr<CanteraMixture> & chem_ptr )
   {
     chem_ptr.reset( new CanteraMixture(input,material) );
   }
@@ -52,11 +52,11 @@ namespace GRINS
 #ifdef GRINS_HAVE_ANTIOCH
   template<>
   void ChemistryBuilder::build_chemistry(const GetPot & input,const std::string & material,
-                                         libMesh::UniquePtr<AntiochChemistry> & chem_ptr )
+                                         std::unique_ptr<AntiochChemistry> & chem_ptr )
   {
     AntiochMixtureBuilderBase builder;
 
-    libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > antioch_chem_mix
+    std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > antioch_chem_mix
       = builder.build_chem_mix(input,material);
 
     chem_ptr.reset( new AntiochChemistry(antioch_chem_mix) );

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -95,7 +95,7 @@ namespace GRINS
                               const libMesh::Real time);
 
     //! Not used
-    virtual libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Real> > clone() const;
+    virtual std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Real> > clone() const;
 
   protected:
     //! Antioch/Cantera object

--- a/src/qoi/include/grins/composite_qoi.h
+++ b/src/qoi/include/grins/composite_qoi.h
@@ -64,7 +64,7 @@ namespace GRINS
     //! Required to provide clone for adding QoI object to libMesh objects.
     /*! Note that we do a deep copy here since the previous object might
       get destroyed and wipe out the objects being pointed to in _qois. */
-    virtual libMesh::UniquePtr<libMesh::DifferentiableQoI> clone();
+    virtual std::unique_ptr<libMesh::DifferentiableQoI> clone();
 
     virtual void add_qoi( const QoIBase& qoi );
 

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -57,7 +57,7 @@ namespace GRINS
     /*!
       @param p_level The desired Gauss Quadrature level
       @param f A FunctionBase or FEMFunctionBase object for evaluting the QoI
-      @param rayfire A RayfireMesh object (will be initialized in init()) <b>Ownership will be taken by an internal libMesh::UniquePtr</b>
+      @param rayfire A RayfireMesh object (will be initialized in init()) <b>Ownership will be taken by an internal std::unique_ptr</b>
       @param qoi_name Passed to the QoIBase
     */
     IntegratedFunction(unsigned int p_level, SharedPtr<Function> f, RayfireMesh * rayfire, const std::string & qoi_name);
@@ -113,7 +113,7 @@ namespace GRINS
     SharedPtr<Function> _f;
 
     //! Pointer to RayfireMesh object
-    libMesh::UniquePtr<RayfireMesh> _rayfire;
+    std::unique_ptr<RayfireMesh> _rayfire;
 
     //! Compute the value of a QoI at a QP
     libMesh::Real qoi_value(Function & f, AssemblyContext & context, const libMesh::Point & xyz);

--- a/src/qoi/include/grins/parsed_boundary_qoi.h
+++ b/src/qoi/include/grins/parsed_boundary_qoi.h
@@ -76,7 +76,7 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >
     qoi_functional;
 
 

--- a/src/qoi/include/grins/parsed_interior_qoi.h
+++ b/src/qoi/include/grins/parsed_interior_qoi.h
@@ -76,7 +76,7 @@ namespace GRINS
 
   protected:
 
-    libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Number> >
+    std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Number> >
     qoi_functional;
 
     //! Manual copy constructor due to the UniquePtr

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -145,7 +145,7 @@ namespace GRINS
     libMesh::Real   _phi;
 
     //! Internal 1D mesh of EDGE2 elements
-    libMesh::UniquePtr<libMesh::Mesh> _mesh;
+    std::unique_ptr<libMesh::Mesh> _mesh;
 
     //! Map of main mesh elem_id to rayfire mesh elem_id
     std::map<libMesh::dof_id_type,libMesh::dof_id_type> _elem_id_map;

--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -181,15 +181,15 @@ namespace GRINS
     std::vector<libMesh::Point> qp(1);
     qp[0] = qp_ref;
 
-    libMesh::UniquePtr< libMesh::FEBase > T_fe = libMesh::FEGenericBase<libMesh::Real>::build(context.get_elem().dim(), context.get_element_fe(_T_var.T())->get_fe_type() );
+    std::unique_ptr< libMesh::FEBase > T_fe = libMesh::FEGenericBase<libMesh::Real>::build(context.get_elem().dim(), context.get_element_fe(_T_var.T())->get_fe_type() );
     const std::vector<std::vector<libMesh::Real> > & T_phi =T_fe->get_phi();
     T_fe->reinit(&(context.get_elem()),&qp);
 
-    libMesh::UniquePtr< libMesh::FEBase > P_fe = libMesh::FEGenericBase<libMesh::Real>::build(context.get_elem().dim(), context.get_element_fe(_P_var.p())->get_fe_type() );
+    std::unique_ptr< libMesh::FEBase > P_fe = libMesh::FEGenericBase<libMesh::Real>::build(context.get_elem().dim(), context.get_element_fe(_P_var.p())->get_fe_type() );
     const std::vector<std::vector<libMesh::Real> > & P_phi = P_fe->get_phi();
     P_fe->reinit(&(context.get_elem()),&qp);
 
-    libMesh::UniquePtr< libMesh::FEBase > Ys_fe = libMesh::FEGenericBase<libMesh::Real>::build(context.get_elem().dim(), context.get_element_fe(_Y_var.species(_species_idx))->get_fe_type() );
+    std::unique_ptr< libMesh::FEBase > Ys_fe = libMesh::FEGenericBase<libMesh::Real>::build(context.get_elem().dim(), context.get_element_fe(_Y_var.species(_species_idx))->get_fe_type() );
     const std::vector<std::vector<libMesh::Real> > & Ys_phi = Ys_fe->get_phi();
     Ys_fe->reinit(&(context.get_elem()),&qp);
 
@@ -234,7 +234,7 @@ namespace GRINS
   }
 
   template<typename Chemistry>
-  libMesh::UniquePtr<libMesh::FEMFunctionBase<libMesh::Real> > AbsorptionCoeff<Chemistry>::clone() const
+  std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Real> > AbsorptionCoeff<Chemistry>::clone() const
   {
     libmesh_not_implemented();
   }

--- a/src/qoi/src/composite_qoi.C
+++ b/src/qoi/src/composite_qoi.C
@@ -55,7 +55,7 @@ namespace GRINS
     return;
   }
 
-  libMesh::UniquePtr<libMesh::DifferentiableQoI> CompositeQoI::clone()
+  std::unique_ptr<libMesh::DifferentiableQoI> CompositeQoI::clone()
   {
     CompositeQoI* clone = new CompositeQoI;
 
@@ -64,7 +64,7 @@ namespace GRINS
         clone->add_qoi( this->get_qoi(q) );
       }
 
-    return libMesh::UniquePtr<libMesh::DifferentiableQoI>(clone);
+    return std::unique_ptr<libMesh::DifferentiableQoI>(clone);
   }
 
   void CompositeQoI::add_qoi( const QoIBase& qoi )

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -108,7 +108,7 @@ namespace GRINS
         qbase.init(rayfire_elem->type(),libMesh::Order(_p_level));
 
         // need the QP coordinates and JxW
-        libMesh::UniquePtr< libMesh::FEGenericBase<libMesh::Real> > fe = libMesh::FEGenericBase<libMesh::Real>::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
+        std::unique_ptr< libMesh::FEGenericBase<libMesh::Real> > fe = libMesh::FEGenericBase<libMesh::Real>::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
 
         fe->attach_quadrature_rule( &qbase );
         const std::vector<libMesh::Real> & JxW = fe->get_JxW();
@@ -142,7 +142,7 @@ namespace GRINS
         qbase.init(rayfire_elem->type(),libMesh::Order(_p_level));
 
         // need the QP coordinates and JxW
-        libMesh::UniquePtr< libMesh::FEGenericBase<libMesh::Real> > fe = libMesh::FEGenericBase<libMesh::Real>::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
+        std::unique_ptr< libMesh::FEGenericBase<libMesh::Real> > fe = libMesh::FEGenericBase<libMesh::Real>::build(rayfire_elem->dim(), libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE) );
 
         fe->attach_quadrature_rule( &qbase );
         const std::vector<libMesh::Real> & JxW = fe->get_JxW();

--- a/src/qoi/src/qoi_factory.C
+++ b/src/qoi/src/qoi_factory.C
@@ -185,13 +185,13 @@ namespace GRINS
         ChemistryBuilder chem_builder;
 
 #if GRINS_HAVE_ANTIOCH
-        libMesh::UniquePtr<AntiochChemistry> chem_ptr;
+        std::unique_ptr<AntiochChemistry> chem_ptr;
         chem_builder.build_chemistry(input,material,chem_ptr);
         SharedPtr<AntiochChemistry> chem(chem_ptr.release());
 
         absorb = new AbsorptionCoeff<AntiochChemistry>(chem,hitran,nu_min,nu_max,nu_desired,species,thermo_pressure);
 #elif GRINS_HAVE_CANTERA
-        libMesh::UniquePtr<CanteraMixture> chem_ptr;
+        std::unique_ptr<CanteraMixture> chem_ptr;
         chem_builder.build_chemistry(input,material,chem_ptr);
         SharedPtr<CanteraMixture> chem(chem_ptr.release());
 

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -263,7 +263,7 @@ namespace GRINS
           continue;
 
         // we found a boundary elem, so make an edge and see if it contains the origin
-        libMesh::UniquePtr<const libMesh::Elem> edge_elem = start_elem->build_edge_ptr(s);
+        std::unique_ptr<const libMesh::Elem> edge_elem = start_elem->build_edge_ptr(s);
         valid |= edge_elem->contains_point(_origin);
       }
 
@@ -276,7 +276,7 @@ namespace GRINS
   {
     const libMesh::Elem* start_elem = NULL;
 
-    libMesh::UniquePtr<libMesh::PointLocatorBase> locator = mesh_base.sub_point_locator();
+    std::unique_ptr<libMesh::PointLocatorBase> locator = mesh_base.sub_point_locator();
     const libMesh::Elem* elem = (*locator)(_origin);
 
     // elem would be NULL if origin is not on mesh
@@ -329,7 +329,7 @@ namespace GRINS
     // loop over all sides of the elem and check each one for intersection
     for (unsigned int s=0; s<cur_elem->n_sides(); s++)
       {
-        libMesh::UniquePtr<const libMesh::Elem> edge_elem = cur_elem->build_edge_ptr(s);
+        std::unique_ptr<const libMesh::Elem> edge_elem = cur_elem->build_edge_ptr(s);
 
         // Using the default tol can cause a false positive when start_point is near a node,
         // causing this loop to skip over an otherwise valid edge to check
@@ -400,7 +400,7 @@ namespace GRINS
 
     for (unsigned int s=0; s<neighbor->n_sides(); s++)
       {
-        libMesh::UniquePtr<const libMesh::Elem> side_elem = neighbor->build_side_ptr(s);
+        std::unique_ptr<const libMesh::Elem> side_elem = neighbor->build_side_ptr(s);
 
         if ( (side_elem->contains_point(*node0)) && (side_elem->contains_point(*node1)) )
           {
@@ -411,7 +411,7 @@ namespace GRINS
 
     if ( side != libMesh::invalid_uint )
       {
-        libMesh::UniquePtr<const libMesh::Elem> edge_elem = neighbor->build_side_ptr(side);
+        std::unique_ptr<const libMesh::Elem> edge_elem = neighbor->build_side_ptr(side);
 
         bool start_point_on_edge = edge_elem->contains_point(start_point);
         bool end_point_on_edge = edge_elem->contains_point(end_point);
@@ -463,7 +463,7 @@ namespace GRINS
             // check elem neighbors first
             for (unsigned int s=0; s<cur_elem->n_sides(); s++)
               {
-                libMesh::UniquePtr<const libMesh::Elem> side_elem = cur_elem->build_side_ptr(s);
+                std::unique_ptr<const libMesh::Elem> side_elem = cur_elem->build_side_ptr(s);
                 if (side_elem->contains_point(end_point))
                   {
                     const libMesh::Elem * neighbor = cur_elem->neighbor_ptr(s);

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -71,7 +71,7 @@ namespace GRINS
 
     RefinementFlaggingType _refinement_type;
 
-    libMesh::UniquePtr<libMesh::MeshRefinement> _mesh_refinement;
+    std::unique_ptr<libMesh::MeshRefinement> _mesh_refinement;
 
     void build_mesh_refinement( libMesh::MeshBase& mesh );
 

--- a/src/solver/include/grins/runner.h
+++ b/src/solver/include/grins/runner.h
@@ -97,11 +97,11 @@ namespace GRINS
 
     GetPot _command_line;
 
-    libMesh::UniquePtr<libMesh::LibMeshInit> _libmesh_init;
+    std::unique_ptr<libMesh::LibMeshInit> _libmesh_init;
 
-    libMesh::UniquePtr<GetPot> _inputfile;
+    std::unique_ptr<GetPot> _inputfile;
 
-    libMesh::UniquePtr<Simulation> _simulation;
+    std::unique_ptr<Simulation> _simulation;
 
   private:
 

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -116,7 +116,7 @@ namespace GRINS
 
     SharedPtr<libMesh::EquationSystems> _equation_system;
 
-    libMesh::UniquePtr<GRINS::Solver> _solver;
+    std::unique_ptr<GRINS::Solver> _solver;
 
     //! GRINS::Multiphysics system name
     std::string _system_name;

--- a/src/solver/include/grins/solver_factory_abstract.h
+++ b/src/solver/include/grins/solver_factory_abstract.h
@@ -46,11 +46,11 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Solver> build_solver( const GetPot & input ) =0;
+    virtual std::unique_ptr<Solver> build_solver( const GetPot & input ) =0;
 
   private:
 
-    virtual libMesh::UniquePtr<Solver> create();
+    virtual std::unique_ptr<Solver> create();
 
     SolverFactoryAbstract();
   };

--- a/src/solver/include/grins/solver_factory_basic.h
+++ b/src/solver/include/grins/solver_factory_basic.h
@@ -41,7 +41,7 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<Solver> build_solver( const GetPot & input );
+    virtual std::unique_ptr<Solver> build_solver( const GetPot & input );
 
   private:
 
@@ -50,10 +50,10 @@ namespace GRINS
 
   template<typename DerivedSolver>
   inline
-  libMesh::UniquePtr<Solver>
+  std::unique_ptr<Solver>
   SolverFactoryBasic<DerivedSolver>::build_solver( const GetPot & input )
   {
-    return libMesh::UniquePtr<Solver>( new DerivedSolver(input) );
+    return std::unique_ptr<Solver>( new DerivedSolver(input) );
   }
 
 } // end namespace GRINS

--- a/src/solver/src/parameter_manager.C
+++ b/src/solver/src/parameter_manager.C
@@ -76,7 +76,7 @@ namespace GRINS
           }
 
         this->parameter_vector.push_back
-          (libMesh::UniquePtr<libMesh::ParameterAccessor<libMesh::Number> >
+          (std::unique_ptr<libMesh::ParameterAccessor<libMesh::Number> >
            (next_param));
       }
   }

--- a/src/solver/src/solver_factory_abstract.C
+++ b/src/solver/src/solver_factory_abstract.C
@@ -27,7 +27,7 @@
 
 namespace GRINS
 {
-  libMesh::UniquePtr<Solver> SolverFactoryAbstract::create()
+  std::unique_ptr<Solver> SolverFactoryAbstract::create()
   {
     if( !this->_input )
       libmesh_error_msg("ERROR: must call set_getpot() before building boundary condition!");

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -57,7 +57,7 @@ namespace GRINS
   {
     libMesh::SteadySolver* time_solver = new libMesh::SteadySolver( *(system) );
 
-    system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>( time_solver );
+    system->time_solver = std::unique_ptr<libMesh::TimeSolver>( time_solver );
 
     return;
   }

--- a/src/solver/src/steady_solver.C
+++ b/src/solver/src/steady_solver.C
@@ -55,7 +55,7 @@ namespace GRINS
   {
     libMesh::SteadySolver* time_solver = new libMesh::SteadySolver( *(system) );
 
-    system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>(time_solver);
+    system->time_solver = std::unique_ptr<libMesh::TimeSolver>(time_solver);
     return;
   }
 

--- a/src/solver/src/unsteady_solver.C
+++ b/src/solver/src/unsteady_solver.C
@@ -98,12 +98,12 @@ namespace GRINS
         outer_solver->quiet = false;
 
         outer_solver->core_time_solver =
-          libMesh::UniquePtr<libMesh::UnsteadySolver>(time_solver);
-        system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>(outer_solver);
+          std::unique_ptr<libMesh::UnsteadySolver>(time_solver);
+        system->time_solver = std::unique_ptr<libMesh::TimeSolver>(outer_solver);
       }
     else
       {
-        system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>(time_solver);
+        system->time_solver = std::unique_ptr<libMesh::TimeSolver>(time_solver);
       }
 
     time_solver->reduce_deltat_on_diffsolver_failure = this->_backtrack_deltat;

--- a/src/strategies/include/grins/adjoint_error_estimator_factories.h
+++ b/src/strategies/include/grins/adjoint_error_estimator_factories.h
@@ -47,11 +47,11 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<libMesh::ErrorEstimator>
+    virtual std::unique_ptr<libMesh::ErrorEstimator>
     build_error_estimator( const GetPot& input, MultiphysicsSystem& system,
                            const ErrorEstimatorOptions& estimator_options )
     {
-      libMesh::UniquePtr<libMesh::ErrorEstimator>
+      std::unique_ptr<libMesh::ErrorEstimator>
         raw_error_estimator( new EstimatorType );
 
       // Now cast to derived type

--- a/src/strategies/include/grins/error_estimator_factory_base.h
+++ b/src/strategies/include/grins/error_estimator_factory_base.h
@@ -62,8 +62,8 @@ namespace GRINS
 
     //! Subclasses implement this method for building the ErrorEstimator object.
     virtual std::unique_ptr<libMesh::ErrorEstimator> build_error_estimator( const GetPot& input,
-                                                                               MultiphysicsSystem& system,
-                                                                               const ErrorEstimatorOptions& estimator_options ) =0;
+                                                                            MultiphysicsSystem& system,
+                                                                            const ErrorEstimatorOptions& estimator_options ) =0;
 
     //! Cache pointer to system
     /*! We can't copy this so it must be a pointer. We do *not* own

--- a/src/strategies/include/grins/error_estimator_factory_base.h
+++ b/src/strategies/include/grins/error_estimator_factory_base.h
@@ -61,7 +61,7 @@ namespace GRINS
   protected:
 
     //! Subclasses implement this method for building the ErrorEstimator object.
-    virtual libMesh::UniquePtr<libMesh::ErrorEstimator> build_error_estimator( const GetPot& input,
+    virtual std::unique_ptr<libMesh::ErrorEstimator> build_error_estimator( const GetPot& input,
                                                                                MultiphysicsSystem& system,
                                                                                const ErrorEstimatorOptions& estimator_options ) =0;
 
@@ -76,12 +76,12 @@ namespace GRINS
 
   private:
 
-    virtual libMesh::UniquePtr<libMesh::ErrorEstimator> create();
+    virtual std::unique_ptr<libMesh::ErrorEstimator> create();
 
   };
 
   inline
-  libMesh::UniquePtr<libMesh::ErrorEstimator> ErrorEstimatorFactoryBase::create()
+  std::unique_ptr<libMesh::ErrorEstimator> ErrorEstimatorFactoryBase::create()
   {
     if( !_input )
       libmesh_error_msg("ERROR: must call set_getpot() before building ErrorEstimator!");
@@ -90,7 +90,7 @@ namespace GRINS
     if( !_estimator_options )
       libmesh_error_msg("ERROR: must call set_estimator_options() before building ErrorEstimator!");
 
-    libMesh::UniquePtr<libMesh::ErrorEstimator>
+    std::unique_ptr<libMesh::ErrorEstimator>
       new_estimator = this->build_error_estimator( *_input, *_system, *_estimator_options );
 
     libmesh_assert(new_estimator);

--- a/src/strategies/include/grins/error_estimator_factory_basic.h
+++ b/src/strategies/include/grins/error_estimator_factory_basic.h
@@ -41,12 +41,12 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<libMesh::ErrorEstimator>
+    virtual std::unique_ptr<libMesh::ErrorEstimator>
     build_error_estimator( const GetPot & /*input*/,
                            MultiphysicsSystem & /*system*/,
                            const ErrorEstimatorOptions & /*estimator_options*/ )
     {
-      return libMesh::UniquePtr<libMesh::ErrorEstimator>( new EstimatorType );
+      return std::unique_ptr<libMesh::ErrorEstimator>( new EstimatorType );
     }
 
   };

--- a/src/utilities/include/grins/distance_function.h
+++ b/src/utilities/include/grins/distance_function.h
@@ -83,7 +83,7 @@ namespace GRINS {
     /**
      * Interpolate distance function to points qpts (in reference space) for element *elem
      */
-    libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> > interpolate (const libMesh::Elem* elem, const std::vector<libMesh::Point>& qts) const;
+    std::unique_ptr< libMesh::DenseVector<libMesh::Real> > interpolate (const libMesh::Elem* elem, const std::vector<libMesh::Point>& qts) const;
 
 
 
@@ -107,7 +107,7 @@ namespace GRINS {
      * Currently type is hardcoded to first order, Lagrange
      * (see constructor), but this could be easily changed.
      */
-    libMesh::UniquePtr<libMesh::FEBase> _dist_fe;
+    std::unique_ptr<libMesh::FEBase> _dist_fe;
 
   };
 
@@ -257,7 +257,7 @@ namespace GRINS {
     const unsigned int _dim;
     const libMesh::Point& _p;
 
-    libMesh::UniquePtr<libMesh::FEBase> _fe;
+    std::unique_ptr<libMesh::FEBase> _fe;
     libMesh::FEBase *fe;
 
     // work vectors

--- a/src/utilities/include/grins/parameter_antioch_reset.h
+++ b/src/utilities/include/grins/parameter_antioch_reset.h
@@ -88,11 +88,11 @@ namespace GRINS
     /**
      * Returns a new copy of the accessor.
      */
-    virtual libMesh::UniquePtr<ParameterAccessor<libMesh::Number> > clone() const {
+    virtual std::unique_ptr<ParameterAccessor<libMesh::Number> > clone() const {
       // Default shallow copy works for this class
       ParameterAntiochReset *par = new ParameterAntiochReset(*this);
 
-      return libMesh::UniquePtr<ParameterAccessor<libMesh::Number> >(par);
+      return std::unique_ptr<ParameterAccessor<libMesh::Number> >(par);
     }
 
   private:

--- a/src/utilities/src/distance_function.C
+++ b/src/utilities/src/distance_function.C
@@ -500,7 +500,7 @@ namespace GRINS {
                     // physical space and use it to evaluate the distance
 
                     // assuming first order lagrange basis here
-                    libMesh::UniquePtr<libMesh::FEBase> fe( libMesh::FEBase::build(2, libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE)) );
+                    std::unique_ptr<libMesh::FEBase> fe( libMesh::FEBase::build(2, libMesh::FEType(libMesh::FIRST, libMesh::LAGRANGE)) );
 
                     std::vector<libMesh::Point> xi(1);
                     xi[0](0) = X(0);
@@ -611,7 +611,7 @@ namespace GRINS {
   //---------------------------------------------------
   // Interpolate nodal data
   //
-  libMesh::UniquePtr< libMesh::DenseVector<libMesh::Real> >
+  std::unique_ptr< libMesh::DenseVector<libMesh::Real> >
   DistanceFunction::interpolate (const libMesh::Elem* elem, const std::vector<libMesh::Point>& qpts) const
   {
     libmesh_assert( elem != NULL );    // can't interpolate in NULL elem
@@ -630,7 +630,7 @@ namespace GRINS {
     const unsigned int n_pts = qpts.size();
 
     // instantiate auto_ptr to dense vector to hold results
-    libMesh::UniquePtr< DenseVector<libMesh::Real> > ap( new libMesh::DenseVector<libMesh::Real>(qpts.size()) );
+    std::unique_ptr< DenseVector<libMesh::Real> > ap( new libMesh::DenseVector<libMesh::Real>(qpts.size()) );
     (*ap).zero();
 
     // pull off distance function at nodes on this element

--- a/src/variables/include/grins/variable_builder.h
+++ b/src/variables/include/grins/variable_builder.h
@@ -30,7 +30,7 @@
 #include "grins/fe_variables_base.h"
 
 // libMesh
-#include "libmesh/auto_ptr.h" // libMesh::UniquePtr
+#include "libmesh/auto_ptr.h" // std::unique_ptr
 
 // libMesh forward declarations
 class GetPot;

--- a/src/variables/include/grins/variable_factory.h
+++ b/src/variables/include/grins/variable_factory.h
@@ -49,7 +49,7 @@ namespace GRINS
 
     ~VariableFactoryAbstract(){};
 
-    virtual libMesh::UniquePtr<FEVariablesBase> create();
+    virtual std::unique_ptr<FEVariablesBase> create();
 
     //! Build the variable names for the FEVariablesBase type (name), returned in the std::vector
     /*! Similarly to build(), this will grab the factory subclass and then
@@ -95,7 +95,7 @@ namespace GRINS
     /*! This function will be called from within create(), which called from
       VariableFactoryAbstract::build. Note the var_names can be built a priori
       using the VariableFactoryAbstract::build_var_names() method. */
-    virtual libMesh::UniquePtr<FEVariablesBase> build_fe_var( const std::vector<std::string>& var_names,
+    virtual std::unique_ptr<FEVariablesBase> build_fe_var( const std::vector<std::string>& var_names,
                                                               const std::vector<VariableIndex>& var_indices,
                                                               const std::set<libMesh::subdomain_id_type>& subdomain_ids ) =0;
 
@@ -176,12 +176,12 @@ namespace GRINS
 
   protected:
 
-    virtual libMesh::UniquePtr<FEVariablesBase>
+    virtual std::unique_ptr<FEVariablesBase>
     build_fe_var( const std::vector<std::string>& var_names,
                   const std::vector<VariableIndex>& var_indices,
                   const std::set<libMesh::subdomain_id_type>& subdomain_ids )
     {
-      return libMesh::UniquePtr<FEVariablesBase>( new VariableType(var_names,var_indices,subdomain_ids) );
+      return std::unique_ptr<FEVariablesBase>( new VariableType(var_names,var_indices,subdomain_ids) );
     }
 
     //! The basic factory implementation looks in [Variables/<VariableName>/names].
@@ -239,10 +239,10 @@ namespace GRINS
       and accordingly build up the variable names. */
     virtual std::vector<std::string> parse_var_names( const GetPot& input, const std::string& var_section );
 
-    virtual libMesh::UniquePtr<FEVariablesBase> build_fe_var( const std::vector<std::string>& var_names,
+    virtual std::unique_ptr<FEVariablesBase> build_fe_var( const std::vector<std::string>& var_names,
                                                               const std::vector<VariableIndex>& var_indices,
                                                               const std::set<libMesh::subdomain_id_type>& subdomain_ids )
-    { return libMesh::UniquePtr<FEVariablesBase>( new VariableType(var_names,var_indices,_prefix,_material,subdomain_ids) ); }
+    { return std::unique_ptr<FEVariablesBase>( new VariableType(var_names,var_indices,_prefix,_material,subdomain_ids) ); }
 
     std::string _prefix;
 

--- a/src/variables/include/grins/variable_factory.h
+++ b/src/variables/include/grins/variable_factory.h
@@ -96,8 +96,8 @@ namespace GRINS
       VariableFactoryAbstract::build. Note the var_names can be built a priori
       using the VariableFactoryAbstract::build_var_names() method. */
     virtual std::unique_ptr<FEVariablesBase> build_fe_var( const std::vector<std::string>& var_names,
-                                                              const std::vector<VariableIndex>& var_indices,
-                                                              const std::set<libMesh::subdomain_id_type>& subdomain_ids ) =0;
+                                                           const std::vector<VariableIndex>& var_indices,
+                                                           const std::set<libMesh::subdomain_id_type>& subdomain_ids ) =0;
 
     // Subclasses implement this to parse the variable component name(s)
     virtual std::vector<std::string> parse_var_names( const GetPot& input, const std::string& var_section ) =0;
@@ -240,8 +240,8 @@ namespace GRINS
     virtual std::vector<std::string> parse_var_names( const GetPot& input, const std::string& var_section );
 
     virtual std::unique_ptr<FEVariablesBase> build_fe_var( const std::vector<std::string>& var_names,
-                                                              const std::vector<VariableIndex>& var_indices,
-                                                              const std::set<libMesh::subdomain_id_type>& subdomain_ids )
+                                                           const std::vector<VariableIndex>& var_indices,
+                                                           const std::set<libMesh::subdomain_id_type>& subdomain_ids )
     { return std::unique_ptr<FEVariablesBase>( new VariableType(var_names,var_indices,_prefix,_material,subdomain_ids) ); }
 
     std::string _prefix;

--- a/src/variables/src/variable_builder.C
+++ b/src/variables/src/variable_builder.C
@@ -89,7 +89,7 @@ namespace GRINS
     VariableFactoryAbstract::set_var_indices(var_indices);
     VariableFactoryAbstract::set_subdomain_ids(subdomain_ids);
 
-    libMesh::UniquePtr<FEVariablesBase> var = VariableFactoryAbstract::build(var_type);
+    std::unique_ptr<FEVariablesBase> var = VariableFactoryAbstract::build(var_type);
 
     // Need to return a SharedPtr, so release from the UniquePtr we got back
     return SharedPtr<FEVariablesBase>( var.release() );

--- a/src/variables/src/variable_factory.C
+++ b/src/variables/src/variable_factory.C
@@ -27,12 +27,12 @@
 
 namespace GRINS
 {
-  libMesh::UniquePtr<FEVariablesBase> VariableFactoryAbstract::create()
+  std::unique_ptr<FEVariablesBase> VariableFactoryAbstract::create()
   {
     // Make sure all necessary state has been setup
     this->check_create_state();
 
-    libMesh::UniquePtr<FEVariablesBase> func;
+    std::unique_ptr<FEVariablesBase> func;
 
     func = this->build_fe_var( *_var_names, *_var_indices, *_subdomain_ids );
 

--- a/src/visualization/include/grins/postprocessed_quantities.h
+++ b/src/visualization/include/grins/postprocessed_quantities.h
@@ -47,10 +47,10 @@ namespace GRINS
     /* Methods to override from FEMFunctionBase needed for libMesh-based evaluations */
     virtual void init_context( const libMesh::FEMContext & context);
 
-    virtual libMesh::UniquePtr<libMesh::FEMFunctionBase<NumericType> >
+    virtual std::unique_ptr<libMesh::FEMFunctionBase<NumericType> >
     clone() const
     {
-      return libMesh::UniquePtr<libMesh::FEMFunctionBase<NumericType> >
+      return std::unique_ptr<libMesh::FEMFunctionBase<NumericType> >
         ( new PostProcessedQuantities(*this) );
     }
 

--- a/src/visualization/src/unsteady_visualization.C
+++ b/src/visualization/src/unsteady_visualization.C
@@ -74,7 +74,7 @@ namespace GRINS
 
     libMesh::SteadySolver* steady_solver = new libMesh::SteadySolver( *(system) );
 
-    system->time_solver = libMesh::UniquePtr<libMesh::TimeSolver>(steady_solver);
+    system->time_solver = std::unique_ptr<libMesh::TimeSolver>(steady_solver);
 
     system->assembly( true /*residual*/, false /*jacobian*/ );
     system->rhs->close();

--- a/test/common/system_helper.h
+++ b/test/common/system_helper.h
@@ -59,9 +59,9 @@ namespace GRINSTesting
       _mesh.reset();
     }
 
-    libMesh::UniquePtr<GetPot> _input;
+    std::unique_ptr<GetPot> _input;
     GRINS::SharedPtr<libMesh::UnstructuredMesh> _mesh;
-    libMesh::UniquePtr<libMesh::EquationSystems> _es;
+    std::unique_ptr<libMesh::EquationSystems> _es;
 
     // Needs to be an ordinar pointer since EquationSystems owns this
     GRINS::MultiphysicsSystem* _system;

--- a/test/interface/antioch_mixture_averaged_transport_evaluator_regression.C
+++ b/test/interface/antioch_mixture_averaged_transport_evaluator_regression.C
@@ -119,7 +119,7 @@ int test_evaluator( const GetPot& input )
 {
   GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
 
-  libMesh::UniquePtr<GRINS::AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> >
+  std::unique_ptr<GRINS::AntiochMixtureAveragedTransportMixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity> >
     mixture_ptr = builder.build_mixture<KineticsThermo,Thermo,Viscosity,Conductivity,Diffusivity>
     (input,"TestMaterial");
 

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -64,7 +64,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochMixtureBuilderBase builder;
 
-      libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix
+      std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix
         = builder.build_chem_mix(*_input, "TestMaterial");
 
       // Just a couple of basic tests for the parsed ChemicalMixture
@@ -80,10 +80,10 @@ namespace GRINSTesting
     {
       GRINS::AntiochMixtureBuilderBase builder;
 
-      libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix
+      std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix
         = builder.build_chem_mix(*_input, "TestMaterial");
 
-      libMesh::UniquePtr<Antioch::ReactionSet<libMesh::Real> > reaction_set
+      std::unique_ptr<Antioch::ReactionSet<libMesh::Real> > reaction_set
         = builder.build_reaction_set(*_input, "TestMaterial", *chem_mix);
 
       CPPUNIT_ASSERT_EQUAL( 5, (int)reaction_set->n_species() );
@@ -94,10 +94,10 @@ namespace GRINSTesting
     {
       GRINS::AntiochMixtureBuilderBase builder;
 
-      libMesh::UniquePtr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix
+      std::unique_ptr<Antioch::ChemicalMixture<libMesh::Real> > chem_mix
         = builder.build_chem_mix(*_input, "TestMaterial");
 
-      libMesh::UniquePtr<Antioch::NASAThermoMixture<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > >
+      std::unique_ptr<Antioch::NASAThermoMixture<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> > >
         nasa_mix =
         builder.build_nasa_thermo_mix<Antioch::CEACurveFit<libMesh::Real> >(*_input, "TestMaterial", *chem_mix);
 
@@ -126,7 +126,7 @@ namespace GRINSTesting
 
   private:
 
-    libMesh::UniquePtr<GetPot> _input;
+    std::unique_ptr<GetPot> _input;
   };
 
 
@@ -156,7 +156,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochConstantTransportMixtureBuilder builder;
 
-      libMesh::UniquePtr<GRINS::ConstantViscosity> visc =
+      std::unique_ptr<GRINS::ConstantViscosity> visc =
         builder.build_constant_viscosity( *_input, "TestMaterial" );
 
       libMesh::Real mu = (*visc)();
@@ -168,7 +168,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochConstantTransportMixtureBuilder builder;
 
-      libMesh::UniquePtr<GRINS::ConstantConductivity> conductivity =
+      std::unique_ptr<GRINS::ConstantConductivity> conductivity =
         builder.build_constant_conductivity<GRINS::ConstantConductivity>( *_input, "TestMaterial" );
 
       libMesh::Real k = (*conductivity)();
@@ -180,7 +180,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochConstantTransportMixtureBuilder builder;
 
-      libMesh::UniquePtr<GRINS::ConstantPrandtlConductivity> conductivity =
+      std::unique_ptr<GRINS::ConstantPrandtlConductivity> conductivity =
         builder.build_constant_conductivity<GRINS::ConstantPrandtlConductivity>( *_input, "TestMaterial" );
 
       libMesh::Real mu = 1.2;
@@ -196,7 +196,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochConstantTransportMixtureBuilder builder;
 
-      libMesh::UniquePtr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > diff =
+      std::unique_ptr<Antioch::ConstantLewisDiffusivity<libMesh::Real> > diff =
         builder.build_constant_lewis_diff( *_input, "TestMaterial" );
 
       libMesh::Real rho = 1.2;
@@ -215,7 +215,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochConstantTransportMixtureBuilder builder;
 
-      libMesh::UniquePtr<GRINS::AntiochConstantTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+      std::unique_ptr<GRINS::AntiochConstantTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
                                                                 GRINS::ConstantConductivity> >
         mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,GRINS::ConstantConductivity>
         (*_input, "TestMaterial");
@@ -241,7 +241,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochConstantTransportMixtureBuilder builder;
 
-      libMesh::UniquePtr<GRINS::AntiochConstantTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+      std::unique_ptr<GRINS::AntiochConstantTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
                                                                 GRINS::ConstantPrandtlConductivity> >
         mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,GRINS::ConstantPrandtlConductivity>
         (*_input, "TestMaterial");
@@ -267,7 +267,7 @@ namespace GRINSTesting
 
   private:
 
-    libMesh::UniquePtr<GetPot> _input;
+    std::unique_ptr<GetPot> _input;
   };
 
 
@@ -299,7 +299,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
 
-      libMesh::UniquePtr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+      std::unique_ptr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
                                                                        Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
                                                                        Antioch::SutherlandViscosity<libMesh::Real>,
                                                                        Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> > ,
@@ -317,7 +317,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
 
-      libMesh::UniquePtr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+      std::unique_ptr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
                                                                        Antioch::StatMechThermodynamics<libMesh::Real>,
                                                                        Antioch::SutherlandViscosity<libMesh::Real>,
                                                                        Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >,
@@ -336,7 +336,7 @@ namespace GRINSTesting
     {
       GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
 
-      libMesh::UniquePtr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
+      std::unique_ptr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
                                                                        Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
                                                                        Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,
                                                                        Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,libMesh::Real>,
@@ -353,7 +353,7 @@ namespace GRINSTesting
 
   private:
 
-    libMesh::UniquePtr<GetPot> _input;
+    std::unique_ptr<GetPot> _input;
   };
 
 

--- a/test/interface/antioch_mixture_builder_test.C
+++ b/test/interface/antioch_mixture_builder_test.C
@@ -216,7 +216,7 @@ namespace GRINSTesting
       GRINS::AntiochConstantTransportMixtureBuilder builder;
 
       std::unique_ptr<GRINS::AntiochConstantTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
-                                                                GRINS::ConstantConductivity> >
+                                                             GRINS::ConstantConductivity> >
         mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,GRINS::ConstantConductivity>
         (*_input, "TestMaterial");
 
@@ -242,7 +242,7 @@ namespace GRINSTesting
       GRINS::AntiochConstantTransportMixtureBuilder builder;
 
       std::unique_ptr<GRINS::AntiochConstantTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
-                                                                GRINS::ConstantPrandtlConductivity> >
+                                                             GRINS::ConstantPrandtlConductivity> >
         mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,GRINS::ConstantPrandtlConductivity>
         (*_input, "TestMaterial");
 
@@ -300,10 +300,10 @@ namespace GRINSTesting
       GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
 
       std::unique_ptr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
-                                                                       Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
-                                                                       Antioch::SutherlandViscosity<libMesh::Real>,
-                                                                       Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> > ,
-                                                                       Antioch::ConstantLewisDiffusivity<libMesh::Real> > >
+                                                                    Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
+                                                                    Antioch::SutherlandViscosity<libMesh::Real>,
+                                                                    Antioch::EuckenThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real> > ,
+                                                                    Antioch::ConstantLewisDiffusivity<libMesh::Real> > >
         mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,
                                         Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
                                         Antioch::SutherlandViscosity<libMesh::Real>,
@@ -318,10 +318,10 @@ namespace GRINSTesting
       GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
 
       std::unique_ptr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
-                                                                       Antioch::StatMechThermodynamics<libMesh::Real>,
-                                                                       Antioch::SutherlandViscosity<libMesh::Real>,
-                                                                       Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >,
-                                                                       Antioch::ConstantLewisDiffusivity<libMesh::Real> > >
+                                                                    Antioch::StatMechThermodynamics<libMesh::Real>,
+                                                                    Antioch::SutherlandViscosity<libMesh::Real>,
+                                                                    Antioch::EuckenThermalConductivity<Antioch::StatMechThermodynamics<libMesh::Real> >,
+                                                                    Antioch::ConstantLewisDiffusivity<libMesh::Real> > >
         mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,
                                         Antioch::StatMechThermodynamics<libMesh::Real>,
                                         Antioch::SutherlandViscosity<libMesh::Real>,
@@ -337,10 +337,10 @@ namespace GRINSTesting
       GRINS::AntiochMixtureAveragedTransportMixtureBuilder builder;
 
       std::unique_ptr<GRINS::AntiochMixtureAveragedTransportMixture<Antioch::CEACurveFit<libMesh::Real>,
-                                                                       Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
-                                                                       Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,
-                                                                       Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,libMesh::Real>,
-                                                                       Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >
+                                                                    Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
+                                                                    Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,
+                                                                    Antioch::KineticsTheoryThermalConductivity<Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,libMesh::Real>,
+                                                                    Antioch::MolecularBinaryDiffusion<libMesh::Real,Antioch::GSLSpliner> > >
         mixture = builder.build_mixture<Antioch::CEACurveFit<libMesh::Real>,
                                         Antioch::IdealGasMicroThermo<Antioch::NASAEvaluator<libMesh::Real,Antioch::CEACurveFit<libMesh::Real> >, libMesh::Real>,
                                         Antioch::KineticsTheoryViscosity<libMesh::Real,Antioch::GSLSpliner>,

--- a/test/interface/antioch_test_base.h
+++ b/test/interface/antioch_test_base.h
@@ -55,7 +55,7 @@ namespace GRINSTesting
 
   protected:
 
-    libMesh::UniquePtr<GRINS::AntiochMixture<Antioch::CEACurveFit<libMesh::Real> > > _antioch_mixture;
+    std::unique_ptr<GRINS::AntiochMixture<Antioch::CEACurveFit<libMesh::Real> > > _antioch_mixture;
   };
 
 } // end namespace GRINSTesting

--- a/test/interface/cantera_test_base.h
+++ b/test/interface/cantera_test_base.h
@@ -51,7 +51,7 @@ namespace GRINSTesting
 
   protected:
 
-    libMesh::UniquePtr<GRINS::CanteraMixture> _cantera_mixture;
+    std::unique_ptr<GRINS::CanteraMixture> _cantera_mixture;
   };
 
 } // end namespace GRINSTesting

--- a/test/regression/test_turbulent_channel.C
+++ b/test/regression/test_turbulent_channel.C
@@ -120,8 +120,8 @@ namespace GRINSTesting
     virtual libMesh::Number compute_final_value( const libMesh::DenseVector<libMesh::Number>& u_nu_values )
     { return  u_nu_values(0)/21.995539; }
 
-    virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > clone() const
-    { return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > (new TurbulentBdyFunctionU(_turbulent_bc_values)); }
+    virtual std::unique_ptr<libMesh::FunctionBase<libMesh::Number> > clone() const
+    { return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> > (new TurbulentBdyFunctionU(_turbulent_bc_values)); }
   };
 
   // Class to construct the Dirichlet boundary object and operator for the inlet u velocity and nu profiles
@@ -135,8 +135,8 @@ namespace GRINSTesting
     virtual libMesh::Number compute_final_value( const libMesh::DenseVector<libMesh::Number>& u_nu_values )
     { return  u_nu_values(1)/(2.0*21.995539); }
 
-    virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > clone() const
-    { return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> > (new TurbulentBdyFunctionNu(_turbulent_bc_values)); }
+    virtual std::unique_ptr<libMesh::FunctionBase<libMesh::Number> > clone() const
+    { return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> > (new TurbulentBdyFunctionNu(_turbulent_bc_values)); }
 
   };
 
@@ -167,7 +167,7 @@ namespace GRINSTesting
 
   protected:
 
-    virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+    virtual std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
     build_func( const GetPot& /*input*/,
                 GRINS::MultiphysicsSystem& system,
                 std::vector<std::string>& var_names,
@@ -177,10 +177,10 @@ namespace GRINSTesting
       libmesh_assert_equal_to(var_names[0], std::string("u"));
       libmesh_assert_equal_to(var_names[1], std::string("v"));
 
-      libMesh::UniquePtr<libMesh::CompositeFunction<libMesh::Number> >
+      std::unique_ptr<libMesh::CompositeFunction<libMesh::Number> >
         composite_func( new libMesh::CompositeFunction<libMesh::Number> );
 
-      libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+      std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
         bound_func(new TurbulentBdyFunctionU(_turbulent_bc_values) );
 
       std::vector<GRINS::VariableIndex> vars(1);
@@ -190,7 +190,7 @@ namespace GRINSTesting
       vars[0] = system.variable_number(var_names[1]);
       composite_func->attach_subfunction(libMesh::ZeroFunction<libMesh::Number>(), vars);
 
-      return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >( composite_func.release() );
+      return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >( composite_func.release() );
     }
   };
 
@@ -204,7 +204,7 @@ namespace GRINSTesting
 
   protected:
 
-    virtual libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+    virtual std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
     build_func( const GetPot& /*input*/,
                 GRINS::MultiphysicsSystem& system,
                 std::vector<std::string>& var_names,
@@ -213,17 +213,17 @@ namespace GRINSTesting
       libmesh_assert_equal_to(var_names.size(), 1);
       libmesh_assert_equal_to(var_names[0], std::string("nu"));
 
-      libMesh::UniquePtr<libMesh::CompositeFunction<libMesh::Number> >
+      std::unique_ptr<libMesh::CompositeFunction<libMesh::Number> >
         composite_func( new libMesh::CompositeFunction<libMesh::Number> );
 
-      libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >
+      std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >
         bound_func( new TurbulentBdyFunctionNu(_turbulent_bc_values) );
 
       std::vector<GRINS::VariableIndex> vars(1);
       vars[0] = system.variable_number(var_names[0]);
       composite_func->attach_subfunction(*bound_func, vars);
 
-      return libMesh::UniquePtr<libMesh::FunctionBase<libMesh::Number> >( composite_func.release() );
+      return std::unique_ptr<libMesh::FunctionBase<libMesh::Number> >( composite_func.release() );
     }
   };
 
@@ -278,9 +278,9 @@ int main(int argc, char* argv[])
   equation_systems.print_info();
 
   // Prepare a global solution and a MeshFunction of the Turbulent system
-  libMesh::UniquePtr<libMesh::MeshFunction> turbulent_bc_values;
+  std::unique_ptr<libMesh::MeshFunction> turbulent_bc_values;
 
-  libMesh::UniquePtr<libMesh::NumericVector<libMesh::Number> > turbulent_bc_soln = libMesh::NumericVector<libMesh::Number>::build(equation_systems.comm());
+  std::unique_ptr<libMesh::NumericVector<libMesh::Number> > turbulent_bc_soln = libMesh::NumericVector<libMesh::Number>::build(equation_systems.comm());
 
   std::vector<libMesh::Number> flow_soln;
 
@@ -294,7 +294,7 @@ int main(int argc, char* argv[])
   turbulent_bc_system_variables.push_back(0);
   turbulent_bc_system_variables.push_back(1);
 
-  turbulent_bc_values = libMesh::UniquePtr<libMesh::MeshFunction>
+  turbulent_bc_values = std::unique_ptr<libMesh::MeshFunction>
     (new libMesh::MeshFunction(equation_systems,
                                *turbulent_bc_soln,
                                turbulent_bc_system.get_dof_map(),

--- a/test/unit/antioch_mixture.C
+++ b/test/unit/antioch_mixture.C
@@ -57,7 +57,7 @@ int main( int argc, char* argv[] )
   GetPot input( argv[1] );
 
   GRINS::AntiochMixtureBuilderBase builder;
-  libMesh::UniquePtr<GRINS::AntiochMixture<Antioch::CEACurveFit<libMesh::Real> > >
+  std::unique_ptr<GRINS::AntiochMixture<Antioch::CEACurveFit<libMesh::Real> > >
     antioch_ptr = builder.build_antioch_mixture<Antioch::CEACurveFit<libMesh::Real> >(input,"TestMaterial");
 
   const GRINS::AntiochMixture<Antioch::CEACurveFit<libMesh::Real> > & antioch = *antioch_ptr;

--- a/test/unit/gas_recombination_catalytic_wall.C
+++ b/test/unit/gas_recombination_catalytic_wall.C
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
   if( test_type == "cantera" )
     {
 #ifdef GRINS_HAVE_CANTERA
-      libMesh::UniquePtr<GRINS::CanteraMixture> chem_uptr;
+      std::unique_ptr<GRINS::CanteraMixture> chem_uptr;
       chem_builder.build_chemistry(input,"TestMaterial",chem_uptr);
       return_flag = test<GRINS::CanteraMixture>( *chem_uptr );
 #else
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
   else if( test_type == "antioch" )
     {
 #ifdef GRINS_HAVE_ANTIOCH
-      libMesh::UniquePtr<GRINS::AntiochChemistry> chem_uptr;
+      std::unique_ptr<GRINS::AntiochChemistry> chem_uptr;
       chem_builder.build_chemistry(input,"TestMaterial",chem_uptr);
       return_flag = test<GRINS::AntiochChemistry>( *chem_uptr );
 #else

--- a/test/unit/gas_solid_catalytic_wall.C
+++ b/test/unit/gas_solid_catalytic_wall.C
@@ -208,7 +208,7 @@ int main(int argc, char* argv[])
   if( test_type == "cantera" )
     {
 #ifdef GRINS_HAVE_CANTERA
-      libMesh::UniquePtr<GRINS::CanteraMixture> chem_uptr;
+      std::unique_ptr<GRINS::CanteraMixture> chem_uptr;
       chem_builder.build_chemistry(input,"CanteraMaterial",chem_uptr);
       return_flag = test<GRINS::CanteraMixture>( *chem_uptr );
 #else
@@ -218,7 +218,7 @@ int main(int argc, char* argv[])
   else if( test_type == "antioch" )
     {
 #ifdef GRINS_HAVE_ANTIOCH
-      libMesh::UniquePtr<GRINS::AntiochChemistry> chem_uptr;
+      std::unique_ptr<GRINS::AntiochChemistry> chem_uptr;
       chem_builder.build_chemistry(input,"AntiochMaterial",chem_uptr);
       return_flag = test<GRINS::AntiochChemistry>( *chem_uptr );
 #else

--- a/test/unit/spectroscopic_absorption_test.C
+++ b/test/unit/spectroscopic_absorption_test.C
@@ -112,7 +112,7 @@ namespace GRINSTesting
       libMesh::Real nu_min = 3682.69;
       libMesh::Real nu_max = 3682.8;
       GRINS::ChemistryBuilder chem_builder;
-      libMesh::UniquePtr<GRINS::AntiochChemistry> chem_ptr;
+      std::unique_ptr<GRINS::AntiochChemistry> chem_ptr;
       chem_builder.build_chemistry(*(_input.get()),material,chem_ptr);
       GRINS::SharedPtr<GRINS::AntiochChemistry> chem(chem_ptr.release());
       GRINS::SharedPtr<AbsorptionCoeffTesting<GRINS::AntiochChemistry> > absorb = new AbsorptionCoeffTesting<GRINS::AntiochChemistry>(chem,hitran,nu_min,nu_max,nu_desired,species,thermo_pressure);


### PR DESCRIPTION
Also ran `make reindent`. This is just redoing what @jwpeterson did in #516 since some conflicts arose and it seemed easier to just redo the sed from master then fixup the rebase.

This will be the first PR after 0.8.0 release to require C++11.