### PR TITLE
New rayfire 2D solvers

### DIFF
--- a/doxygen/grins.dox.in
+++ b/doxygen/grins.dox.in
@@ -1023,7 +1023,7 @@ PAPER_TYPE             = $(PAPER_SIZE)
 # The EXTRA_PACKAGES tag can be to specify one or more names of LaTeX 
 # packages that should be included in the LaTeX output.
 
-EXTRA_PACKAGES         = 
+EXTRA_PACKAGES         = amsmath
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for 
 # the generated latex document. The header should contain everything until 

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -42,10 +42,11 @@ namespace GRINS
     This class performs a rayfire across a given mesh.
     The user supplies an origin point on the mesh boundary,
     and spherical angle(s) theta (and phi for 3D) to describe the direction of the rayfire.
-    As is standard in spherical coordinates, theta is the angle from the x-axis in the xy-plane,
-    with counterclockwise being positive. -2&pi; &le; theta &le; +2&pi;.
-    Phi is the angle from the xy-plane, with phi>0 being in the positive half of the z-plane.
-    -&pi; &le; phi &le; +&pi;
+    As is standard in spherical coordinates, theta is the azimuthal angle from
+    the positive x-axis in the xy-plane, with counterclockwise being positive;
+    \f$-2\pi \leq \theta \leq +2\pi\f$.
+    Phi is the polar angle from the positive z-axis, with \f$\phi = \pi/2\f$ being the xy-plane;
+    \f$ 0 \leq \phi \leq \pi \f$.
 
     Starting at the given origin point, this class will walk in a straight line
     across the mesh in the prescribed direction. On each element along the line,
@@ -71,7 +72,7 @@ namespace GRINS
       This is restricted to 2D meshes. The init() function must
       be called to perform the actual rayfire.
       @param origin Origin point (x,y) of the rayfire on mesh boundary
-      @param theta Spherical polar angle (in radians)
+      @param theta Spherical azimuthal angle (in radians)
     */
     RayfireMesh(libMesh::Point& origin, libMesh::Real theta);
 
@@ -80,8 +81,8 @@ namespace GRINS
       This is restricted to 3D meshes. The init() function must
       be called to perform the actual rayfire.
       @param origin Origin point (x,y,z) of the rayfire on mesh boundary
-      @param theta  Spherical polar angle (in radians)
-      @param phi    Spherical azimuthal angle (in radians)
+      @param theta  Spherical azimuthal angle (in radians)
+      @param phi    Spherical polar angle (in radians)
     */
     RayfireMesh(libMesh::Point& origin, libMesh::Real theta, libMesh::Real phi);
 
@@ -138,11 +139,11 @@ namespace GRINS
     //! Origin point
     libMesh::Point _origin;
 
-    //! Rayfire Spherical polar angle (in radians)
-    libMesh::Real   _theta;
+    //! Spherical azimuthal angle (in radians)
+    libMesh::Real _theta;
 
-    //! Rayfire Spherical azimuthal angle (in radians)
-    libMesh::Real   _phi;
+    //! Spherical polar angle (in radians)
+    libMesh::Real _phi;
 
     //! Internal 1D mesh of EDGE2 elements
     std::unique_ptr<libMesh::Mesh> _mesh;

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -74,7 +74,7 @@ namespace GRINS
       @param origin Origin point (x,y) of the rayfire on mesh boundary
       @param theta Spherical azimuthal angle (in radians)
     */
-    RayfireMesh(libMesh::Point& origin, libMesh::Real theta);
+    RayfireMesh(libMesh::Point & origin, libMesh::Real theta);
 
     //! 3D Constructor
     /*!
@@ -84,7 +84,7 @@ namespace GRINS
       @param theta  Spherical azimuthal angle (in radians)
       @param phi    Spherical polar angle (in radians)
     */
-    RayfireMesh(libMesh::Point& origin, libMesh::Real theta, libMesh::Real phi);
+    RayfireMesh(libMesh::Point & origin, libMesh::Real theta, libMesh::Real phi);
 
     //! Input File Constructor
     /*!
@@ -105,7 +105,7 @@ namespace GRINS
       Must be called before any refinements of the main mesh.
       @param mesh_base Reference to the main mesh
     */
-    void init(const libMesh::MeshBase& mesh_base);
+    void init(const libMesh::MeshBase & mesh_base);
 
     /*!
       This function takes in an elem_id on the main mesh and returns an elem from the 1D rayfire mesh.
@@ -113,12 +113,12 @@ namespace GRINS
       @return Elem* to 1D elem from the rayfire mesh if the elem_id falls along the rayfire path
       @return NULL if the given elem_id does not correspond to an elem through which the rayfire passes
     */
-    const libMesh::Elem* map_to_rayfire_elem(const libMesh::dof_id_type elem_id);
+    const libMesh::Elem * map_to_rayfire_elem(const libMesh::dof_id_type elem_id);
 
     /*!
       Returns a vector of elem IDs that are currently along the rayfire
     */
-    void elem_ids_in_rayfire(std::vector<libMesh::dof_id_type>& id_vector) const;
+    void elem_ids_in_rayfire(std::vector<libMesh::dof_id_type> & id_vector) const;
 
     /*!
       Checks for refined and coarsened main mesh elements along the rayfire path.
@@ -129,7 +129,7 @@ namespace GRINS
       Both can be done on different elements, as long as they are only 1 level in either direction.
       @param mesh: reference to main mesh, needed to get Elem* from the stored elem_id's
     */
-    void reinit(const libMesh::MeshBase& mesh_base);
+    void reinit(const libMesh::MeshBase & mesh_base);
 
 
   private:
@@ -166,7 +166,7 @@ namespace GRINS
       Also used by map_to_rayfire_elem(), which adds a const to prevent modification
       outside this class.
     */
-    libMesh::Elem* get_rayfire_elem(const libMesh::dof_id_type elem_id);
+    libMesh::Elem * get_rayfire_elem(const libMesh::dof_id_type elem_id);
 
     //! Calculate the intersection point
     /*!
@@ -174,13 +174,13 @@ namespace GRINS
       @return Elem* if intersection is found
       @return NULL  if no intersection point found (i.e. start_point is on a boundary)
     */
-    const libMesh::Elem* get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point& start_point, libMesh::Point& end_point, bool same_parent = false);
+    const libMesh::Elem * get_next_elem(const libMesh::Elem * cur_elem, libMesh::Point & start_point, libMesh::Point & end_point, bool same_parent = false);
 
     //! Ensure the calculated intersection point is on the edge_elem and is not the start_point
-    bool check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, const libMesh::Elem& edge_elem, libMesh::Point& next_point);
+    bool check_valid_point(libMesh::Point & intersection_point, libMesh::Point & start_point, const libMesh::Elem & edge_elem, libMesh::Point & next_point);
 
     //! Knowing the end_point, get the appropraite next elem along the path
-    const libMesh::Elem* get_correct_neighbor(libMesh::Point & start_point, libMesh::Point & end_point, const libMesh::Elem * cur_elem, unsigned int side, bool same_parent);
+    const libMesh::Elem * get_correct_neighbor(libMesh::Point & start_point, libMesh::Point & end_point, const libMesh::Elem * cur_elem, unsigned int side, bool same_parent);
 
     //! Ensure the supplied origin is on a boundary of the mesh
     void check_origin_on_boundary(const libMesh::Elem* start_elem);
@@ -190,13 +190,13 @@ namespace GRINS
       @return NULL Origin is not on the mesh
       @return Elem* First elem on the rayfire
     */
-    const libMesh::Elem* get_start_elem(const libMesh::MeshBase& mesh_base);
+    const libMesh::Elem * get_start_elem(const libMesh::MeshBase& mesh_base);
 
     //! Ensures the rayfire doesn't wander into the middle of an elem
     bool validate_edge(const libMesh::Point & start_point, const libMesh::Point & end_point, const libMesh::Elem * side_elem, const libMesh::Elem * neighbor);
 
     //! Walks a short distance along the rayfire and checks if elem contains that point
-    bool rayfire_in_elem(const libMesh::Point& end_point, const libMesh::Elem* elem);
+    bool rayfire_in_elem(const libMesh::Point & end_point, const libMesh::Elem* elem);
 
     //! Find the intersection point of the rayfire and a side of cur_elem. Returns libMesh::invalid_uint if no intersection is found
     unsigned int calculate_intersection_point(libMesh::Point & initial_point, const libMesh::Elem * cur_elem, libMesh::Point & intersection_point);
@@ -249,10 +249,10 @@ namespace GRINS
     unsigned int intersection_2D_second_order(libMesh::Point & initial_point, const libMesh::Elem * cur_elem, libMesh::Point & intersection_point);
 
     //! Refinement of a rayfire element whose main mesh counterpart was refined
-    void refine(const libMesh::Elem* main_elem, libMesh::Elem* rayfire_elem);
+    void refine(const libMesh::Elem * main_elem, libMesh::Elem * rayfire_elem);
 
     //! Coarsening of a rayfire element whose main mesh counterpart was coarsened
-    void coarsen(const libMesh::Elem* rayfire_elem);
+    void coarsen(const libMesh::Elem * rayfire_elem);
 
   };
 

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -84,13 +84,13 @@ namespace GRINS
     if (input.have_variable("QoI/"+qoi_string+"/Rayfire/theta"))
       _theta = input("QoI/"+qoi_string+"/Rayfire/theta", -7.0);
     else
-      libmesh_error_msg("ERROR: Spherical polar angle theta must be given for Rayfire");
+      libmesh_error_msg("ERROR: Spherical azimuthal angle theta must be given for Rayfire");
 
     if (std::abs(_theta) > 2.0*Constants::pi)
       libmesh_error_msg("Please supply a theta value between -2*pi and 2*pi");
 
     if (input.have_variable("QoI/"+qoi_string+"/Rayfire/phi"))
-      libmesh_error_msg("ERROR: cannot specify spherical azimuthal angle phi for Rayfire, only 2D is currently supported");
+      libmesh_error_msg("ERROR: cannot specify spherical polar angle phi for Rayfire, only 2D is currently supported");
   }
 
   void RayfireMesh::init(const libMesh::MeshBase& mesh_base)

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -39,7 +39,7 @@
 
 namespace GRINS
 {
-  RayfireMesh::RayfireMesh(libMesh::Point& origin, libMesh::Real theta, libMesh::Real phi) :
+  RayfireMesh::RayfireMesh(libMesh::Point & origin, libMesh::Real theta, libMesh::Real phi) :
     _dim(3),
     _origin(origin),
     _theta(theta),
@@ -50,7 +50,7 @@ namespace GRINS
   }
 
 
-  RayfireMesh::RayfireMesh(libMesh::Point& origin, libMesh::Real theta) :
+  RayfireMesh::RayfireMesh(libMesh::Point & origin, libMesh::Real theta) :
     _dim(2),
     _origin(origin),
     _theta(theta),
@@ -93,7 +93,7 @@ namespace GRINS
       libmesh_error_msg("ERROR: cannot specify spherical polar angle phi for Rayfire, only 2D is currently supported");
   }
 
-  void RayfireMesh::init(const libMesh::MeshBase& mesh_base)
+  void RayfireMesh::init(const libMesh::MeshBase & mesh_base)
   {
     // check if rayfire has already been initialized
     if (_elem_id_map.size() == 0)
@@ -114,7 +114,7 @@ namespace GRINS
       libMesh::Point start_point(_origin);
 
       // get first element
-      const libMesh::Elem* start_elem = this->get_start_elem(mesh_base);
+      const libMesh::Elem * start_elem = this->get_start_elem(mesh_base);
 
       if (!start_elem)
         libmesh_error_msg("Origin is not on mesh");
@@ -129,8 +129,8 @@ namespace GRINS
 
       libMesh::Point end_point;
 
-      const libMesh::Elem* next_elem;
-      const libMesh::Elem* prev_elem = start_elem;
+      const libMesh::Elem * next_elem;
+      const libMesh::Elem * prev_elem = start_elem;
 
       do
         {
@@ -146,7 +146,7 @@ namespace GRINS
 
           // add end point as node on the rayfire mesh
           end_node = _mesh->add_point(end_point);
-          libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
+          libMesh::Elem * elem = _mesh->add_elem(new libMesh::Edge2);
           elem->set_node(0) = start_node;
           elem->set_node(1) = end_node;
 
@@ -183,13 +183,13 @@ namespace GRINS
   }
 
 
-  const libMesh::Elem* RayfireMesh::map_to_rayfire_elem(const libMesh::dof_id_type elem_id)
+  const libMesh::Elem * RayfireMesh::map_to_rayfire_elem(const libMesh::dof_id_type elem_id)
   {
     return this->get_rayfire_elem(elem_id);
   }
 
 
-  void RayfireMesh::elem_ids_in_rayfire(std::vector<libMesh::dof_id_type>& id_vector) const
+  void RayfireMesh::elem_ids_in_rayfire(std::vector<libMesh::dof_id_type> & id_vector) const
   {
     std::map<libMesh::dof_id_type,libMesh::dof_id_type>::const_iterator it = _elem_id_map.begin();
     for(; it != _elem_id_map.end(); it++)
@@ -200,7 +200,7 @@ namespace GRINS
   }
 
 
-  void RayfireMesh::reinit(const libMesh::MeshBase& mesh_base)
+  void RayfireMesh::reinit(const libMesh::MeshBase & mesh_base)
   {
     // we don't want to reinit() multiple times
     // at the same AMR level
@@ -209,11 +209,11 @@ namespace GRINS
     // store the elems to be refined until later
     // so we don't mess with the _elem_id_map while we
     // iterate over it
-    std::vector<std::pair<const libMesh::Elem*,libMesh::Elem*> > elems_to_refine;
+    std::vector<std::pair<const libMesh::Elem *,libMesh::Elem *> > elems_to_refine;
 
     // same with elems to coarsen
     // store the main_mesh elem
-    std::vector<const libMesh::Elem*> elems_to_coarsen;
+    std::vector<const libMesh::Elem *> elems_to_coarsen;
 
     // iterate over all main elems along the rayfire and look for
     // refinement: INACTIVE parent with JUST_REFINED children
@@ -277,7 +277,7 @@ namespace GRINS
 
   // private functions
 
-  void RayfireMesh::check_origin_on_boundary(const libMesh::Elem* start_elem)
+  void RayfireMesh::check_origin_on_boundary(const libMesh::Elem * start_elem)
   {
     libmesh_assert(start_elem);
 
@@ -305,12 +305,12 @@ namespace GRINS
   }
 
 
-  const libMesh::Elem* RayfireMesh::get_start_elem(const libMesh::MeshBase& mesh_base)
+  const libMesh::Elem * RayfireMesh::get_start_elem(const libMesh::MeshBase & mesh_base)
   {
-    const libMesh::Elem* start_elem = NULL;
+    const libMesh::Elem * start_elem = NULL;
 
     std::unique_ptr<libMesh::PointLocatorBase> locator = mesh_base.sub_point_locator();
-    const libMesh::Elem* elem = (*locator)(_origin);
+    const libMesh::Elem * elem = (*locator)(_origin);
 
     // elem would be NULL if origin is not on mesh
     if (elem)
@@ -321,7 +321,7 @@ namespace GRINS
           {
             for (unsigned int i=0; i<elem->n_neighbors(); i++)
               {
-                const libMesh::Elem* neighbor_elem = elem->neighbor_ptr(i);
+                const libMesh::Elem * neighbor_elem = elem->neighbor_ptr(i);
                 if (!neighbor_elem)
                   continue;
 
@@ -338,10 +338,10 @@ namespace GRINS
   }
 
 
-  libMesh::Elem* RayfireMesh::get_rayfire_elem(const libMesh::dof_id_type elem_id)
+  libMesh::Elem * RayfireMesh::get_rayfire_elem(const libMesh::dof_id_type elem_id)
   {
     // return value; set if valid rayfire elem is found
-    libMesh::Elem* retval = NULL;
+    libMesh::Elem * retval = NULL;
 
     std::map<libMesh::dof_id_type,libMesh::dof_id_type>::iterator it;
     it = _elem_id_map.find(elem_id);
@@ -353,7 +353,7 @@ namespace GRINS
   }
 
 
-  const libMesh::Elem* RayfireMesh::get_next_elem(const libMesh::Elem* cur_elem, libMesh::Point& start_point, libMesh::Point& next_point, bool same_parent)
+  const libMesh::Elem * RayfireMesh::get_next_elem(const libMesh::Elem * cur_elem, libMesh::Point & start_point, libMesh::Point & next_point, bool same_parent)
   {
     libmesh_assert(cur_elem);
 
@@ -374,7 +374,7 @@ namespace GRINS
   }
 
 
-  bool RayfireMesh::check_valid_point(libMesh::Point& intersection_point, libMesh::Point& start_point, const libMesh::Elem& edge_elem, libMesh::Point& next_point)
+  bool RayfireMesh::check_valid_point(libMesh::Point & intersection_point, libMesh::Point & start_point, const libMesh::Elem & edge_elem, libMesh::Point & next_point)
   {
     bool is_not_start = !(intersection_point.absolute_fuzzy_equals(start_point));
     bool is_on_edge = edge_elem.contains_point(intersection_point);
@@ -391,7 +391,7 @@ namespace GRINS
   }
 
 
-  bool RayfireMesh::rayfire_in_elem(const libMesh::Point& end_point, const libMesh::Elem* elem)
+  bool RayfireMesh::rayfire_in_elem(const libMesh::Point & end_point, const libMesh::Elem * elem)
   {
     libmesh_assert(elem);
 
@@ -451,7 +451,7 @@ namespace GRINS
   }
 
 
-  const libMesh::Elem* RayfireMesh::get_correct_neighbor(libMesh::Point & start_point, libMesh::Point & end_point, const libMesh::Elem * cur_elem, unsigned int side, bool same_parent)
+  const libMesh::Elem * RayfireMesh::get_correct_neighbor(libMesh::Point & start_point, libMesh::Point & end_point, const libMesh::Elem * cur_elem, unsigned int side, bool same_parent)
   {
     libmesh_assert(cur_elem);
     libmesh_assert(cur_elem->active());
@@ -515,7 +515,7 @@ namespace GRINS
 
             // next elem is not a neighbor,
             // so get all elems that share this vertex
-            std::set<const libMesh::Elem*> elem_set;
+            std::set<const libMesh::Elem *> elem_set;
             cur_elem->find_point_neighbors(*vertex,elem_set);
             std::set<const libMesh::Elem *>::const_iterator       it  = elem_set.begin();
             const std::set<const libMesh::Elem *>::const_iterator end = elem_set.end();
@@ -523,7 +523,7 @@ namespace GRINS
             // iterate over each elem
             for (; it != end; ++it)
               {
-                const libMesh::Elem* elem = *it;
+                const libMesh::Elem * elem = *it;
 
                 if (elem == cur_elem) // skip the current elem
                   continue;
@@ -805,7 +805,7 @@ namespace GRINS
   }
 
 
-  void RayfireMesh::refine(const libMesh::Elem* main_elem, libMesh::Elem* rayfire_elem)
+  void RayfireMesh::refine(const libMesh::Elem * main_elem, libMesh::Elem * rayfire_elem)
   {
     libmesh_assert(main_elem);
     libmesh_assert(rayfire_elem);
@@ -813,8 +813,8 @@ namespace GRINS
     libmesh_assert_equal_to(main_elem->refinement_flag(),libMesh::Elem::RefinementState::INACTIVE);
 
     // these nodes cannot change
-    libMesh::Node* start_node = rayfire_elem->node_ptr(0);
-    libMesh::Node* end_node   = rayfire_elem->node_ptr(1);
+    libMesh::Node * start_node = rayfire_elem->node_ptr(0);
+    libMesh::Node * end_node   = rayfire_elem->node_ptr(1);
 
     // set the rayfire_elem as INACTIVE
     rayfire_elem->set_refinement_flag(libMesh::Elem::RefinementState::INACTIVE);
@@ -860,8 +860,8 @@ namespace GRINS
     libMesh::Point start_point = *start_node;
     libMesh::Point end_point;
 
-    const libMesh::Elem* next_elem;
-    const libMesh::Elem* prev_elem = main_elem->child_ptr(start_child);
+    const libMesh::Elem * next_elem;
+    const libMesh::Elem * prev_elem = main_elem->child_ptr(start_child);
 
     // if prev_elem is INACTIVE, then more than one refinement
     // has taken place between reinit() calls and will
@@ -884,7 +884,7 @@ namespace GRINS
 
         // add end point as node on the rayfire mesh
         new_node = _mesh->add_point(end_point);
-        libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
+        libMesh::Elem * elem = _mesh->add_elem(new libMesh::Edge2);
 
         elem->set_node(0) = prev_node;
         elem->set_node(1) = new_node;
@@ -918,21 +918,21 @@ namespace GRINS
   }
 
 
-  void RayfireMesh::coarsen(const libMesh::Elem* child_elem)
+  void RayfireMesh::coarsen(const libMesh::Elem * child_elem)
   {
     libmesh_assert(child_elem);
 
     if (this->get_rayfire_elem(child_elem->id()))
       {
-        const libMesh::Elem* parent_elem = child_elem->parent();
+        const libMesh::Elem * parent_elem = child_elem->parent();
         libmesh_assert(parent_elem);
 
-        const libMesh::Node* start_node = NULL;
-        const libMesh::Node* end_node = NULL;
+        const libMesh::Node * start_node = NULL;
+        const libMesh::Node * end_node = NULL;
 
         for (unsigned int c=0; c<parent_elem->n_children(); c++)
           {
-            libMesh::Elem* rayfire_child = this->get_rayfire_elem(parent_elem->child_ptr(c)->id());
+            libMesh::Elem * rayfire_child = this->get_rayfire_elem(parent_elem->child_ptr(c)->id());
 
             if (rayfire_child)
               {
@@ -959,7 +959,7 @@ namespace GRINS
         libmesh_assert(end_node);
 
         // add a new rayfire elem
-        libMesh::Elem* elem = _mesh->add_elem(new libMesh::Edge2);
+        libMesh::Elem * elem = _mesh->add_elem(new libMesh::Edge2);
         elem->set_node(0) = _mesh->node_ptr(start_node->id());
         elem->set_node(1) = _mesh->node_ptr(end_node->id());
 

--- a/test/unit/rayfire_test.C
+++ b/test/unit/rayfire_test.C
@@ -68,6 +68,8 @@ namespace GRINSTesting
     CPPUNIT_TEST( test_quad9_2D );
     CPPUNIT_TEST( fire_through_vertex );
     CPPUNIT_TEST( origin_between_elems );
+    CPPUNIT_TEST( quad4_off_origin );
+    CPPUNIT_TEST( quadratic_top_quad9 );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -280,6 +282,69 @@ namespace GRINSTesting
 
       this->run_test(origin,theta,calc_end_node,9,8,"quad4",2);
       this->run_test(origin,theta,calc_end_node,9,8,"quad9",2);
+    }
+
+    void quad4_off_origin()
+    {
+      // vector of intersection points
+      std::vector<libMesh::Point> pts(4);
+      pts[0] = libMesh::Point(1.4,0.8);
+      pts[1] = libMesh::Point(2.2,1.3);
+      pts[2] = libMesh::Point(2.0,2.25);
+      pts[3] = libMesh::Point(1.3,1.6);
+
+      // create the mesh (single trapezoidal QUAD4 element)
+      std::shared_ptr<libMesh::UnstructuredMesh> mesh( new libMesh::SerialMesh(*TestCommWorld) );
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(1.0,1.0),0 );
+      mesh->add_point( libMesh::Point(2.0,0.5),1 );
+      mesh->add_point( libMesh::Point(2.5,2.5),2 );
+      mesh->add_point( libMesh::Point(1.5,2.0),3 );
+
+      libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad4 );
+      for (unsigned int n=0; n<4; n++)
+        elem->set_node(n) = mesh->node_ptr(n);
+
+      mesh->prepare_for_use();
+
+      run_test_on_all_point_combinations(pts,mesh);
+
+    }
+
+    void quadratic_top_quad9()
+    {
+      // vector of intersection points
+      std::vector<libMesh::Point> pts(4);
+      pts[0] = libMesh::Point(0.25,0.0);
+      pts[1] = libMesh::Point(1.0,0.333);
+      pts[2] = libMesh::Point(0.25,1.375);
+      pts[3] = libMesh::Point(0.0,0.875);
+
+      // create a non-rectangular QUAD9
+      std::shared_ptr<libMesh::UnstructuredMesh> mesh( new libMesh::SerialMesh(*TestCommWorld) );
+
+      mesh->set_mesh_dimension(2);
+
+      mesh->add_point( libMesh::Point(0.0,0.0),0 );
+      mesh->add_point( libMesh::Point(1.0,0.0),1 );
+      mesh->add_point( libMesh::Point(1.0,1.0),2 );
+      mesh->add_point( libMesh::Point(0.0,1.0),3 );
+      mesh->add_point( libMesh::Point(0.5,0.0),4 );
+      mesh->add_point( libMesh::Point(1.0,0.5),5 );
+      mesh->add_point( libMesh::Point(0.5,1.5),6 );
+      mesh->add_point( libMesh::Point(0.0,0.5),7 );
+      mesh->add_point( libMesh::Point(0.5,0.5),8 );
+
+      libMesh::Elem* elem = mesh->add_elem( new libMesh::Quad9 );
+      for (unsigned int n=0; n<9; n++)
+        elem->set_node(n) = mesh->node_ptr(n);
+
+      mesh->prepare_for_use();
+
+      run_test_on_all_point_combinations(pts,mesh);
+
     }
 
 


### PR DESCRIPTION
We reformulate the calculation of the intersection between the rayfire line and the edge of a 2D element. 

When the 2D element is `FIRST` order, all edges are linear so we can actually solve for the intersection point analytically (see `intersection_2D_first_order()`). When the element is `SECOND` order, the edges may be quadratic so we use a Newton iterative solver to find the intersection point (see `intersection_2D_second_order()`)

Two new rayfire tests are included: one is a non-square QUAD4 element that is translated away from the origin, and the other is a QUAD9 where the top edge is quadratic.

To make clear documentation, the `amsmath` package was included in the `doxygen` configuration to allow for the use of `bmatrix` in the comments.