### PR TITLE
PETSC_OPTIONS for axi_thermally_driven_flow test

### DIFF
--- a/test/regression/axi_thermally_driven_flow.sh
+++ b/test/regression/axi_thermally_driven_flow.sh
@@ -5,4 +5,5 @@ PROG="${GRINS_TEST_DIR}/generic_solution_regression"
 INPUT="${GRINS_TEST_INPUT_DIR}/axi_thermally_driven_flow.in"
 DATA="${GRINS_TEST_DATA_DIR}/axi_thermally_driven.xdr"
 
-${LIBMESH_RUN:-} $PROG --input $INPUT soln-data=$DATA vars='u v p T' norms='L2 H1' tol='8.0e-9'
+PETSC_OPTIONS="-pc_type asm -pc_asm_overlap 4 -sub_pc_type ilu -sub_pc_factor_levels 4 -sub_pc_factor_mat_ordering_type 1wd -sub_pc_factor_shift_type nonzero"
+${LIBMESH_RUN:-} $PROG --input $INPUT soln-data=$DATA vars='u v p T' norms='L2 H1' tol='2.0e-8' $PETSC_OPTIONS


### PR DESCRIPTION
With these options, GRINS "make check" again passes for me on 1 through
32 processors.  With no options axi_thermally_driven_flow.sh was failing
for me on 16 processors, the first value I tried.

I'm not sure how this wasn't already tripping up femputer...