### PR TITLE
DiffSolver Factory, Support libMesh::PetscDiffSolver

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
 Version 0.9.0 (in progress)
    * C++11 compiler now required
    * Minimum libMesh git hash for this release is: daf2f70
+   * Use factory pattern for DiffSolver, now support
+     specifying DiffSolver type in inputfile,
+     add support for libMesh::PetscDiffSolver
 
 Version 0.8.0
    * Minimum libMesh git hash for this release is: 8be0a4e

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -521,6 +521,8 @@ include_HEADERS += solver/include/grins/unsteady_mesh_adaptive_solver.h
 include_HEADERS += solver/include/grins/simulation_initializer.h
 include_HEADERS += solver/include/grins/runner.h
 include_HEADERS += solver/include/grins/nonlinear_solver_options.h
+include_HEADERS += solver/include/grins/diff_solver_names.h
+
 
 # src/strategies headers
 include_HEADERS += strategies/include/grins/strategies_parsing.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -218,6 +218,8 @@ libgrins_la_SOURCES += solver/src/unsteady_mesh_adaptive_solver.C
 libgrins_la_SOURCES += solver/src/simulation_initializer.C
 libgrins_la_SOURCES += solver/src/runner.C
 libgrins_la_SOURCES += solver/src/nonlinear_solver_options.C
+libgrins_la_SOURCES += solver/src/diff_solver_factory.C
+
 
 # src/strategies files
 libgrins_la_SOURCES += strategies/src/strategies_parsing.C
@@ -522,6 +524,7 @@ include_HEADERS += solver/include/grins/simulation_initializer.h
 include_HEADERS += solver/include/grins/runner.h
 include_HEADERS += solver/include/grins/nonlinear_solver_options.h
 include_HEADERS += solver/include/grins/diff_solver_names.h
+include_HEADERS += solver/include/grins/diff_solver_factory.h
 
 
 # src/strategies headers

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -219,6 +219,7 @@ libgrins_la_SOURCES += solver/src/simulation_initializer.C
 libgrins_la_SOURCES += solver/src/runner.C
 libgrins_la_SOURCES += solver/src/nonlinear_solver_options.C
 libgrins_la_SOURCES += solver/src/diff_solver_factory.C
+libgrins_la_SOURCES += solver/src/diff_solver_factory_initializer.C
 
 
 # src/strategies files
@@ -525,6 +526,7 @@ include_HEADERS += solver/include/grins/runner.h
 include_HEADERS += solver/include/grins/nonlinear_solver_options.h
 include_HEADERS += solver/include/grins/diff_solver_names.h
 include_HEADERS += solver/include/grins/diff_solver_factory.h
+include_HEADERS += solver/include/grins/diff_solver_factory_initializer.h
 
 
 # src/strategies headers

--- a/src/solver/include/grins/diff_solver_factory.h
+++ b/src/solver/include/grins/diff_solver_factory.h
@@ -1,0 +1,90 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_DIFF_SOLVER_FACTORY_H
+#define GRINS_DIFF_SOLVER_FACTORY_H
+
+// GRINS
+#include "grins/factory_abstract.h"
+#include "grins/multiphysics_sys.h"
+
+// libMesh
+#include "libmesh/diff_solver.h"
+
+namespace GRINS
+{
+  class DiffSolverFactoryAbstract : public FactoryAbstract<libMesh::DiffSolver>
+  {
+  public:
+    DiffSolverFactoryAbstract( const std::string & diff_solver_name )
+      : FactoryAbstract<libMesh::DiffSolver>(diff_solver_name)
+    {}
+
+    virtual ~DiffSolverFactoryAbstract() =0;
+
+    static void set_system( MultiphysicsSystem * system )
+    { _system = system; }
+
+  protected:
+
+   static MultiphysicsSystem * _system;
+
+   virtual std::unique_ptr<libMesh::DiffSolver> build_diff_solver( MultiphysicsSystem & system ) =0;
+
+  private:
+
+    virtual std::unique_ptr<libMesh::DiffSolver> create();
+
+    DiffSolverFactoryAbstract();
+  };
+
+  inline
+  DiffSolverFactoryAbstract::~DiffSolverFactoryAbstract(){}
+
+
+  template<typename DiffSolverType>
+  class DiffSolverFactoryBasic : public DiffSolverFactoryAbstract
+  {
+  public:
+
+    DiffSolverFactoryBasic( const std::string & diff_solver_name )
+      : DiffSolverFactoryAbstract(diff_solver_name)
+    {}
+
+    virtual ~DiffSolverFactoryBasic(){}
+
+  protected:
+
+    virtual std::unique_ptr<libMesh::DiffSolver> build_diff_solver( MultiphysicsSystem & system )
+    { return std::unique_ptr<libMesh::DiffSolver>( new DiffSolverType(system) ); }
+
+  private:
+
+    DiffSolverFactoryBasic();
+
+  };
+
+} // end namespace GRINS
+
+#endif // GRINS_DIFF_SOLVER_FACTORY_H

--- a/src/solver/include/grins/diff_solver_factory_initializer.h
+++ b/src/solver/include/grins/diff_solver_factory_initializer.h
@@ -1,0 +1,43 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_DIFF_SOLVER_FACTORY_INITIALIZER_H
+#define GRINS_DIFF_SOLVER_FACTORY_INITIALIZER_H
+
+namespace GRINS
+{
+  //! Initialize all Factory objects related to libMesh::DiffSolver subclasses
+  /*! To avoid symbol stripping from static linking, we use this
+    class to initialize/register the libMesh::DiffSolver factory objects.
+
+    Relevant discussion: http://stackoverflow.com/questions/5202142/static-variable-initialization-over-a-library*/
+  class DiffSolverFactoryInitializer
+  {
+  public:
+    DiffSolverFactoryInitializer();
+    ~DiffSolverFactoryInitializer(){}
+  };
+} // end namespace GRINS
+
+#endif // GRINS_SOLVER_FACTORY_INITIALIZER_H

--- a/src/solver/include/grins/diff_solver_names.h
+++ b/src/solver/include/grins/diff_solver_names.h
@@ -1,0 +1,46 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef GRINS_DIFF_SOLVER_NAMES_H
+#define GRINS_DIFF_SOLVER_NAMES_H
+
+// C++
+#include <string>
+
+namespace GRINS
+{
+  class DiffSolverNames
+  {
+  public:
+
+    static const std::string newton_solver()
+    { return "libmesh_newton"; }
+
+    static const std::string petsc_diff_solver()
+    { return "libmesh_petsc_diff"; }
+
+  };
+} // end namespace GRINS
+
+#endif // GRINS_DIFF_SOLVER_NAMES_H

--- a/src/solver/include/grins/nonlinear_solver_options.h
+++ b/src/solver/include/grins/nonlinear_solver_options.h
@@ -28,6 +28,9 @@
 // C++
 #include <string>
 
+// GRINS
+#include "grins/diff_solver_names.h"
+
 // libMesh
 #include "libmesh/libmesh.h"
 #include "libmesh/getpot.h"
@@ -41,6 +44,10 @@ namespace GRINS
 
     NonlinearSolverOptions( const GetPot & input );
     ~NonlinearSolverOptions(){};
+
+    inline
+    std::string type() const
+    { return _input(_prefix+"/type",DiffSolverNames::newton_solver()); }
 
     inline
     unsigned int max_nonlinear_iterations() const

--- a/src/solver/include/grins/solver.h
+++ b/src/solver/include/grins/solver.h
@@ -104,6 +104,9 @@ namespace GRINS
 
     virtual void init_time_solver(GRINS::MultiphysicsSystem* system)=0;
 
+    void build_diff_solver( const NonlinearSolverOptions & options,
+                            MultiphysicsSystem * system );
+
   };
 
 } //End namespace block

--- a/src/solver/include/grins/solver_names.h
+++ b/src/solver/include/grins/solver_names.h
@@ -22,6 +22,9 @@
 //
 //-----------------------------------------------------------------------el-
 
+#ifndef GRINS_SOLVER_NAMES_H
+#define GRINS_SOLVER_NAMES_H
+
 // C++
 #include <string>
 
@@ -54,3 +57,5 @@ namespace GRINS
 
   };
 } // end namespace GRINS
+
+#endif // GRINS_SOLVER_NAMES_H

--- a/src/solver/src/diff_solver_factory.C
+++ b/src/solver/src/diff_solver_factory.C
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins/diff_solver_factory.h"
+
+namespace GRINS
+{
+  std::unique_ptr<libMesh::DiffSolver> DiffSolverFactoryAbstract::create()
+  {
+    if(!_system)
+      libmesh_error_msg("ERROR: Must must MultiphysicsSystem pointer before calling DiffSolverFactoryAbstract::create()!");
+
+    return this->build_diff_solver(*_system);
+  }
+
+  // Full specialization for the Factory<libMesh::DiffSolver>
+  template<>
+  std::map<std::string, FactoryAbstract<libMesh::DiffSolver>*>&
+  FactoryAbstract<libMesh::DiffSolver>::factory_map()
+  {
+    static std::map<std::string, FactoryAbstract<libMesh::DiffSolver>*> _map;
+    return _map;
+  }
+
+  // Definition of static members
+  MultiphysicsSystem * DiffSolverFactoryAbstract::_system = NULL;
+
+} // end namespace GRINS

--- a/src/solver/src/diff_solver_factory_initializer.C
+++ b/src/solver/src/diff_solver_factory_initializer.C
@@ -1,0 +1,41 @@
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include "grins/diff_solver_factory_initializer.h"
+
+// GRINS
+#include "grins/diff_solver_factory.h"
+#include "grins/diff_solver_names.h"
+
+// libMesh DiffSolvers
+#include "libmesh/newton_solver.h"
+#include "libmesh/petsc_diff_solver.h"
+
+namespace GRINS
+{
+  DiffSolverFactoryInitializer::DiffSolverFactoryInitializer()
+  {
+    static DiffSolverFactoryBasic<libMesh::NewtonSolver>
+      grins_factory_newton_solver(DiffSolverNames::newton_solver());
+
+    static DiffSolverFactoryBasic<libMesh::PetscDiffSolver>
+      grins_factory_petsc_diff_solver(DiffSolverNames::petsc_diff_solver());
+  }
+} // end namespace GRINS

--- a/src/solver/src/simulation_initializer.C
+++ b/src/solver/src/simulation_initializer.C
@@ -31,6 +31,7 @@
 #include "grins/boundary_condition_factory_initializer.h"
 #include "grins/variable_factory_initializer.h"
 #include "grins/solver_factory_initializer.h"
+#include "grins/diff_solver_factory_initializer.h"
 
 namespace GRINS
 {
@@ -45,6 +46,7 @@ namespace GRINS
         BoundaryConditionFactoryInitializer bc_init;
         VariableFactoryInitializer var_init;
         SolverFactoryInitializer solver_init;
+        DiffSolverFactoryInitializer diff_solver_init;
 
         _is_initialized = true;
       }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -269,6 +269,7 @@ TESTS += regression/velocity_penalty_drag.sh
 TESTS += regression/redistribute.sh
 TESTS += regression/coupled_stokes_ns.sh
 TESTS += regression/hot_cylinder.sh
+TESTS += regression/hot_cylinder_petsc_diff.sh
 
 TESTS += regression/reacting_low_mach_cantera.sh
 XFAIL_TESTS += regression/reacting_low_mach_cantera.sh

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -199,6 +199,7 @@ TESTS += exact_soln/axi_ns_con_cyl_flow.sh
 TESTS += exact_soln/axi_ns_poiseuille_flow.sh
 TESTS += exact_soln/convection_diffusion_steady_1d.sh
 TESTS += exact_soln/convection_diffusion_unsteady_2d.sh
+TESTS += exact_soln/convection_diffusion_unsteady_2d_petsc_diff.sh
 TESTS += exact_soln/heat_eqn_unsteady_2d_restart.sh
 TESTS += exact_soln/laplace_parsed_source.sh
 TESTS += exact_soln/ns_couette_flow_2d_x.sh

--- a/test/exact_soln/convection_diffusion_unsteady_2d_petsc_diff.sh
+++ b/test/exact_soln/convection_diffusion_unsteady_2d_petsc_diff.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+INPUT="${GRINS_TEST_INPUT_DIR}/convection_diffusion_unsteady_2d.in"
+TESTDATA_NOTUSED="./convection_diffusion_unsteady_2d_petsc_diff.xdr"
+TESTDATA="./convection_diffusion_unsteady_2d_petsc_diff.49.xdr"
+
+# First run the case with grins
+${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT linear-nonlinear-solver/type='libmesh_petsc_diff' vis-options/vis_output_file_prefix='convection_diffusion_unsteady_2d_petsc_diff'
+
+# Now run the test part to make sure we're getting the correct thing
+${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app \
+                 --input $INPUT \
+                 vars='u' \
+                 norms='L2' \
+                 tol='1.0e-10' \
+                 u_L2_error='6.289317886708677e-03' \
+                 u_exact_soln='tf:=50*0.025;exp(-((x-0.8*tf-0.2)^2+(y-0.8*tf-0.2)^2)/(0.01*(4.0*tf+1.0)))/(4.0*tf+1.0)' \
+                 test_data=$TESTDATA
+
+# Now remove the test turd
+rm $TESTDATA $TESTDATA_NOTUSED

--- a/test/input_files/hot_cylinder.in
+++ b/test/input_files/hot_cylinder.in
@@ -135,6 +135,7 @@
 []
 
 [linear-nonlinear-solver]
+   type = 'libmesh_newton'
    max_nonlinear_iterations =  '30'
    max_linear_iterations = '1000'
    relative_residual_tolerance = '1.0e-12'

--- a/test/regression/hot_cylinder_petsc_diff.sh
+++ b/test/regression/hot_cylinder_petsc_diff.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+PROG="${GRINS_BUILDSRC_DIR}/grins"
+
+INPUT="${GRINS_TEST_INPUT_DIR}/hot_cylinder.in"
+
+PETSC_OPTIONS="-pc_type asm -pc_asm_overlap 2 -sub_pc_type lu -sub_pc_factor_shift_type nonzero -snes_monitor -snes_view -snes_linesearch_monitor"
+
+# Solution output from GRINS run
+SOLNDATA="./hot_cylinder_petsc_diff.xda"
+
+# Gold data used for regression comparsion
+GOLDDATA="${GRINS_TEST_DATA_DIR}/hot_cylinder_gold.xdr"
+
+# First run the case with grins
+# PETSC_OPTIONS need to be at the end. PETSc gets confused when our options come later
+${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT linear-nonlinear-solver/type='libmesh_petsc_diff' vis-options/vis_output_file_prefix='hot_cylinder_petsc_diff' $PETSC_OPTIONS 
+
+# Now run the test part to make sure we're getting the correct thing
+${GRINS_TEST_DIR}/regression_testing_app \
+   input=$INPUT \
+   vars='Ux Uy p T' \
+   norms='L2 H1' \
+   tol='2.0e-7' \
+   gold-data=$GOLDDATA \
+   soln-data=$SOLNDATA
+
+# Now remove the test turd
+rm $SOLNDATA

--- a/test/unit/nonlinear_solver_options.C
+++ b/test/unit/nonlinear_solver_options.C
@@ -71,6 +71,7 @@ namespace GRINSTesting
         "numerical_jacobian_h  = '1.0e-3'                    \n"
         "numerical_jacobian_h_variables = 'U y Vz'           \n"
         "numerical_jacobian_h_values = '1.0  2.0e-6  3.0e-8' \n"
+        "type = 'libmesh_petsc_diff'                         \n"
         "[]\n";
 
       std::stringstream inputfile;
@@ -101,6 +102,8 @@ namespace GRINSTesting
       options.numerical_jacobian_h_vars_and_vals(variables,values);
       CPPUNIT_ASSERT(variables.empty());
       CPPUNIT_ASSERT(values.empty());
+
+      CPPUNIT_ASSERT_EQUAL(GRINS::DiffSolverNames::newton_solver(), options.type() );
     }
 
     void test_eval()
@@ -132,6 +135,8 @@ namespace GRINSTesting
       CPPUNIT_ASSERT_EQUAL(1.0,values[0]);
       CPPUNIT_ASSERT_EQUAL(2.0e-6,values[1]);
       CPPUNIT_ASSERT_EQUAL(3.0e-8,values[2]);
+
+      CPPUNIT_ASSERT_EQUAL(GRINS::DiffSolverNames::petsc_diff_solver(), options.type() );
     }
 
   };


### PR DESCRIPTION
This PR adds the factory pattern for `libMesh::DiffSolver`. Type is now controlled through input, with default going to `libMesh::NewtonSolver`, but we now support and test `libMesh::PetscDiffSolver`.