### PR TITLE
Thermochemsity Parsing Refactoring Part 1: Cantera

### DIFF
--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -176,20 +176,28 @@
         # Species in this gas mixture
         species = 'N2 N C CN'
 
-        # Path to file containing kinetics data.
-        # For Cantera, this may also contain all other thermochemistry data.
-        kinetics_data = 'datafile.xml'
-
         [./Cantera]
-           # Specify the mixture to be used. This is the "mixture"
-           # given in the kinetics_data file. The user must set this
+           # Specify the mixture to be used. This is the "mixture" or "phase"
+           # given in the chemical_data file. The user must set this
            # since the Cantera data file may contain more than one mixture.
            gas_mixture = 'air4sp'
+
+           # Path to file containing thermochemical and transport data.
+           # This is the only file Cantera will look for so all data
+           # must be present in the Cantera XML format.
+           # You may wish to consider looking at Cantera's .cti format
+           # and then using Cantera-deployed tools to convert to .xml format.
+           # If you have a ChemKin file, Cantera deploys a ck2cti tool
+           # to convert to cti, then you can convert to XML.
+           chemical_data = 'datafile.xml'
+        [../]
+     [../]
+   [../]
 
    # Arbitrary material name. Here we describe input parameters related
    # to the Antioch thermochemistry library. These are used for reacting
    # flow Physics. Note that units here *must* be SI.
-   [../../../AntiochMaterial]
+   [./AntiochMaterial]
       [./GasMixture]
          # Notify that we're using Antioch
          thermochemistry_library = 'antioch'

--- a/examples/ozone_flame/ozone_cantera.in
+++ b/examples/ozone_flame/ozone_cantera.in
@@ -23,10 +23,10 @@
      [./GasMixture]
         thermochemistry_library = 'cantera'
         species = 'O O2 O3'
-        kinetics_data = 'ozone.xml'
 
         [./Cantera]
            gas_mixture = 'ozone'
+           chemical_data = 'ozone.xml'
         [../]
      [../]
 []

--- a/src/properties/include/grins/cantera_mixture.h
+++ b/src/properties/include/grins/cantera_mixture.h
@@ -106,6 +106,8 @@ namespace GRINS
 
     std::string parse_mixture( const GetPot& input, const std::string& material );
 
+    std::string parse_chem_file( const GetPot& input, const std::string& material );
+
   private:
 
     CanteraMixture();

--- a/src/properties/include/grins/materials_parsing.h
+++ b/src/properties/include/grins/materials_parsing.h
@@ -130,6 +130,9 @@ namespace GRINS
     static std::string parse_chemical_kinetics_datafile_name( const GetPot & input,
                                                               const std::string & material );
 
+    static std::string chemical_data_option()
+    { return std::string("chemical_data"); }
+
   };
 
   inline

--- a/src/properties/include/grins/materials_parsing.h
+++ b/src/properties/include/grins/materials_parsing.h
@@ -114,11 +114,18 @@ namespace GRINS
                                         std::vector<std::string>& species_names );
 
     //! Helper function for parsing the chemical species and setting variable name
-    /*! The user-provided vector will populated with the chemical
-      species variable names based on the species name the input file. The variable
-      name will used for adding the variable to the libMesh System.
-      "Physics/Chemistry/species" is deprecated in favor of
-      "Material/"+material+"/GasMixture/species" */
+    /*! This function will parse the thermochemistry library requested by the
+        user and then use the corresponding thermochemistry object to parse
+        the datafiles to ascertain the requested species names. As such,
+        this function could be very inefficient if called repeatedly so it should
+        only be called if *absolutely necessary*, essentially if the
+        MultiphysicsSystem has not been constructed.
+
+        Deprecated functionality is explicitly setting the species names
+        in the GRINS inptu file.
+        The user-provided vector will populated with the chemical
+        species variable names based on the species name the input file. The variable
+        name will used for adding the variable to the libMesh System. */
     static void parse_species_varnames( const GetPot & input,
                                         const std::string & material,
                                         const std::string & prefix,

--- a/src/properties/include/grins/materials_parsing.h
+++ b/src/properties/include/grins/materials_parsing.h
@@ -133,6 +133,11 @@ namespace GRINS
     static std::string chemical_data_option()
     { return std::string("chemical_data"); }
 
+  private:
+
+    static std::string thermochem_lib_input_string( const std::string & material )
+    { return std::string("Materials/"+material+"/GasMixture/thermochemistry_library"); }
+
   };
 
   inline
@@ -150,6 +155,8 @@ namespace GRINS
     if( !input.have_variable(option) )
       libmesh_error_msg("ERROR: Could not find required input parameter "+option+"!");
   }
+
+
 
 } // end namespace GRINS
 

--- a/src/properties/src/cantera_mixture.C
+++ b/src/properties/src/cantera_mixture.C
@@ -56,7 +56,7 @@ namespace GRINS
 
     try
       {
-        _cantera_transport.reset( Cantera::newTransportMgr("Mix", _cantera_gas.get()) );
+        _cantera_transport.reset( Cantera::newDefaultTransportMgr(_cantera_gas.get()) );
       }
     catch(Cantera::CanteraError)
       {

--- a/src/properties/src/cantera_mixture.C
+++ b/src/properties/src/cantera_mixture.C
@@ -41,8 +41,7 @@ namespace GRINS
   CanteraMixture::CanteraMixture( const GetPot& input, const std::string& material )
     : ParameterUser("CanteraMixture")
   {
-    const std::string cantera_chem_file = MaterialsParsing::parse_chemical_kinetics_datafile_name( input, material );
-
+    const std::string cantera_chem_file = this->parse_chem_file(input,material);
     std::string mixture = this->parse_mixture(input,material);
 
     try
@@ -71,6 +70,22 @@ namespace GRINS
   CanteraMixture::~CanteraMixture()
   {
     return;
+  }
+
+  std::string CanteraMixture::parse_chem_file( const GetPot& input, const std::string& material )
+  {
+    std::string filename;
+
+    // Preferred option
+    std::string option = "Materials/"+material+"/GasMixture/Cantera/"+MaterialsParsing::chemical_data_option();
+    if( input.have_variable(option) )
+      filename = input(option, std::string("DIE!") );
+
+    // Now check for deprecated option
+    else
+      filename = MaterialsParsing::parse_chemical_kinetics_datafile_name( input, material );
+
+    return filename;
   }
 
   std::string CanteraMixture::parse_mixture( const GetPot& input, const std::string& material )

--- a/src/properties/src/materials_parsing.C
+++ b/src/properties/src/materials_parsing.C
@@ -101,7 +101,8 @@ namespace GRINS
   {
     std::string material = MaterialsParsing::material_name( input, physics );
 
-    std::string thermochem_lib_option("Materials/"+material+"/GasMixture/thermochemistry_library");
+    std::string thermochem_lib_option =
+      MaterialsParsing::thermochem_lib_input_string(material);
 
     MaterialsParsing::check_for_input_option(input,thermochem_lib_option);
 

--- a/src/properties/src/materials_parsing.C
+++ b/src/properties/src/materials_parsing.C
@@ -220,6 +220,11 @@ namespace GRINS
     std::string option("Materials/"+material+"/GasMixture/kinetics_data");
     MaterialsParsing::check_for_input_option(input,option);
 
+    std::string warning = "WARNING: option "+option+"is DEPRECATED!\n";
+    warning += "         kinetics_data moved to thermochemistry section\n";
+    warning += "         and renamed chemical_data!";
+    grins_warning_once(warning);
+
     std::string filename = input(option, "DIE!");
 
     return filename;

--- a/src/properties/src/materials_parsing.C
+++ b/src/properties/src/materials_parsing.C
@@ -22,6 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include "grins_config.h"
+
 // These functions
 #include "grins/materials_parsing.h"
 
@@ -29,6 +31,10 @@
 #include "grins/common.h"
 #include "grins/physics_naming.h"
 #include "grins/parameter_user.h"
+
+#ifdef GRINS_HAVE_CANTERA
+#include "grins/cantera_mixture.h"
+#endif //#ifdef GRINS_HAVE_CANTERA
 
 namespace GRINS
 {
@@ -179,6 +185,7 @@ namespace GRINS
     species_names.reserve(n_species);
     for( unsigned int i = 0; i < n_species; i++ )
       species_names.push_back( input( option, "DIE!", i ) );
+
   }
 
   void MaterialsParsing::parse_species_varnames( const GetPot & input,
@@ -186,14 +193,62 @@ namespace GRINS
                                                  const std::string & prefix,
                                                  std::vector<std::string>& species_varnames )
   {
+    // We're going to use the chemistry libraries to figure out the species
+    // names, so we need to figure out which chemistry library the user
+    // asked for
+    std::string thermochem_lib_option =
+      MaterialsParsing::thermochem_lib_input_string(material);
+
+    MaterialsParsing::check_for_input_option(input,thermochem_lib_option);
+
+    std::string thermochem_lib = input( thermochem_lib_option, std::string("DIE!") );
+
     std::vector<std::string> species_names;
-    MaterialsParsing::parse_chemical_species(input,material,species_names);
+
+    // For Cantera, build the mixture and then extract the species names,
+    // populate species_names, and then prefix them below
+    if( thermochem_lib == std::string("cantera") )
+      {
+#ifdef GRINS_HAVE_CANTERA
+        // First check if the user still lists the species manually
+        // and warn them we're igoring it
+        std::string old_option("Materials/"+material+"/GasMixture/species");
+        if( input.have_variable(old_option) )
+          {
+            std::string warning = "WARNING: option "+old_option+" is ignored!\n";
+            warning += "          Species names are parsed from the Cantera ";
+            warning += MaterialsParsing::chemical_data_option()+" file.\n";
+            grins_warning(warning);
+          }
+
+        // Now build a cantera mixture and populate the species_names
+        CanteraMixture cantera(input,material);
+
+        unsigned int n_species = cantera.n_species();
+        species_names.reserve(n_species);
+
+        for( unsigned int s = 0; s < n_species; s++ )
+          species_names.push_back( cantera.species_name(s) );
+#else
+        libmesh_error_msg("ERROR: GRINS not compiled with Cantera! Reconfigure GRINS to use Cantera!");
+#endif // GRINS_HAVE_CANTERA
+      }
+
+    // For Antioch, for now we're falling back to having the user
+    // specify the species explicitly
+    else if( thermochem_lib == std::string("antioch") )
+      {
+        MaterialsParsing::parse_chemical_species(input,material,species_names);
+      }
+    else
+      libmesh_error_msg("ERROR: Invalid thermochem_lib value "+thermochem_lib+"!");
+
     unsigned int n_species = species_names.size();
     species_varnames.reserve(n_species);
 
     for( unsigned int i = 0; i < n_species; i++ )
       {
-        std::string var_name = prefix+species_names[i];
+        std::string var_name(prefix+species_names[i]);
         species_varnames.push_back(var_name);
       }
   }

--- a/test/input_files/air_4sp.xml
+++ b/test/input_files/air_4sp.xml
@@ -23,7 +23,7 @@
     </state>
     <thermo model="IdealGas"/>
     <kinetics model="GasKinetics"/>
-    <transport model="MixTransport"/>
+    <transport model="Mix"/>
   </phase>
 
   <!-- park_jaffe_partridge_JTHT_2001 - Park, Jaffe, Partridge "Chemical-Kinetic Parameters of Hyperbolic Earth Entry," JTHT, Vol 15, No 1, pp 76-90, 2001. -->

--- a/test/input_files/air_5sp_test.xml
+++ b/test/input_files/air_5sp_test.xml
@@ -21,7 +21,7 @@
     </state>
     <thermo model="IdealGas"/>
     <kinetics model="GasKinetics"/>
-    <transport model="MixTransport"/>
+    <transport model="Mix"/>
   </phase>
 
   <!-- species definitions     -->

--- a/test/input_files/cantera_chem_thermo.in
+++ b/test/input_files/cantera_chem_thermo.in
@@ -4,10 +4,10 @@
      [./GasMixture]
         thermochemistry_library = 'cantera'
         species = 'N2 O2 NO N  O'
-        kinetics_data = './input_files/air_5sp_test.xml'
 
         [./Cantera]
            gas_mixture = 'air5sp'
+           chemical_data = './input_files/air_5sp_test.xml'
 []
 
 [screen-options]

--- a/test/input_files/cantera_transport.in
+++ b/test/input_files/cantera_transport.in
@@ -4,8 +4,8 @@
      [./GasMixture]
         thermochemistry_library = 'cantera'
         species = 'N2 O2 NO N  O'
-        kinetics_data = './input_files/air_5sp_test.xml'
 
         [./Cantera]
            gas_mixture = 'air5sp'
+           chemical_data = './input_files/air_5sp_test.xml'
 []

--- a/test/input_files/gas_surface.in
+++ b/test/input_files/gas_surface.in
@@ -4,10 +4,10 @@
      [./GasMixture]
         thermochemistry_library = 'cantera'
         species = 'N2 N C CN'
-        kinetics_data = './input_files/air_4sp.xml'
 
         [./Cantera]
            gas_mixture = 'air4sp'
+           chemical_data = './input_files/air_4sp.xml'
 
    [../../../AntiochMaterial]
       [./GasMixture]

--- a/test/input_files/ozone_flame_cantera_regression.in
+++ b/test/input_files/ozone_flame_cantera_regression.in
@@ -90,7 +90,6 @@
 
      [./GasMixture]
         thermochemistry_library = 'cantera'
-        species = 'O O2 O3'
 
         [./Cantera]
            chemical_data = './input_files/ozone.xml'

--- a/test/input_files/ozone_flame_cantera_regression.in
+++ b/test/input_files/ozone_flame_cantera_regression.in
@@ -91,9 +91,9 @@
      [./GasMixture]
         thermochemistry_library = 'cantera'
         species = 'O O2 O3'
-        kinetics_data = './input_files/ozone.xml'
 
         [./Cantera]
+           chemical_data = './input_files/ozone.xml'
            gas_mixture = 'ozone'
         [../]
       [../]

--- a/test/input_files/reacting_low_mach_cantera_regression.in
+++ b/test/input_files/reacting_low_mach_cantera_regression.in
@@ -4,10 +4,10 @@
      [./GasMixture]
         thermochemistry_library = 'cantera'
         species   = 'N2 N'
-        kinetics_data = './input_files/air_2sp.xml'
 
         [./Cantera]
            gas_mixture = 'air2sp'
+           chemical_data = './input_files/air_2sp.xml'
         [../]
    [../]
 

--- a/test/input_files/reacting_low_mach_cantera_regression.in
+++ b/test/input_files/reacting_low_mach_cantera_regression.in
@@ -3,7 +3,6 @@
   [./2SpeciesNGas]
      [./GasMixture]
         thermochemistry_library = 'cantera'
-        species   = 'N2 N'
 
         [./Cantera]
            gas_mixture = 'air2sp'

--- a/test/unit/input_files/variables_2d.in
+++ b/test/unit/input_files/variables_2d.in
@@ -34,6 +34,7 @@
 [Materials]
   [./2SpeciesNGas]
      [./GasMixture]
+        thermochemistry_library = 'antioch'
         species   = 'N2 N'
 []
 

--- a/test/unit/input_files/variables_arbitrary_names.in
+++ b/test/unit/input_files/variables_arbitrary_names.in
@@ -39,6 +39,7 @@
 [Materials]
   [./2SpeciesNGas]
      [./GasMixture]
+        thermochemistry_library = 'antioch'
         species   = 'N2 N'
 []
 

--- a/test/unit/input_files/variables_species_cantera.in
+++ b/test/unit/input_files/variables_species_cantera.in
@@ -1,0 +1,35 @@
+# Mesh related options
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD4'
+      n_elems_x = '10'
+      n_elems_y = '10'
+[]
+
+[Variables]
+   [./SpeciesMassFractions]
+      material = '2SpeciesNGas'
+      names = 'Y_'
+      fe_family = 'LAGRANGE'
+      order = 'SECOND'
+   [../]
+[]
+
+[Materials]
+  [./2SpeciesNGas]
+     [./GasMixture]
+        thermochemistry_library = 'cantera'
+        
+        [./Cantera]
+           gas_mixture = 'ozone'
+           chemical_data = './input_files/ozone.xml'
+        [../]
+     [../]
+   [../]
+[]
+
+[Physics]
+   [./TestSpeciesMassFractionsVariables]
+      material = '2SpeciesNGas'
+[]

--- a/test/unit/variables.C
+++ b/test/unit/variables.C
@@ -59,6 +59,7 @@ namespace GRINSTesting
     CPPUNIT_TEST( test_variable_builder );
     CPPUNIT_TEST( test_var_constraint );
     CPPUNIT_TEST( test_variable_arbitrary_names );
+    CPPUNIT_TEST( test_variable_species_from_cantera );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -122,6 +123,26 @@ namespace GRINSTesting
 
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();
+    }
+
+    void test_variable_species_from_cantera()
+    {
+#ifdef GRIN_HAVE_CANTERA
+      std::string filename =
+        std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/variables_species_cantera.in";
+
+      this->setup_multiphysics_system(filename);
+
+      GRINS::VariableBuilder::build_variables((*_input),(*_system));
+
+      const GRINS::FEVariablesBase& species_vars =
+          GRINS::GRINSPrivate::VariableWarehouse::get_variable("SpeciesMassFractions");
+
+        const std::vector<std::string>& var_names = species_vars.active_var_names();
+        CPPUNIT_ASSERT_EQUAL( std::string("Y_O"),  var_names[0] );
+        CPPUNIT_ASSERT_EQUAL( std::string("Y_O2"), var_names[1] );
+        CPPUNIT_ASSERT_EQUAL( std::string("Y_O3"), var_names[2] );
+#endif // GRIN_HAVE_CANTERA
     }
 
   private:


### PR DESCRIPTION
Part 1 of a monster branch on refactoring the input parsing for thermochemistry. First is Cantera because was easier to do. 

In short, we've added a new option `chemical_data` that will correspond to the file that contains thermo, transport, and kinetics all in one XML file (this is standard for Cantera). Previously the option lived outside the Cantera section was specifically labeled as kinetics. Secondly, we don't require explicitly (and redundantly) setting the species in the GRINS input file, we now parse the species list from the XML file, based on the gas_mixture specified by the user (since there can be more than 1 mixture in the XML file, which we test). So the new format for Cantera will look like, for example,

<pre>
[Materials]
   [./OzoneGas]
      [./GasMixture]
         thermochemistry_library = 'cantera'

         [./Cantera]
            gas_mixture = 'ozone'
            chemical_data = 'ozone.xml'
         [../]
      [../]
 []
</pre>

I think this is much cleaner. This PR preserves backward compatibility (and spews deprecated warnings) as tests passed before we updated to the new format.

Part 2 will be for Antioch where we will try and get as close to this as we can.
