### PR TITLE
Modularize Displacement Gradient, Stress, and Elasticity Computation in Solids Physics

### DIFF
--- a/src/physics/include/grins/elastic_cable.h
+++ b/src/physics/include/grins/elastic_cable.h
@@ -62,6 +62,13 @@ namespace GRINS
                                                  const libMesh::Point& point,
                                                  libMesh::Real& value );
 
+    //! Precompute data needed for residual inline function
+    void get_grad_disp( const AssemblyContext & context,
+                        unsigned int qp,
+                        libMesh::Gradient & grad_u,
+                        libMesh::Gradient & grad_v,
+                        libMesh::Gradient & grad_w );
+
   private:
 
     ElasticCable();
@@ -75,7 +82,10 @@ namespace GRINS
     //! Index from registering this quantity. Each component will have it's own index.
     std::vector<unsigned int> _force_indices;
 
-  };
+  }; //end class ElasticCable
+
+
+  /* ------------- Inline Functions ---------------*/
 
 } // end namespace GRINS
 

--- a/src/physics/include/grins/elastic_cable.h
+++ b/src/physics/include/grins/elastic_cable.h
@@ -28,6 +28,7 @@
 
 //GRINS
 #include "grins/elastic_cable_base.h"
+#include "grins/elasticity_tensor.h"
 
 namespace GRINS
 {
@@ -69,6 +70,16 @@ namespace GRINS
                         libMesh::Gradient & grad_v,
                         libMesh::Gradient & grad_w );
 
+
+    //! Precompute tau, needed for residual
+    void get_stress_and_elasticity( const AssemblyContext & context,
+                                    unsigned int qp,
+                                    const libMesh::Gradient & grad_u,
+                                    const libMesh::Gradient & grad_v,
+                                    const libMesh::Gradient & grad_w,
+                                    libMesh::TensorValue<libMesh::Real> & tau,
+                                    ElasticityTensor & C );
+
   private:
 
     ElasticCable();
@@ -83,9 +94,6 @@ namespace GRINS
     std::vector<unsigned int> _force_indices;
 
   }; //end class ElasticCable
-
-
-  /* ------------- Inline Functions ---------------*/
 
 } // end namespace GRINS
 

--- a/src/physics/include/grins/elastic_membrane.h
+++ b/src/physics/include/grins/elastic_membrane.h
@@ -64,6 +64,13 @@ namespace GRINS
                                                  const libMesh::Point& point,
                                                  libMesh::Real& value );
 
+    //! Precompute data needed for get_stress inline function
+    void get_grad_disp( const AssemblyContext & context,
+                        unsigned int qp,
+                        libMesh::Gradient & grad_u,
+                        libMesh::Gradient & grad_v,
+                        libMesh::Gradient & grad_w );
+
   private:
 
     ElasticMembrane();
@@ -77,7 +84,7 @@ namespace GRINS
     //! Index from registering this quantity for postprocessing. Each component will have it's own index.
     std::vector<unsigned int> _strain_indices;
 
-  };
+  }; //end class ElasticMembrane
 
 } // end namespace GRINS
 

--- a/src/physics/include/grins/elastic_membrane.h
+++ b/src/physics/include/grins/elastic_membrane.h
@@ -27,6 +27,7 @@
 
 //GRINS
 #include "grins/elastic_membrane_base.h"
+#include "grins/elasticity_tensor.h"
 
 namespace GRINS
 {
@@ -70,6 +71,16 @@ namespace GRINS
                         libMesh::Gradient & grad_u,
                         libMesh::Gradient & grad_v,
                         libMesh::Gradient & grad_w );
+
+
+    //! Precompute stress and elasticity
+    void get_stress_and_elasticity( const AssemblyContext & context,
+                                    unsigned int qp,
+                                    const libMesh::Gradient & grad_u,
+                                    const libMesh::Gradient & grad_v,
+                                    const libMesh::Gradient & grad_w,
+                                    libMesh::TensorValue<libMesh::Real> & tau,
+                                    ElasticityTensor & C );
 
   private:
 

--- a/src/physics/src/elastic_cable.C
+++ b/src/physics/src/elastic_cable.C
@@ -138,7 +138,8 @@ namespace GRINS
           w_coeffs = &context.get_elem_solution( this->_disp_vars.w() );
 
         // Build new FE for the current point. We need this to build tensors at point.
-        std::unique_ptr<libMesh::FEGenericBase<libMesh::Real> > fe_new =  this->build_new_fe( &context.get_elem(), this->get_fe(context), point );
+        std::unique_ptr<libMesh::FEGenericBase<libMesh::Real> > fe_new =
+          this->build_new_fe( &context.get_elem(), this->get_fe(context), point );
 
         const std::vector<std::vector<libMesh::Real> >& dphi_dxi =  fe_new->get_dphidxi();
 
@@ -329,7 +330,8 @@ namespace GRINS
                   {
                     libMesh::RealGradient u_gradphi_J( dphi_dxi[j][qp] );
 
-                    const libMesh::Real diag_term = this->_A*jac*tau(0,0)*( u_gradphi_J(0)*u_gradphi_I(0))*context.get_elem_solution_derivative();
+                    const libMesh::Real diag_term =
+                      this->_A*jac*tau(0,0)*( u_gradphi_J(0)*u_gradphi_I(0))*context.get_elem_solution_derivative();
 
                     Kuu(i,j) += diag_term;
 

--- a/src/physics/src/elastic_cable.C
+++ b/src/physics/src/elastic_cable.C
@@ -288,37 +288,15 @@ namespace GRINS
     // All shape function gradients are w.r.t. master element coordinates
     const std::vector<std::vector<libMesh::Real> >& dphi_dxi = this->get_fe(context)->get_dphidxi();
 
-    const libMesh::DenseSubVector<libMesh::Number>& u_coeffs = context.get_elem_solution( u_var );
-    const libMesh::DenseSubVector<libMesh::Number>* v_coeffs = NULL;
-    const libMesh::DenseSubVector<libMesh::Number>* w_coeffs = NULL;
-
-    if( this->_disp_vars.dim() >= 2 )
-      v_coeffs = &context.get_elem_solution( v_var );
-
-    if( this->_disp_vars.dim() == 3 )
-      w_coeffs = &context.get_elem_solution( w_var );
-
     // Need these to build up the covariant and contravariant metric tensors
     const std::vector<libMesh::RealGradient>& dxdxi  = this->get_fe(context)->get_dxyzdxi();
 
-    const unsigned int dim = 1; // The cable dimension is always 1 for this physics
-
     for (unsigned int qp=0; qp != n_qpoints; qp++)
       {
-        // Gradients are w.r.t. master element coordinates
-        libMesh::Gradient grad_u, grad_v, grad_w;
+        libMesh::Real jac = JxW[qp];
+        libMesh::Gradient grad_u,grad_v,grad_w;
+        this->get_grad_disp(context, qp, grad_u,grad_v,grad_w);
 
-        for( unsigned int d = 0; d < n_u_dofs; d++ )
-          {
-            libMesh::RealGradient u_gradphi( dphi_dxi[d][qp] );
-            grad_u += u_coeffs(d)*u_gradphi;
-
-            if( this->_disp_vars.dim() >= 2 )
-              grad_v += (*v_coeffs)(d)*u_gradphi;
-
-            if( this->_disp_vars.dim() == 3 )
-              grad_w += (*w_coeffs)(d)*u_gradphi;
-          }
 
         libMesh::RealGradient grad_x( dxdxi[qp](0) );
         libMesh::RealGradient grad_y( dxdxi[qp](1) );
@@ -335,10 +313,8 @@ namespace GRINS
         // Compute stress tensor
         libMesh::TensorValue<libMesh::Real> tau;
         ElasticityTensor C;
+        const unsigned int dim = 1; // The cable dimension is always 1 for this physics
         this->_stress_strain_law.compute_stress_and_elasticity(dim,a_contra,a_cov,A_contra,A_cov,tau,C);
-
-
-        libMesh::Real jac = JxW[qp];
 
         for (unsigned int i=0; i != n_u_dofs; i++)
           {
@@ -415,4 +391,39 @@ namespace GRINS
       } // end qp loop
   }
 
+  template<typename StressStrainLaw>
+  void ElasticCable<StressStrainLaw>::get_grad_disp( const AssemblyContext & context,
+                                                     unsigned int qp,
+                                                     libMesh::Gradient & grad_u,
+                                                     libMesh::Gradient & grad_v,
+                                                     libMesh::Gradient & grad_w )
+  {
+    const int n_u_dofs = context.get_dof_indices(this->_disp_vars.u()).size();
+
+    // All shape function gradients are w.r.t. master element coordinates
+    const std::vector<std::vector<libMesh::Real> >& dphi_dxi = this->get_fe(context)->get_dphidxi();
+
+    const libMesh::DenseSubVector<libMesh::Number>& u_coeffs = context.get_elem_solution( this->_disp_vars.u() );
+    const libMesh::DenseSubVector<libMesh::Number>* v_coeffs = NULL;
+    const libMesh::DenseSubVector<libMesh::Number>* w_coeffs = NULL;
+
+    if( this->_disp_vars.dim() >= 2 )
+      v_coeffs = &context.get_elem_solution( this->_disp_vars.v() );
+
+    if( this->_disp_vars.dim() == 3 )
+      w_coeffs = &context.get_elem_solution( this->_disp_vars.w() );
+
+    // Compute gradients  w.r.t. master element coordinates
+    for( int d = 0; d < n_u_dofs; d++ )
+      {
+        libMesh::RealGradient u_gradphi( dphi_dxi[d][qp] );
+        grad_u += u_coeffs(d)*u_gradphi;
+
+        if( this->_disp_vars.dim() >= 2 )
+          grad_v += (*v_coeffs)(d)*u_gradphi;
+
+        if( this->_disp_vars.dim() == 3 )
+          grad_w += (*w_coeffs)(d)*u_gradphi;
+      }
+  }
 } // end namespace GRINS


### PR DESCRIPTION
We're eventually going to want to call these from an ImmersedBoundary type Physics kernel so let's do it separately now. We'll probably want to move to a CRTP interface for SolidMechanicsAbstract to encode this API, but let's actually try and see if this is the right thing to do before enforcing that.