### PR TITLE
Update SpectroscopicAbsorption QoI to actually calculate absorption

### DIFF
--- a/src/qoi/include/grins/spectroscopic_absorption.h
+++ b/src/qoi/include/grins/spectroscopic_absorption.h
@@ -39,9 +39,9 @@ namespace GRINS
     Relies upon the IntegratedFunction class for hooking into QoI infrastructure,
     and AbsorptionCoeff class for evaluating the <i>spectral absorption coefficient</i>, \f$ k_{\nu} \f$
 
-    \f$ \frac{I_{\nu}}{I_{\nu}^0} = \exp\left\{- \int_0^L k_{\nu} dx\right\} \f$
+    \f$ \frac{I_{\nu}^0 - I_{\nu}}{I_{\nu}^0} = 1.0 - \exp\left\{- \int_0^L k_{\nu} dx\right\} \f$
 
-    where \f$ \frac{I_{\nu}}{I_{\nu}^0} \f$ is the <i>spectral absorption</i>
+    where \f$ \frac{I_{\nu}^0 - I_{\nu}}{I_{\nu}^0} \f$ is the <i>spectral absorption</i>
 
     Expects all parameters given in standard SI units [m], [K], [Pa]
   */

--- a/src/qoi/src/spectroscopic_absorption.C
+++ b/src/qoi/src/spectroscopic_absorption.C
@@ -59,7 +59,7 @@ namespace GRINS
 
     // absorption coefficient is calculated in [cm^-1], but path length is given in [m]
     // 100.0 factor converts pathlength to [cm]
-    sys_qoi = std::exp( -sys_qoi * 100.0 );
+    sys_qoi = 1.0 - std::exp( -sys_qoi * 100.0 );
     QoIBase::_qoi_value = sys_qoi;
   }
 
@@ -74,7 +74,7 @@ namespace GRINS
     qs.add_index(qoi_index);
     _multiphysics_system->assemble_qoi(qs);
 
-    derivatives.scale(-100.0 * QoIBase::_qoi_value);
+    derivatives.scale(100.0 * (1.0-QoIBase::_qoi_value));
   }
 
 } //namespace GRINS

--- a/test/unit/spectroscopic_absorption_test.C
+++ b/test/unit/spectroscopic_absorption_test.C
@@ -80,7 +80,7 @@ namespace GRINSTesting
     void single_elem_mesh()
     {
       const std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/spectroscopic_absorption_qoi.in";
-      libMesh::Real calc_answer = 0.520403290868787;
+      libMesh::Real calc_answer = 1.0 - 0.520403290868787;
 
       this->run_test(filename,calc_answer);
     }
@@ -89,7 +89,7 @@ namespace GRINSTesting
     void multi_elem_mesh()
     {
       const std::string filename = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/spectroscopic_absorption_qoi_fine.in";
-      libMesh::Real calc_answer = 0.520403290868787; // same physical conditions as single_elem_mesh, so answer should not change
+      libMesh::Real calc_answer = 1.0 - 0.520403290868787; // same physical conditions as single_elem_mesh, so answer should not change
 
       this->run_test(filename,calc_answer);
     }


### PR DESCRIPTION
`I/I0` is actually the **transmission** not the absorption.

The absorption is `1 - I/I0` or `(I0-I)/I0`

Technically, this should be merged before #534 