### PR TITLE
Better way to generate absorption plot

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -232,6 +232,7 @@ EXTRA_DIST += $(ozone_DATA)
 spectroscopydir = $(prefix)/examples/spectroscopy
 spectroscopy_PROGRAMS = spec
 spectroscopy_DATA  = $(top_srcdir)/examples/spectroscopy/spectroscopy.in
+spectroscopy_DATA += $(top_srcdir)/examples/spectroscopy/opt_spectroscopy.in
 spectroscopy_DATA += $(top_srcdir)/examples/spectroscopy/CO_data.dat
 spectroscopy_DATA += $(top_srcdir)/examples/spectroscopy/CO_O_O2.xml
 spectroscopy_DATA += $(top_srcdir)/examples/spectroscopy/CO_partition_function.dat

--- a/examples/spectroscopy/README
+++ b/examples/spectroscopy/README
@@ -1,3 +1,22 @@
+======================================================
+  UPDATE: August 2018
+
+  You can now generate a full absorption plot without
+  having to use this example code.
+
+  Simply specify:
+    QoI/SpectroscopicAbsorption/desired_wavenumber = 'nu_min nu_max nu_step'
+    Display/QoI/default_file_prefix = 'prefix'
+
+  This method is much faster than the Spectroscopy example code, particularly
+  for large meshes and small nu_step sizes.
+  Note both wavenumber and absorption values will be output to 16 decimal places.
+
+  See 'opt_spectroscopy.in'
+
+======================================================
+
+
 This example utilizes the SpectroscopicAbsorption QoI to produce a plot of
 absorption vs wavenumber over a specified wavenumber range.
 Two values must be specified in the input file:

--- a/examples/spectroscopy/opt_spectroscopy.in
+++ b/examples/spectroscopy/opt_spectroscopy.in
@@ -114,7 +114,7 @@
     hitran_data_file = './CO_data.dat'
     hitran_partition_function_file = './CO_partition_function.dat'
     partition_temperatures = '295 900 1'
-    desired_wavenumber = '2172.758825'
+    desired_wavenumber = '2171.0 2174.0 0.01'
     min_wavenumber = '2170'
     max_wavenumber = '2175'
     calc_thermo_pressure = 'false'
@@ -127,11 +127,6 @@
   [../]
 []
 
-[SpectroscopyExample]
-  wavenumber_range = '2171.0 2174.0 0.01'
-  output_prefix = 'example_data'
-[]
-
 [linear-nonlinear-solver]
    max_nonlinear_iterations =  25
    max_linear_iterations = 2500
@@ -142,8 +137,8 @@
 []
 
 [Output]
-   [./Display]
-      print_qoi = 'true'
+   [./QoI]
+      default_file_prefix = 'example_data'
    [../]
 []
 

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -31,6 +31,7 @@
 #include "libmesh/auto_ptr.h"
 
 // GRINS
+#include "grins/absorption_coeff_base.h"
 #include "grins/assembly_context.h"
 #include "grins/hitran.h"
 #include "grins/single_variable.h"
@@ -60,7 +61,7 @@ namespace GRINS
     A chemistry library (Antioch or Cantera) is also required.
   */
   template<typename Chemistry>
-  class AbsorptionCoeff : public FEMFunctionAndDerivativeBase<libMesh::Real>
+  class AbsorptionCoeff : public AbsorptionCoeffBase
   {
   public:
 
@@ -77,16 +78,6 @@ namespace GRINS
                     libMesh::Real nu_min, libMesh::Real nu_max,
                     libMesh::Real desired_nu, const std::string & species,
                     libMesh::Real thermo_pressure);
-
-    libMesh::Real get_wavenumber() const
-    {
-      return _nu;
-    }
-
-    void set_wavenumber(libMesh::Real new_nu)
-    {
-      _nu = new_nu;
-    }
 
     //! Calculate the absorption coefficient at a quadratue point
     virtual libMesh::Real operator()(const libMesh::FEMContext & context, const libMesh::Point & qp_xyz, const libMesh::Real t);
@@ -113,9 +104,6 @@ namespace GRINS
 
     //! HITRAN
     std::shared_ptr<HITRAN> _hitran;
-
-    //! Desired wavenumber [cm^-1]
-    libMesh::Real _nu;
 
     PrimitiveTempFEVariables & _T_var;
     PressureFEVariable & _P_var;

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -78,6 +78,11 @@ namespace GRINS
                     libMesh::Real desired_nu, const std::string & species,
                     libMesh::Real thermo_pressure);
 
+    libMesh::Real get_wavenumber() const
+    {
+      return _nu;
+    }
+
     void set_wavenumber(libMesh::Real new_nu)
     {
       _nu = new_nu;

--- a/src/qoi/include/grins/absorption_coeff_base.h
+++ b/src/qoi/include/grins/absorption_coeff_base.h
@@ -1,0 +1,69 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_ABSORPTION_COEFF_BASE_H
+#define GRINS_ABSORPTION_COEFF_BASE_H
+
+// libMesh
+#include "libmesh/fem_function_base.h"
+#include "libmesh/auto_ptr.h"
+
+// GRINS
+#include "grins/assembly_context.h"
+#include "grins/hitran.h"
+#include "grins/single_variable.h"
+#include "grins/multicomponent_variable.h"
+#include "grins/variable_warehouse.h"
+#include "grins/fem_function_and_derivative_base.h"
+
+namespace GRINS
+{
+  class AbsorptionCoeffBase : public FEMFunctionAndDerivativeBase<libMesh::Real>
+  {
+  public:
+    AbsorptionCoeffBase(libMesh::Real nu)
+      : _nu(nu)
+    {}
+
+    libMesh::Real get_wavenumber() const
+    {
+      return _nu;
+    }
+
+    void set_wavenumber(libMesh::Real new_nu)
+    {
+      _nu = new_nu;
+    }
+
+    AbsorptionCoeffBase() = delete;
+
+  protected:
+    //! Desired wavenumber [cm^-1]
+    libMesh::Real _nu;
+
+  };
+
+}
+#endif //GRINS_ABSORPTION_COEFF_BASE_H

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -109,6 +109,11 @@ namespace GRINS
     {
       return *(_f.get());
     }
+    
+    const Function & get_function() const
+    {
+      return *(_f.get());
+    }
 
   private:
     //! Quadrature order

--- a/src/qoi/include/grins/spectroscopic_absorption.h
+++ b/src/qoi/include/grins/spectroscopic_absorption.h
@@ -52,7 +52,9 @@ namespace GRINS
     /*!
       @param absorb AbsorptionCoeff object
     */
-    SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb);
+    SpectroscopicAbsorption(const GetPot & input, const std::string & qoi_name,
+                            std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb,
+                            bool output_as_csv);
 
     virtual QoIBase * clone() const;
 
@@ -64,7 +66,12 @@ namespace GRINS
     //! Override DifferentiableQoI's empty implementation to add chain rule (QoI is exponential)
     virtual void finalize_derivative(libMesh::NumericVector<libMesh::Number> & derivatives, std::size_t qoi_index);
 
+    // Allow for outputting in CSV format
+    virtual void output_qoi(std::ostream & out) const;
+
   private:
+
+    bool _output_as_csv;
 
     SpectroscopicAbsorption();
 

--- a/src/qoi/include/grins/spectroscopic_absorption.h
+++ b/src/qoi/include/grins/spectroscopic_absorption.h
@@ -51,6 +51,8 @@ namespace GRINS
 
     /*!
       @param absorb AbsorptionCoeff object
+      @param output_as_csv Flag for whether we should output QoI value in wavenumber,absorption CSV format
+        or in the normal QoIBase way
     */
     SpectroscopicAbsorption(const GetPot & input, const std::string & qoi_name,
                             std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb,

--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -53,9 +53,9 @@ namespace GRINS
                                               libMesh::Real nu_min, libMesh::Real nu_max,
                                               libMesh::Real desired_nu, const std::string & species,
                                               libMesh::Real thermo_pressure)
-    : _chemistry(chem),
+    : AbsorptionCoeffBase(desired_nu),
+      _chemistry(chem),
       _hitran(hitran),
-      _nu(desired_nu),
       _T_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>("Temperature")),
       _P_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<PressureFEVariable>("Pressure")),
       _Y_var(GRINSPrivate::VariableWarehouse::get_variable_subclass<SpeciesMassFractionsVariable>("SpeciesMassFractions")),

--- a/src/qoi/src/qoi_factory.C
+++ b/src/qoi/src/qoi_factory.C
@@ -202,6 +202,9 @@ namespace GRINS
           {
             // Calculating QoI at a single wavenumber
 
+            // Output the QoI value normally
+            bool output_as_csv = false;
+
             libMesh::Real nu_desired;
             this->get_var_value<libMesh::Real>(input,nu_desired,"QoI/SpectroscopicAbsorption/desired_wavenumber",0.0);
 
@@ -213,11 +216,14 @@ namespace GRINS
             libmesh_error_msg("ERROR: GRINS must be built with either Antioch or Cantera to use the SpectroscopicAbsorption QoI");
 #endif
             
-            qoi = new SpectroscopicAbsorption(input,qoi_name,absorb);
+            qoi = new SpectroscopicAbsorption(input,qoi_name,absorb,output_as_csv);
           }
         else if (num_wavenumbers == 3)
           {
             // Calculating QoI within a range of wavenumbers (i.e. absorption plot)
+
+            // Output wavenumber,absorption (ideally to a file) for easy plotting
+            bool output_as_csv = true;
 
             // We don't want to duplicate the last qoi
             do_final_add = false;
@@ -249,7 +255,7 @@ namespace GRINS
                 libmesh_error_msg("ERROR: GRINS must be built with either Antioch or Cantera to use the SpectroscopicAbsorption QoI");
 #endif
                 
-                qoi = new SpectroscopicAbsorption(input,qoi_name,absorb);
+                qoi = new SpectroscopicAbsorption(input,qoi_name,absorb,output_as_csv);
                 qois->add_qoi( *qoi );
               }
           }

--- a/src/qoi/src/spectroscopic_absorption.C
+++ b/src/qoi/src/spectroscopic_absorption.C
@@ -42,8 +42,11 @@
 
 namespace GRINS
 {
-  SpectroscopicAbsorption::SpectroscopicAbsorption(const GetPot & input,const std::string & qoi_name,std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb)
-    : IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >(input,2 /* QGauss order */,absorb,"SpectroscopicAbsorption",qoi_name)
+  SpectroscopicAbsorption::SpectroscopicAbsorption( const GetPot & input, const std::string & qoi_name,
+                                                    std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real> > absorb,
+                                                    bool output_as_csv)
+    : IntegratedFunction<FEMFunctionAndDerivativeBase<libMesh::Real> >(input,2 /* QGauss order */,absorb,"SpectroscopicAbsorption",qoi_name),
+      _output_as_csv(output_as_csv)
   {}
 
   QoIBase * SpectroscopicAbsorption::clone() const
@@ -75,6 +78,24 @@ namespace GRINS
     _multiphysics_system->assemble_qoi(qs);
 
     derivatives.scale(100.0 * (1.0-QoIBase::_qoi_value));
+  }
+
+  void SpectroscopicAbsorption::output_qoi(std::ostream & out) const
+  {
+    if (_output_as_csv)
+      {
+        const AbsorptionCoeffBase & abs = libMesh::cast_ref<const AbsorptionCoeffBase &>(this->get_function());
+        libMesh::Real nu = abs.get_wavenumber();
+
+        out << std::setprecision(16)
+            << std::scientific
+            << nu << ","
+            << _qoi_value << std::endl;
+      }
+    else
+      {
+        QoIBase::output_qoi(out);
+      }
   }
 
 } //namespace GRINS


### PR DESCRIPTION
This PR generates the same absorption vs. wavenumber plot as the `Spectroscopy` example (#534) but utilizes the `CompositeQoI` class to dramatically speed up this process.

The `Spectroscopy` example loops over _N_ wavenumbers in a given range and recalculates the QoI every time. This results in looping over the entire mesh _N_ times, which is painfully slow for larger meshes or when _N_ is large.

Now, the user can specify `QoI/SpectroscopicAbsorption/desired_wavenumber = 'nu_min nu_max nu_step'` and a separate QoI will be created for each of the _N_ wavenumbers and added to `CompositeQoI`. This means that we only have to loop over the elements **once** and on each element we will calculate the qoi contributions for all _N_ wavenumbers.

Test case: 100x100 QUAD9 element mesh with conditions given in `examples/spectroscopy/spectroscopy.in`
Example code runtime: 165 seconds
New CompositeQoI runtime: 51 seconds

When a user specifies a range of wavenumbers as above, the QoI results will be output in wavenumber,absorption CSV format. This can be directly output to a file for easy plotting by setting `Display/QoI/default_file_prefix = 'prefix'` or can be output to the screen if desired.

The README in the `Spectroscopy` example was updated to indicate this new way for generating an absorption plot, and a sample input file `opt_spectroscopy.in` was included.