### PR TITLE
Add missing header to build system

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -499,6 +499,7 @@ include_HEADERS += qoi/include/grins/integrated_function.h
 include_HEADERS += qoi/include/grins/qoi_output.h
 include_HEADERS += qoi/include/grins/qoi_options.h
 include_HEADERS += qoi/include/grins/hitran.h
+include_HEADERS += qoi/include/grins/absorption_coeff_base.h
 include_HEADERS += qoi/include/grins/absorption_coeff.h
 include_HEADERS += qoi/include/grins/spectroscopic_absorption.h
 include_HEADERS += qoi/include/grins/fem_function_and_derivative_base.h


### PR DESCRIPTION
This got overlooked in #554 and broke distcheck. Thanks femputer!