### PR TITLE
Error out Rayleigh Damping if using 1st order time solver

### DIFF
--- a/src/physics/include/grins/elastic_cable_rayleigh_damping.h
+++ b/src/physics/include/grins/elastic_cable_rayleigh_damping.h
@@ -40,6 +40,9 @@ namespace GRINS
 
     virtual ~ElasticCableRayleighDamping(){};
 
+    //! Error out if using libMesh::FirstOrderUnsteadySolver
+    virtual void auxiliary_init( MultiphysicsSystem & system );
+
     //! Time dependent part(s) of physics for element interiors
     virtual void damping_residual( bool compute_jacobian,
                                    AssemblyContext & context );

--- a/src/physics/include/grins/elastic_membrane_rayleigh_damping.h
+++ b/src/physics/include/grins/elastic_membrane_rayleigh_damping.h
@@ -40,6 +40,9 @@ namespace GRINS
 
     virtual ~ElasticMembraneRayleighDamping(){};
 
+    //! Error out if using libMesh::FirstOrderUnsteadySolver
+    virtual void auxiliary_init( MultiphysicsSystem & system );
+
     //! Time dependent part(s) of physics for element interiors
     virtual void damping_residual( bool compute_jacobian,
                                    AssemblyContext & context );

--- a/src/physics/src/elastic_cable_rayleigh_damping.C
+++ b/src/physics/src/elastic_cable_rayleigh_damping.C
@@ -28,10 +28,12 @@
 // GRINS
 #include "grins/physics_naming.h"
 #include "grins/elasticity_tensor.h"
+#include "grins/multiphysics_sys.h"
 
 // libMesh
 #include "libmesh/getpot.h"
 #include "libmesh/quadrature.h"
+#include "libmesh/first_order_unsteady_solver.h"
 
 namespace GRINS
 {
@@ -59,6 +61,23 @@ namespace GRINS
                         +PhysicsNaming::elastic_cable()+".");
 
     this->parse_enabled_subdomains(input,PhysicsNaming::elastic_cable());
+  }
+
+  template<typename StressStrainLaw>
+  void ElasticCableRayleighDamping<StressStrainLaw>::auxiliary_init
+  ( MultiphysicsSystem & system )
+  {
+    if( !this->is_steady() )
+      {
+        // Currently, we don't support first order time solvers
+        const libMesh::TimeSolver & raw_time_solver = system.get_time_solver();
+
+        const libMesh::FirstOrderUnsteadySolver * time_solver =
+          dynamic_cast<const libMesh::FirstOrderUnsteadySolver *>(&raw_time_solver);
+
+        if( time_solver )
+          libmesh_error_msg("ERROR: First order time solvers not supported for ElasticCableRayleighDamping!");
+      }
   }
 
   template<typename StressStrainLaw>

--- a/src/physics/src/elastic_membrane_rayleigh_damping.C
+++ b/src/physics/src/elastic_membrane_rayleigh_damping.C
@@ -29,10 +29,12 @@
 #include "grins/physics_naming.h"
 #include "grins/elasticity_tensor.h"
 #include "grins/assembly_context.h"
+#include "grins/multiphysics_sys.h"
 
 // libMesh
 #include "libmesh/getpot.h"
 #include "libmesh/quadrature.h"
+#include "libmesh/first_order_unsteady_solver.h"
 
 namespace GRINS
 {
@@ -59,6 +61,23 @@ namespace GRINS
                         +PhysicsNaming::elastic_membrane()+".");
 
     this->parse_enabled_subdomains(input,PhysicsNaming::elastic_membrane());
+  }
+
+  template<typename StressStrainLaw>
+  void ElasticMembraneRayleighDamping<StressStrainLaw>::auxiliary_init
+  ( MultiphysicsSystem & system )
+  {
+    if( !this->is_steady() )
+      {
+        // Currently, we don't support first order time solvers
+        const libMesh::TimeSolver & raw_time_solver = system.get_time_solver();
+
+        const libMesh::FirstOrderUnsteadySolver * time_solver =
+          dynamic_cast<const libMesh::FirstOrderUnsteadySolver *>(&raw_time_solver);
+
+        if( time_solver )
+          libmesh_error_msg("ERROR: First order time solvers not supported for ElasticMembraneRayleighDamping!");
+      }
   }
 
   template<typename StressStrainLaw>


### PR DESCRIPTION
Piggybacking on #544.

We haven't updated the RayleighDamping Physics classes to support
the second_order_var interface so this will produce the incorrect
thing if we're using a libMesh::FirstOrderUnsteadySolver so we'll
error out for now until we can update to support this interface. Not
entirely trivial just because we'll need to deal with two different
Jacobians.