### PR TITLE
Add unsteady AMR test using PetscDiffSolver

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Version 0.9.0 (in progress)
    * C++11 compiler now required
-   * Minimum libMesh git hash for this release is: daf2f70
+   * Minimum libMesh git hash for this release is: 2d9b8bc
    * Use factory pattern for DiffSolver, now support
      specifying DiffSolver type in inputfile,
      add support for libMesh::PetscDiffSolver

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In addition to a C++11 compiler, GRINS requires an up-to-date installation of th
 
 libMesh
 -------
-GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is daf2f70, as of GRINS [PR #520](https://github.com/grinsfem/grins/pull/520).
+GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is 2d9b8bc, as of GRINS [PR #520](https://github.com/grinsfem/grins/pull/528).
 GRINS release 0.5.0 can use libMesh versions as old as 0.9.4. Subsequent to
 the 0.5.0 release requires at least libMesh 1.0.0.
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -309,6 +309,7 @@ TESTS += regression/extra_quadrature_order_laplace_arefee_amr.sh
 
 #AMR TESTS
 TESTS += amr/convection_diffusion_unsteady_2d.sh
+TESTS += amr/convection_diffusion_unsteady_2d_petsc_diff.sh
 
 EXTRA_DIST = unit/input_files common amr/gold_data amr/input_files amr/README exact_soln/README
 

--- a/test/amr/convection_diffusion_unsteady_2d.sh
+++ b/test/amr/convection_diffusion_unsteady_2d.sh
@@ -34,4 +34,4 @@ ${GRINS_TEST_DIR}/generic_amr_testing_app \
 
 # Now remove the test turd
 rm -rf $LOCALTESTDIR
-rm $TESTDATA*.xdr $MESHDATA*.xda
+rm $TESTDATA.*.xdr $MESHDATA.*.xda

--- a/test/amr/convection_diffusion_unsteady_2d_petsc_diff.sh
+++ b/test/amr/convection_diffusion_unsteady_2d_petsc_diff.sh
@@ -36,4 +36,4 @@ ${GRINS_TEST_DIR}/generic_amr_testing_app \
 
 # Now remove the test turd
 rm -rf $LOCALTESTDIR
-rm $TESTDATA*.xdr $MESHDATA*.xda
+rm $TESTDATA.*.xdr $MESHDATA.*.xda

--- a/test/amr/convection_diffusion_unsteady_2d_petsc_diff.sh
+++ b/test/amr/convection_diffusion_unsteady_2d_petsc_diff.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+INPUT="${GRINS_TEST_SRCDIR_DIR}/amr/input_files/convection_diffusion_unsteady_2d_amr.in"
+
+TESTDATA="./convection_diffusion_unsteady_2d_amr_petsc_diff"
+MESHDATA=$TESTDATA
+
+PETSC_OPTIONS="-snes_monitor -snes_view -ksp_monitor -ksp_rtol 1.0e-12"
+
+# First run the case with grins
+${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT linear-nonlinear-solver/type='libmesh_petsc_diff' vis-options/vis_output_file_prefix='convection_diffusion_unsteady_2d_amr_petsc_diff' $PETSC_OPTIONS
+
+# Untar the files into a local directory in the build tree
+LOCALTESTDIR="./convection_diffusion_unsteady_2d_amr_petsc_diff_test_tmp"
+
+mkdir -p $LOCALTESTDIR
+tar -xzf ${GRINS_TEST_SRCDIR_DIR}/amr/gold_data/convection_diffusion_unsteady_2d/files.tar.gz --directory $LOCALTESTDIR
+
+# Now give prefixes for the gold data
+GOLDDATA=$LOCALTESTDIR/convection_diffusion_unsteady_2d_amr
+GOLDMESH=$GOLDDATA
+
+# Now run the test part to make sure we're getting the correct thing
+${GRINS_TEST_DIR}/generic_amr_testing_app \
+                 input=$INPUT \
+                 vars='u' \
+                 norms='L2' \
+                 tol='1.0e-10' \
+                 test_data_prefix=$TESTDATA \
+                 mesh_data_prefix=$MESHDATA \
+                 gold_data_prefix=$GOLDDATA \
+                 gold_mesh_prefix=$GOLDMESH \
+                 n_steps=25
+
+# Now remove the test turd
+rm -rf $LOCALTESTDIR
+rm $TESTDATA*.xdr $MESHDATA*.xda


### PR DESCRIPTION
@roystgnr 

This is currently broken and I'm trying to figure out why. ReplicatedMesh, 1 processor.

Manifesting as deteriorated Newton convergence and mismatch of solution values at hanging nodes. Attached picture is comparison with the exact same testing using `libMesh::NewtonSolver` instead of `libMesh::PetscDiffSolver` after completion of the second time step (first timestep is uniform grid, no AMR, and solutions match). Also posting output from log below.

Will open libMesh PR with my changes so far to `libMesh::PetscDiffSolver` and other comments there. Note those changes will be needed to get this test to run as I have in the log below because `PetscDiffSolver::reinit()` is wrong.
![error](https://user-images.githubusercontent.com/3051555/34571781-7109b152-f13d-11e7-94bd-d3685e9318c1.png)


Log for PetscDiffSolver during second time step solve. Notice the linear convergence.
<pre>
Assembling the residual
  PetscDiffSolver step 0, |residual|_2 = 0.0395323
  0 SNES Function norm 3.953226719308e-02
Assembling the Jacobian
    0 KSP Residual norm 9.886882815499e-01
    1 KSP Residual norm 4.622143055206e-03
    2 KSP Residual norm 1.583704450013e-04
    3 KSP Residual norm 2.075233714795e-06
    4 KSP Residual norm 7.561197183862e-08
    5 KSP Residual norm 1.337999410107e-09
    6 KSP Residual norm 4.364747255042e-11
    7 KSP Residual norm 8.925042083544e-13
Assembling the residual
  PetscDiffSolver step 1, |residual|_2 = 0.00145759
  1 SNES Function norm 1.457591846269e-03
Assembling the Jacobian
    0 KSP Residual norm 3.003192513401e-02
    1 KSP Residual norm 3.221958118374e-04
    2 KSP Residual norm 8.098817196632e-06
    3 KSP Residual norm 2.216109644375e-07
    4 KSP Residual norm 4.883916032657e-09
    5 KSP Residual norm 1.476861323986e-10
    6 KSP Residual norm 3.209875462239e-12
    7 KSP Residual norm 8.950349323729e-14
    8 KSP Residual norm 1.962647459455e-15
Assembling the residual
  PetscDiffSolver step 2, |residual|_2 = 0.000245527
  2 SNES Function norm 2.455265564763e-04
Assembling the Jacobian
    0 KSP Residual norm 4.766687068878e-03
    1 KSP Residual norm 5.306754478348e-05
    2 KSP Residual norm 1.302851722259e-06
    3 KSP Residual norm 3.286049169532e-08
    4 KSP Residual norm 7.694366712993e-10
    5 KSP Residual norm 2.299140629820e-11
    6 KSP Residual norm 4.595418949204e-13
    7 KSP Residual norm 1.249182105952e-14
    8 KSP Residual norm 2.823892196047e-16
Assembling the residual
  PetscDiffSolver step 3, |residual|_2 = 4.51642e-05
  3 SNES Function norm 4.516415978581e-05
Assembling the Jacobian
    0 KSP Residual norm 8.003380036327e-04
    1 KSP Residual norm 9.427109979562e-06
    2 KSP Residual norm 2.250542757380e-07
    3 KSP Residual norm 5.317799946419e-09
    4 KSP Residual norm 1.320044012236e-10
    5 KSP Residual norm 3.819724343801e-12
    6 KSP Residual norm 7.202189521444e-14
    7 KSP Residual norm 1.838686124283e-15
    8 KSP Residual norm 4.366095553160e-17
Assembling the residual
  PetscDiffSolver step 4, |residual|_2 = 9.16616e-06
  4 SNES Function norm 9.166160073025e-06
Assembling the Jacobian
0 KSP Residual norm 1.455453617230e-04
    1 KSP Residual norm 1.772118894667e-06
    2 KSP Residual norm 4.045728997966e-08
    3 KSP Residual norm 9.144092453824e-10
    4 KSP Residual norm 2.403708446314e-11
    5 KSP Residual norm 6.518983878162e-13
    6 KSP Residual norm 1.201604824255e-14
    7 KSP Residual norm 2.854326200008e-16
    8 KSP Residual norm 7.272212823104e-18
Assembling the residual
  PetscDiffSolver step 5, |residual|_2 = 2.02051e-06
  5 SNES Function norm 2.020508455550e-06
Assembling the Jacobian
    0 KSP Residual norm 2.914585892779e-05
    1 KSP Residual norm 3.521954170580e-07
    2 KSP Residual norm 7.414361024579e-09
    3 KSP Residual norm 1.656765759785e-10
    4 KSP Residual norm 4.487741570799e-12
    5 KSP Residual norm 1.121483292926e-13
    6 KSP Residual norm 2.103337684249e-15
    7 KSP Residual norm 4.692796566646e-17
    8 KSP Residual norm 1.295004898968e-18
Assembling the residual
  PetscDiffSolver step 6, |residual|_2 = 4.69471e-07
  6 SNES Function norm 4.694710027454e-07
Assembling the Jacobian
0 KSP Residual norm 6.358434095249e-06 
    1 KSP Residual norm 7.363378415110e-08 
    2 KSP Residual norm 1.384739162138e-09 
    3 KSP Residual norm 3.125227511710e-11 
    4 KSP Residual norm 8.408356197699e-13 
    5 KSP Residual norm 1.954749286247e-14 
    6 KSP Residual norm 3.806746856512e-16 
    7 KSP Residual norm 8.140329587905e-18 
    8 KSP Residual norm 2.410973533345e-19 
Assembling the residual
  PetscDiffSolver step 7, |residual|_2 = 1.12185e-07
  7 SNES Function norm 1.121854336327e-07
Assembling the Jacobian
    0 KSP Residual norm 1.468373570806e-06
    1 KSP Residual norm 1.605034001063e-08
    2 KSP Residual norm 2.657242587868e-10
    3 KSP Residual norm 6.061890343360e-12
    4 KSP Residual norm 1.581243157078e-13
    5 KSP Residual norm 3.507123359110e-15
    6 KSP Residual norm 7.024276039841e-17
    7 KSP Residual norm 1.473697007125e-18
    8 KSP Residual norm 4.588149438045e-20
Assembling the residual
  PetscDiffSolver step 8, |residual|_2 = 2.718e-08
  8 SNES Function norm 2.717996533421e-08
Assembling the Jacobian
    0 KSP Residual norm 3.497814234379e-07
    1 KSP Residual norm 3.613395466402e-09
    2 KSP Residual norm 5.248175098441e-11
    3 KSP Residual norm 1.197746367498e-12
    4 KSP Residual norm 3.020844104008e-14
    5 KSP Residual norm 6.541681267018e-16
    6 KSP Residual norm 1.317390691541e-17
    7 KSP Residual norm 2.751225224540e-19
Assembling the residual
  PetscDiffSolver step 9, |residual|_2 = 6.62941e-09
  9 SNES Function norm 6.629413654160e-09
Assembling the Jacobian
    0 KSP Residual norm 8.461335950510e-08
    1 KSP Residual norm 8.334952884055e-10
    2 KSP Residual norm 1.062378326325e-11
    3 KSP Residual norm 2.395585931652e-13
    4 KSP Residual norm 5.921490172371e-15
    5 KSP Residual norm 1.265214610679e-16
    6 KSP Residual norm 2.530257485664e-18
    7 KSP Residual norm 5.254665884115e-20
Assembling the residual
  PetscDiffSolver step 10, |residual|_2 = 1.62244e-09
 10 SNES Function norm 1.622439474130e-09
Assembling the Jacobian
0 KSP Residual norm 2.062213594976e-08 
    1 KSP Residual norm 1.957620625393e-10 
    2 KSP Residual norm 2.194304304460e-12 
    3 KSP Residual norm 4.830187200673e-14
    4 KSP Residual norm 1.192953979232e-15
    5 KSP Residual norm 2.511723449474e-17
    6 KSP Residual norm 5.000207148776e-19
    7 KSP Residual norm 1.022962415621e-20
Assembling the residual
  PetscDiffSolver step 11, |residual|_2 = 3.9778e-10
 11 SNES Function norm 3.977798596097e-10
SNES Object: 1 MPI processes
  type: newtonls
  maximum iterations=50, maximum function evaluations=10000
  tolerances: relative=1e-08, absolute=1e-50, solution=1e-08
  total number of linear solver iterations=84
  total number of function evaluations=12
  norm schedule ALWAYS
  SNESLineSearch Object:   1 MPI processes
    type: bt
      interpolation: cubic
      alpha=1.000000e-04
    maxstep=1.000000e+08, minlambda=1.000000e-12
    tolerances: relative=1.000000e-08, absolute=1.000000e-15, lambda=1.000000e-08
    maximum iterations=40
  KSP Object:   1 MPI processes
    type: gmres
      GMRES: restart=30, using Classical (unmodified) Gram-Schmidt Orthogonalization with no iterative refinement
      GMRES: happy breakdown tolerance 1e-30
    maximum iterations=10000, initial guess is zero
    tolerances:  relative=1e-12, absolute=1e-50, divergence=10000.
    left preconditioning
    using PRECONDITIONED norm type for convergence test
  PC Object:   1 MPI processes
    type: ilu
      ILU: out-of-place factorization
      0 levels of fill
      tolerance for zero pivot 2.22045e-14
      matrix ordering: natural
      factor fill ratio given 1., needed 1.
        Factored matrix follows:
          Mat Object:           1 MPI processes
            type: seqaij
            rows=1726, cols=1726
            package used to perform factorization: petsc
            total: nonzeros=13150, allocated nonzeros=13150
            total number of mallocs used during MatSetValues calls =0
              not using I-node routines
    linear system matrix = precond matrix:
   Mat Object:    ()     1 MPI processes
      type: seqaij
      rows=1726, cols=1726
      total: nonzeros=13150, allocated nonzeros=13150
      total number of mallocs used during MatSetValues calls =0
        not using I-node routines

</pre