### PR TITLE
Add and Use NonlinearSolverOptions Container

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -217,6 +217,7 @@ libgrins_la_SOURCES += solver/src/time_stepping_parsing.C
 libgrins_la_SOURCES += solver/src/unsteady_mesh_adaptive_solver.C
 libgrins_la_SOURCES += solver/src/simulation_initializer.C
 libgrins_la_SOURCES += solver/src/runner.C
+libgrins_la_SOURCES += solver/src/nonlinear_solver_options.C
 
 # src/strategies files
 libgrins_la_SOURCES += strategies/src/strategies_parsing.C
@@ -519,6 +520,7 @@ include_HEADERS += solver/include/grins/simulation_parsing.h
 include_HEADERS += solver/include/grins/unsteady_mesh_adaptive_solver.h
 include_HEADERS += solver/include/grins/simulation_initializer.h
 include_HEADERS += solver/include/grins/runner.h
+include_HEADERS += solver/include/grins/nonlinear_solver_options.h
 
 # src/strategies headers
 include_HEADERS += strategies/include/grins/strategies_parsing.h

--- a/src/solver/include/grins/nonlinear_solver_options.h
+++ b/src/solver/include/grins/nonlinear_solver_options.h
@@ -1,0 +1,95 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_NONLINEAR_SOLVER_OPTIONS_H
+#define GRINS_NONLINEAR_SOLVER_OPTIONS_H
+
+// C++
+#include <string>
+
+// libMesh
+#include "libmesh/libmesh.h"
+#include "libmesh/getpot.h"
+
+namespace GRINS
+{
+  //! Container for nonlinear solver options
+  class NonlinearSolverOptions
+  {
+  public:
+
+    NonlinearSolverOptions( const GetPot & input );
+    ~NonlinearSolverOptions(){};
+
+    inline
+    unsigned int max_nonlinear_iterations() const
+    { return _input(_prefix+"/max_nonlinear_iterations",10); }
+
+    inline
+    libMesh::Real relative_step_tolerance() const
+    { return _input(_prefix+"/relative_step_tolerance",1.0e-6); }
+
+    inline
+    libMesh::Real absolute_step_tolerance() const
+    { return _input(_prefix+"/absolute_step_tolerance",0.0); }
+
+    /* [PB]: Captured this comment from the previous location.
+      _relative_residual_tolerance applies to both one of the
+      stopping criteria for (nonlinear) forward solves and *the*
+      stopping criterion for (linear) adjoint solves. */
+    inline
+    libMesh::Real relative_residual_tolerance() const
+    { return _input(_prefix+"/relative_residual_tolerance",1.0e-15); }
+
+    inline
+    libMesh::Real absolute_residual_tolerance() const
+    { return _input(_prefix+"/absolute_residual_tolerance",0.0); }
+
+    inline
+    bool continue_after_backtrack_failure() const
+    { return _input(_prefix+"/continue_after_backtrack_failure",false); }
+
+    inline
+    bool continue_after_max_iterations() const
+    { return _input(_prefix+"/continue_after_max_iterations",false); }
+
+    inline
+    bool require_residual_reduction() const
+    { return _input(_prefix+"/require_residual_reduction",true); }
+
+  protected:
+
+    const GetPot & _input;
+
+    std::string _prefix;
+
+  private:
+
+    NonlinearSolverOptions();
+
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_NONLINEAR_SOLVER_OPTIONS_H

--- a/src/solver/include/grins/nonlinear_solver_options.h
+++ b/src/solver/include/grins/nonlinear_solver_options.h
@@ -78,6 +78,25 @@ namespace GRINS
     bool require_residual_reduction() const
     { return _input(_prefix+"/require_residual_reduction",true); }
 
+    inline
+    libMesh::Real verify_analytic_jacobians() const
+    { return _input(_prefix+"/verify_analytic_jacobians",0.0); }
+
+    inline
+    bool use_numerical_jacobians_only() const
+    { return _input(_prefix+"/use_numerical_jacobians_only",false); }
+
+    inline
+    libMesh::Real numerical_jacobian_h() const
+    { return _input(_prefix+"/numerical_jacobian_h",libMesh::TOLERANCE); }
+
+    //! Populate numerical-Jacobian-h values and variable names
+    /*! The user is allowed to provide a list of variables and a corresponding
+        numerical_jacobian_h value for that variable. This function will populate
+        the variables and values vector, respectively, with that info. */
+    void numerical_jacobian_h_vars_and_vals( std::vector<std::string> & variables,
+                                             std::vector<libMesh::Real> & values ) const;
+
   protected:
 
     const GetPot & _input;

--- a/src/solver/include/grins/solver.h
+++ b/src/solver/include/grins/solver.h
@@ -26,8 +26,11 @@
 #ifndef GRINS_SOLVER_H
 #define GRINS_SOLVER_H
 
-// GRINS
+// C++
 #include <memory>
+
+// GRINS
+#include "grins/nonlinear_solver_options.h"
 
 // libMesh
 #include "libmesh/equation_systems.h"
@@ -52,7 +55,7 @@ namespace GRINS
   {
   public:
     Solver( const GetPot& input );
-    virtual ~Solver();
+    virtual ~Solver(){};
 
     virtual void initialize( const GetPot& input,
                              std::shared_ptr<libMesh::EquationSystems> equation_system,
@@ -87,23 +90,11 @@ namespace GRINS
 
   protected:
 
-    // Linear/Nonlinear solver options
-    unsigned int _max_nonlinear_iterations;
-    double _relative_step_tolerance;
-    double _absolute_step_tolerance;
+    NonlinearSolverOptions _nonlinear_solver_options;
 
-    // _relative_residual_tolerance applies to both one of the
-    // stopping criteria for (nonlinear) forward solves and *the*
-    // stopping criterion for (linear) adjoint solves.
-    double _relative_residual_tolerance;
-
-    double _absolute_residual_tolerance;
     double _initial_linear_tolerance;
     double _minimum_linear_tolerance;
     unsigned int _max_linear_iterations;
-    bool _continue_after_backtrack_failure;
-    bool _continue_after_max_iterations;
-    bool _require_residual_reduction;
 
     // Screen display options
     bool _solver_quiet;

--- a/src/solver/src/nonlinear_solver_options.C
+++ b/src/solver/src/nonlinear_solver_options.C
@@ -1,0 +1,35 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/nonlinear_solver_options.h"
+
+namespace GRINS
+{
+  NonlinearSolverOptions::NonlinearSolverOptions( const GetPot & input )
+    : _input(input),
+      _prefix("linear-nonlinear-solver")
+  {}
+
+} // end namespace GRINS

--- a/src/solver/src/nonlinear_solver_options.C
+++ b/src/solver/src/nonlinear_solver_options.C
@@ -32,4 +32,40 @@ namespace GRINS
       _prefix("linear-nonlinear-solver")
   {}
 
+  void NonlinearSolverOptions::numerical_jacobian_h_vars_and_vals( std::vector<std::string> & variables,
+                                                                   std::vector<libMesh::Real> & values ) const
+  {
+    const std::string variables_option = _prefix+"/numerical_jacobian_h_variables";
+    const std::string values_option = _prefix+"/numerical_jacobian_h_values";
+
+    const unsigned int n_numerical_jacobian_h_values =
+      _input.vector_variable_size(values_option);
+
+    // Check size consistency
+    if( n_numerical_jacobian_h_values != _input.vector_variable_size(variables_option) )
+      {
+        std::stringstream err;
+        err << "Error: found " << n_numerical_jacobian_h_values
+            << " numerical_jacobian_h_values" << std::endl
+            << "  but "
+            << _input.vector_variable_size(variables_option)
+            << " numerical_jacobian_h_variables" << std::endl;
+
+        libmesh_error_msg(err.str());
+      }
+
+    // Now populate data, if we have any
+    if( n_numerical_jacobian_h_values > 0 )
+      {
+        variables.resize(n_numerical_jacobian_h_values);
+        values.resize(n_numerical_jacobian_h_values);
+
+        for (unsigned int i=0; i != n_numerical_jacobian_h_values; ++i)
+          {
+            variables[i] = _input(variables_option,"", i);
+            values[i] = _input(values_option,libMesh::Real(0), i);
+          }
+      }
+  }
+
 } // end namespace GRINS

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -113,7 +113,8 @@ unit_driver_SOURCES = unit/unit_driver.C \
                       unit/rayfireAMR_test.C \
                       unit/integrated_function_test.C \
                       unit/hitran_test.C \
-                      unit/spectroscopic_absorption_test.C
+                      unit/spectroscopic_absorption_test.C \
+                      unit/nonlinear_solver_options.C
 
 antioch_mixture_SOURCES = unit/antioch_mixture.C
 arrhenius_catalycity_SOURCES = unit/arrhenius_catalycity.C

--- a/test/unit/nonlinear_solver_options.C
+++ b/test/unit/nonlinear_solver_options.C
@@ -1,0 +1,115 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
+
+#include "grins/nonlinear_solver_options.h"
+
+namespace GRINSTesting
+{
+  class NonlinearSolverOptionsTest : public CppUnit::TestCase
+  {
+  public:
+    CPPUNIT_TEST_SUITE( NonlinearSolverOptionsTest );
+
+    CPPUNIT_TEST( test_defaults );
+    CPPUNIT_TEST( test_eval );
+
+    CPPUNIT_TEST_SUITE_END();
+
+  protected:
+
+
+
+    GetPot _input;
+
+  public:
+
+    void setup_nondefault_inputfile()
+    {
+      const char* text =
+        "[linear-nonlinear-solver]                  \n"
+        "max_nonlinear_iterations = '1'             \n"
+        "relative_step_tolerance = '1.0e-9'         \n"
+        "absolute_step_tolerance = '1.0e-10'        \n"
+        "relative_residual_tolerance = '1.0e-10'    \n"
+        "absolute_residual_tolerance = '1.0e-13'    \n"
+        "continue_after_backtrack_failure  = 'true' \n"
+        "continue_after_max_iterations  = 'true'    \n"
+        "require_residual_reduction  = 'false'      \n"
+        "[]\n";
+
+      std::stringstream inputfile;
+      inputfile << text;
+
+      _input.parse_input_stream(inputfile);
+    }
+
+    //! Capture any changes to the default values
+    void test_defaults()
+    {
+      GRINS::NonlinearSolverOptions options(_input);
+
+      CPPUNIT_ASSERT_EQUAL( 10, (int)options.max_nonlinear_iterations() );
+      CPPUNIT_ASSERT_EQUAL( 1.0e-6, options.relative_step_tolerance() );
+      CPPUNIT_ASSERT_EQUAL( 0.0, options.absolute_step_tolerance() );
+      CPPUNIT_ASSERT_EQUAL( 1.0e-15, options.relative_residual_tolerance() );
+      CPPUNIT_ASSERT_EQUAL( 0.0, options.absolute_residual_tolerance() );
+      CPPUNIT_ASSERT_EQUAL( false, options.continue_after_backtrack_failure() );
+      CPPUNIT_ASSERT_EQUAL( false, options.continue_after_max_iterations() );
+      CPPUNIT_ASSERT_EQUAL( true, options.require_residual_reduction() );
+    }
+
+    void test_eval()
+    {
+      this->setup_nondefault_inputfile();
+      GRINS::NonlinearSolverOptions options(_input);
+
+      CPPUNIT_ASSERT_EQUAL( 1, (int)options.max_nonlinear_iterations() );
+      CPPUNIT_ASSERT_EQUAL( 1.0e-9, options.relative_step_tolerance() );
+      CPPUNIT_ASSERT_EQUAL( 1.0e-10, options.absolute_step_tolerance() );
+      CPPUNIT_ASSERT_EQUAL( 1.0e-10, options.relative_residual_tolerance() );
+      CPPUNIT_ASSERT_EQUAL( 1.0e-13, options.absolute_residual_tolerance() );
+      CPPUNIT_ASSERT_EQUAL( true, options.continue_after_backtrack_failure() );
+      CPPUNIT_ASSERT_EQUAL( true, options.continue_after_max_iterations() );
+      CPPUNIT_ASSERT_EQUAL( false, options.require_residual_reduction() );
+    }
+
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( NonlinearSolverOptionsTest );
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_CPPUNIT

--- a/test/unit/nonlinear_solver_options.C
+++ b/test/unit/nonlinear_solver_options.C
@@ -50,8 +50,6 @@ namespace GRINSTesting
 
   protected:
 
-
-
     GetPot _input;
 
   public:
@@ -59,15 +57,20 @@ namespace GRINSTesting
     void setup_nondefault_inputfile()
     {
       const char* text =
-        "[linear-nonlinear-solver]                  \n"
-        "max_nonlinear_iterations = '1'             \n"
-        "relative_step_tolerance = '1.0e-9'         \n"
-        "absolute_step_tolerance = '1.0e-10'        \n"
-        "relative_residual_tolerance = '1.0e-10'    \n"
-        "absolute_residual_tolerance = '1.0e-13'    \n"
-        "continue_after_backtrack_failure  = 'true' \n"
-        "continue_after_max_iterations  = 'true'    \n"
-        "require_residual_reduction  = 'false'      \n"
+        "[linear-nonlinear-solver]                           \n"
+        "max_nonlinear_iterations = '1'                      \n"
+        "relative_step_tolerance = '1.0e-9'                  \n"
+        "absolute_step_tolerance = '1.0e-10'                 \n"
+        "relative_residual_tolerance = '1.0e-10'             \n"
+        "absolute_residual_tolerance = '1.0e-13'             \n"
+        "continue_after_backtrack_failure  = 'true'          \n"
+        "continue_after_max_iterations  = 'true'             \n"
+        "require_residual_reduction  = 'false'               \n"
+        "verify_analytic_jacobians  = '1.0e-6'               \n"
+        "use_numerical_jacobians_only  = 'true'              \n"
+        "numerical_jacobian_h  = '1.0e-3'                    \n"
+        "numerical_jacobian_h_variables = 'U y Vz'           \n"
+        "numerical_jacobian_h_values = '1.0  2.0e-6  3.0e-8' \n"
         "[]\n";
 
       std::stringstream inputfile;
@@ -89,6 +92,15 @@ namespace GRINSTesting
       CPPUNIT_ASSERT_EQUAL( false, options.continue_after_backtrack_failure() );
       CPPUNIT_ASSERT_EQUAL( false, options.continue_after_max_iterations() );
       CPPUNIT_ASSERT_EQUAL( true, options.require_residual_reduction() );
+      CPPUNIT_ASSERT_EQUAL( 0.0, options.verify_analytic_jacobians() );
+      CPPUNIT_ASSERT_EQUAL( false, options.use_numerical_jacobians_only() );
+      CPPUNIT_ASSERT_EQUAL( libMesh::TOLERANCE, options.numerical_jacobian_h() );
+
+      std::vector<std::string> variables;
+      std::vector<libMesh::Real> values;
+      options.numerical_jacobian_h_vars_and_vals(variables,values);
+      CPPUNIT_ASSERT(variables.empty());
+      CPPUNIT_ASSERT(values.empty());
     }
 
     void test_eval()
@@ -104,6 +116,22 @@ namespace GRINSTesting
       CPPUNIT_ASSERT_EQUAL( true, options.continue_after_backtrack_failure() );
       CPPUNIT_ASSERT_EQUAL( true, options.continue_after_max_iterations() );
       CPPUNIT_ASSERT_EQUAL( false, options.require_residual_reduction() );
+      CPPUNIT_ASSERT_EQUAL( 1.e-6, options.verify_analytic_jacobians() );
+      CPPUNIT_ASSERT_EQUAL( true, options.use_numerical_jacobians_only() );
+      CPPUNIT_ASSERT_EQUAL( 1.0e-3, options.numerical_jacobian_h() );
+
+      std::vector<std::string> variables;
+      std::vector<libMesh::Real> values;
+      options.numerical_jacobian_h_vars_and_vals(variables,values);
+      CPPUNIT_ASSERT_EQUAL(3, (int)variables.size());
+      CPPUNIT_ASSERT_EQUAL(std::string("U"),variables[0]);
+      CPPUNIT_ASSERT_EQUAL(std::string("y"),variables[1]);
+      CPPUNIT_ASSERT_EQUAL(std::string("Vz"),variables[2]);
+
+      CPPUNIT_ASSERT_EQUAL(3, (int)values.size());
+      CPPUNIT_ASSERT_EQUAL(1.0,values[0]);
+      CPPUNIT_ASSERT_EQUAL(2.0e-6,values[1]);
+      CPPUNIT_ASSERT_EQUAL(3.0e-8,values[2]);
     }
 
   };


### PR DESCRIPTION
OK, I think I'm starting to figure the right way to contain parsing options. Because I'm an idiot, I've been thinking about `GetPot` as a parser (which it is) rather than a poor-man's-database (which is how we're using it). So, `NonlinearSolverOptions` is basically a very lightweight wrapper around `GetPot` so that we hide the key for which we parse. Then we can dump this object in where ever we need it because it's super lightweight, but we contain the things that might change to one class.

`ErrorEstimatorOptions`, `MeshAdaptivityOptions`, etc. should be refactored in this fashion.

Subsequent PR will change the sectioning for these options. More subsequent PRs will make similar changes to add a `LinearSolverOptions`,  `DisplayOptions`, etc.

Will rebase once #525 is merged (which will be merged once CIVET update snafu is sorted).