### PR TITLE
Update includes for new enum structure.

### DIFF
--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -39,6 +39,7 @@
 #include "libmesh/parsed_function.h"
 #include "libmesh/serial_mesh.h"
 #include "libmesh/elem.h"
+#include "libmesh/enum_order.h"
 
 namespace GRINS
 {

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -44,6 +44,7 @@
 #include "libmesh/parameter_vector.h"
 #include "libmesh/qoi_set.h"
 #include "libmesh/sensitivity_data.h"
+#include "libmesh/enum_xdr_mode.h"
 
 namespace GRINS
 {

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -37,6 +37,7 @@
 #include "libmesh/error_vector.h"
 #include "libmesh/steady_solver.h"
 #include "libmesh/adjoint_refinement_estimator.h"
+#include "libmesh/enum_error_estimator_type.h"
 
 namespace GRINS
 {

--- a/src/strategies/src/adjoint_error_estimator_factories.C
+++ b/src/strategies/src/adjoint_error_estimator_factories.C
@@ -27,6 +27,7 @@
 
 // libMesh
 #include "libmesh/patch_recovery_error_estimator.h"
+#include "libmesh/enum_norm_type.h"
 
 namespace GRINS
 {

--- a/src/visualization/src/visualization.C
+++ b/src/visualization/src/visualization.C
@@ -38,6 +38,7 @@
 #include "libmesh/nemesis_io.h"
 #include "libmesh/tecplot_io.h"
 #include "libmesh/vtk_io.h"
+#include "libmesh/enum_xdr_mode.h"
 
 // POSIX
 #include <sys/errno.h>

--- a/test/amr/generic_amr_testing_app.C
+++ b/test/amr/generic_amr_testing_app.C
@@ -35,6 +35,7 @@
 #include "libmesh/exact_solution.h"
 #include "libmesh/parsed_function.h"
 #include "libmesh/composite_function.h"
+#include "libmesh/enum_xdr_mode.h"
 
 int test_error_norm( libMesh::ExactSolution& exact_sol,
                      const std::string& system_name,

--- a/test/regression/low_mach_cavity_benchmark_regression.C
+++ b/test/regression/low_mach_cavity_benchmark_regression.C
@@ -29,6 +29,9 @@
 // GRINS
 #include "grins/runner.h"
 
+// libMesh
+#include "libmesh/enum_solver_package.h"
+
 // Function for getting initial temperature field
 libMesh::Real
 initial_values( const libMesh::Point& p, const libMesh::Parameters &params,

--- a/test/regression/test_turbulent_channel.C
+++ b/test/regression/test_turbulent_channel.C
@@ -49,6 +49,7 @@
 #include "libmesh/zero_function.h"
 #include "libmesh/composite_function.h"
 #include "libmesh/zero_function.h"
+#include "libmesh/enum_xdr_mode.h"
 
 namespace GRINS
 {


### PR DESCRIPTION
I'm preparing to forward declare most of the enums in libmesh (instead of #including their headers). This will require some slight changes in dependent apps, but luckily they can be made ahead of time.

Refs libMesh/libmesh#1713.