### PR TITLE
LaserAbsorption QoI class

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -185,6 +185,7 @@ libgrins_la_SOURCES += properties/src/chemistry_builder.C
 # src/qoi files
 libgrins_la_SOURCES += qoi/src/average_nusselt_number.C
 libgrins_la_SOURCES += qoi/src/qoi_base.C
+libgrins_la_SOURCES += qoi/src/multi_qoi_base.C
 libgrins_la_SOURCES += qoi/src/qoi_factory.C
 libgrins_la_SOURCES += qoi/src/vorticity.C
 libgrins_la_SOURCES += qoi/src/composite_qoi.C
@@ -500,6 +501,7 @@ include_HEADERS += properties/include/grins/chemistry_builder.h
 # src/qoi headers
 include_HEADERS += qoi/include/grins/average_nusselt_number.h
 include_HEADERS += qoi/include/grins/qoi_base.h
+include_HEADERS += qoi/include/grins/multi_qoi_base.h
 include_HEADERS += qoi/include/grins/qoi_factory.h
 include_HEADERS += qoi/include/grins/qoi_names.h
 include_HEADERS += qoi/include/grins/vorticity.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -203,6 +203,7 @@ libgrins_la_SOURCES += qoi/src/spectroscopic_absorption.C
 libgrins_la_SOURCES += qoi/src/laser_intensity_profile_base.C
 libgrins_la_SOURCES += qoi/src/constant_laser_intensity_profile.C
 libgrins_la_SOURCES += qoi/src/collimated_gaussian_laser_intensity_profile.C
+libgrins_la_SOURCES += qoi/src/laser_absorption.C
 
 # src/solver files
 libgrins_la_SOURCES += solver/src/solver.C
@@ -526,6 +527,7 @@ include_HEADERS += qoi/include/grins/fem_function_and_derivative_base.h
 include_HEADERS += qoi/include/grins/laser_intensity_profile_base.h
 include_HEADERS += qoi/include/grins/constant_laser_intensity_profile.h
 include_HEADERS += qoi/include/grins/collimated_gaussian_laser_intensity_profile.h
+include_HEADERS += qoi/include/grins/laser_absorption.h
 
 # src/solver headers
 include_HEADERS += solver/include/grins/solver.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -200,6 +200,9 @@ libgrins_la_SOURCES += qoi/src/absorption_coeff.C
 libgrins_la_SOURCES += qoi/src/spectroscopic_qoi_base.C
 libgrins_la_SOURCES += qoi/src/spectroscopic_transmission.C
 libgrins_la_SOURCES += qoi/src/spectroscopic_absorption.C
+libgrins_la_SOURCES += qoi/src/laser_intensity_profile_base.C
+libgrins_la_SOURCES += qoi/src/constant_laser_intensity_profile.C
+libgrins_la_SOURCES += qoi/src/collimated_gaussian_laser_intensity_profile.C
 
 # src/solver files
 libgrins_la_SOURCES += solver/src/solver.C
@@ -520,6 +523,9 @@ include_HEADERS += qoi/include/grins/spectroscopic_qoi_base.h
 include_HEADERS += qoi/include/grins/spectroscopic_transmission.h
 include_HEADERS += qoi/include/grins/spectroscopic_absorption.h
 include_HEADERS += qoi/include/grins/fem_function_and_derivative_base.h
+include_HEADERS += qoi/include/grins/laser_intensity_profile_base.h
+include_HEADERS += qoi/include/grins/constant_laser_intensity_profile.h
+include_HEADERS += qoi/include/grins/collimated_gaussian_laser_intensity_profile.h
 
 # src/solver headers
 include_HEADERS += solver/include/grins/solver.h

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -95,7 +95,7 @@ namespace GRINS
                               const unsigned int qoi_index,
                               const libMesh::Real time);
 
-    //! Not used
+    //! Clones the current object
     virtual std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Real> > clone() const;
 
   protected:

--- a/src/qoi/include/grins/collimated_gaussian_laser_intensity_profile.h
+++ b/src/qoi/include/grins/collimated_gaussian_laser_intensity_profile.h
@@ -1,0 +1,55 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_COLLIMATED_GAUSSIAN_LASER_INTENSITY_PROFILE_H
+#define GRINS_COLLIMATED_GAUSSIAN_LASER_INTENSITY_PROFILE_H
+
+// GRINS
+#include "grins/laser_intensity_profile_base.h"
+
+namespace GRINS
+{
+  class CollimatedGaussianLaserIntensityProfile : public LaserIntensityProfileBase
+  {
+  public:
+    /*!
+      Collimated gaussian laser intensity profile where the "spot size", w, is constant
+      along the optical path. The 'spot size" is the radius at which the laser intensity
+      drops to ~13.5% of its centerline value
+
+      \f$ I(r) \ = \ I(0) \exp(-2 \frac{r^2}{w^2} ) \f$
+    */
+    CollimatedGaussianLaserIntensityProfile(libMesh::Real w);
+
+    virtual void init(const std::vector<libMesh::Point> & quadrature_xyz,
+                      const libMesh::Point & laser_centerline);
+
+  private:
+    libMesh::Real _w;
+  };
+
+}
+#endif // GRINS_COLLIMATED_GAUSSIAN_LASER_INTENSITY_PROFILE_H
+

--- a/src/qoi/include/grins/constant_laser_intensity_profile.h
+++ b/src/qoi/include/grins/constant_laser_intensity_profile.h
@@ -1,0 +1,50 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_CONSTANT_LASER_INTENSITY_PROFILE_H
+#define GRINS_CONSTANT_LASER_INTENSITY_PROFILE_H
+
+// GRINS
+#include "grins/laser_intensity_profile_base.h"
+
+namespace GRINS
+{
+  class ConstantLaserIntensityProfile : public LaserIntensityProfileBase
+  {
+  public:
+    //! Laser intensity profile that is constant across the beam width
+    ConstantLaserIntensityProfile(libMesh::Real I0);
+
+    virtual void init(const std::vector<libMesh::Point> & quadrature_xyz,
+                      const libMesh::Point & laser_centerline);
+
+  private:
+    libMesh::Real _I0;
+
+  };
+
+}
+#endif // GRINS_CONSTANT_LASER_INTENSITY_PROFILE_H
+

--- a/src/qoi/include/grins/laser_absorption.h
+++ b/src/qoi/include/grins/laser_absorption.h
@@ -1,0 +1,95 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_LASER_ABSORPTION_H
+#define GRINS_LASER_ABSORPTION_H
+
+// GRINS
+#include "grins/multi_qoi_base.h"
+#include "grins/fem_function_and_derivative_base.h"
+#include "grins/spectroscopic_transmission.h"
+#include "grins/laser_intensity_profile_base.h"
+
+namespace GRINS
+{
+  class LaserAbsorption : public MultiQoIBase
+  {
+  public:
+
+    /*!
+      The LaserAbsorption class is a 2D analogue of SpectroscopicAbsorption that
+      can calculate the total absorbed laser intensity of a two-dimensional
+      laser beam across a given flow field.
+      
+      It uses Gauss quadrature to integrate the initial and final laser intensity profiles.
+      
+      Each quadrature point has a corresponding SpectroscopicTransmission object to calculate the
+      transmitted laser intensity along its respective optical path (i.e. RayfireMesh).
+
+      @param absorb An AbsorptionCoeff object that will be shared by all internal SpectroscopicTransmission classes
+      @param top_origin A point on the mesh boundary at the top of the 2D laser
+      @param centerline_origin A point on the mesh boundary at the centerline of the 2D laser
+      @param bottom_origin A point on the mesh boundary at the bottom of the 2D laser
+      @param theta angle in the xy-plane for the laser path (measured from the positive x-axis)
+      @param n_quadrature_point The number of quadrature points used to integral the intensity profile.
+                                Each quadrature point will have a separate SpectroscopicTransmission class
+      @param intensity_profile A LaserIntensityProfileBase object
+      @param qoi_name The name of the QoI
+    */
+    LaserAbsorption(const std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real>> & absorb,
+                    const libMesh::Point & top_origin, const libMesh::Point & centerline_origin,
+                    const libMesh::Point & bottom_origin,
+                    libMesh::Real theta, unsigned int n_quadrature_points,
+                    std::shared_ptr<LaserIntensityProfileBase> intensity_profile,   
+                    const std::string & qoi_name);
+
+    //! Just call the default copy constructor
+    virtual QoIBase * clone() const;
+
+    virtual void element_qoi( AssemblyContext& context,
+                              const unsigned int qoi_index);
+
+    //! AMR not yet supported
+    virtual void element_qoi_derivative(AssemblyContext & context,
+                                        const unsigned int qoi_index);
+
+    //! Sum _qoi_vals from all processors and then do the gauss quadrature
+    //! integration to find the total absorbed laser intensity
+    virtual void parallel_op( const libMesh::Parallel::Communicator & communicator,
+                              libMesh::Number & sys_qoi,
+                              libMesh::Number & local_qoi );
+
+  private:
+    //! intensity profile object used to get the laser intensity at the quadrature points
+    std::shared_ptr<LaserIntensityProfileBase> _intensity_profile;
+
+    //! gauss quadrature weights cached here for use in parallel_op()
+    std::vector<libMesh::Real> _quadrature_weights;
+
+  };
+
+}
+#endif // GRINS_LASER_ABSORPTION_H
+

--- a/src/qoi/include/grins/laser_intensity_profile_base.h
+++ b/src/qoi/include/grins/laser_intensity_profile_base.h
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_LASER_INTENSITY_PROFILE_BASE_H
+#define GRINS_LASER_INTENSITY_PROFILE_BASE_H
+
+// C++
+#include <vector>
+
+// libMesh
+#include "libmesh/libmesh.h"
+#include "libmesh/point.h"
+
+namespace GRINS
+{
+  class LaserIntensityProfileBase
+  {
+  public:
+    /*!
+      This is a base class for handling evaluation of laser intensity profiles
+      (used by the LaserAbsorption class)
+    */
+
+    virtual void init(const std::vector<libMesh::Point> & quadrature_xyz,
+                      const libMesh::Point & laser_centerline) =0;
+
+    libMesh::Real intensity(unsigned int index) const;
+
+  protected:
+    std::vector<libMesh::Real> _intensity_vals;
+
+  };
+
+}
+#endif // GRINS_LASER_INTENSITY_PROFILE_BASE_H
+

--- a/src/qoi/include/grins/multi_qoi_base.h
+++ b/src/qoi/include/grins/multi_qoi_base.h
@@ -1,0 +1,129 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+#ifndef GRINS_MULTI_QOI_BASE_H
+#define GRINS_MULTI_QOI_BASE_H
+
+// GRINS
+#include "grins/qoi_base.h"
+
+namespace GRINS
+{
+  class MultiQoIBase : public QoIBase
+  {
+  public:
+
+    /*!
+      This class is an amalgamation of CompositeQoI and QoIBase.
+      
+      The intended purpose is to provide functionality for using multiple QoI objects
+      to compute a single QoI value.
+    */
+    MultiQoIBase(const std::string & qoi_name);
+
+    //! Release and delete all internally stored QoIBase objects
+    virtual ~MultiQoIBase();
+
+    //! Move all internal QoI object pointers by *deep copying* via clone() in add_qoi()
+    MultiQoIBase(const MultiQoIBase & original);
+
+    //! clone() and add QoI to internal vector
+    void add_qoi(const QoIBase & qoi);
+
+    unsigned int n_qois() const;
+
+    const QoIBase & get_qoi(unsigned int qoi_index) const;
+
+    QoIBase & get_qoi(unsigned int qoi_index);
+
+    //! Uses clone() to deep copy all internal QoI objects
+    virtual QoIBase * clone() const;
+
+    virtual bool assemble_on_sides() const;
+
+    virtual bool assemble_on_interior() const;
+
+    //! init all internal QoI objects
+    virtual void init( const GetPot & input,
+                       const MultiphysicsSystem & system,
+                       unsigned int qoi_num);
+
+    //! call init_context on all internal QoI objects
+    virtual void init_context(AssemblyContext & context);
+
+    //! reinit all internal QoI objects
+    virtual void reinit(MultiphysicsSystem & system);
+
+  protected:
+    //! A vector of internal QoIs that are *NOT* known to the context or CompositeQoI
+    std::vector<std::unique_ptr<QoIBase>> _qois;
+
+    //! Since the context does not know about the internal QoIs,
+    //! we need to store their accumulated values separately
+    std::vector<libMesh::Number> _qoi_vals;
+
+    bool _assemble_sides;
+
+    bool _assemble_interior;
+
+  };
+
+  inline
+  bool MultiQoIBase::assemble_on_sides() const
+  {
+    return _assemble_sides;
+  }
+
+  inline
+  bool MultiQoIBase::assemble_on_interior() const
+  {
+    return _assemble_interior;
+  }
+
+  inline
+  unsigned int MultiQoIBase::n_qois() const
+  {
+    return _qois.size();
+  }
+
+  inline
+  const QoIBase & MultiQoIBase::get_qoi(unsigned int qoi_index) const
+  {
+    libmesh_assert_less(qoi_index,this->n_qois());
+
+    return (*(_qois[qoi_index].get()));
+  }
+
+  inline
+  QoIBase & MultiQoIBase::get_qoi(unsigned int qoi_index)
+  {
+    libmesh_assert_less(qoi_index,this->n_qois());
+
+    return (*(_qois[qoi_index]).get());
+  }
+
+}
+#endif // GRINS_MULTI_QOI_BASE_H
+

--- a/src/qoi/include/grins/qoi_factory.h
+++ b/src/qoi/include/grins/qoi_factory.h
@@ -31,6 +31,7 @@
 //GRINS
 #include "grins/composite_qoi.h"
 #include "grins/rayfire_mesh.h"
+#include "grins/fem_function_and_derivative_base.h"
 
 // shared_ptr
 #include <memory>
@@ -71,6 +72,9 @@ namespace GRINS
 
     //! Helper function to reduce code duplication in SpectroscopicTransmission and SpectroscopicAbsorption creation
     bool create_spectroscopic_qoi(const GetPot & input, const std::string & qoi_name, const std::string & qoi_string, QoIBase ** qoi, std::shared_ptr<CompositeQoI> & qois);
+
+    //! Helper function to encapsulate the creation of an AbsorptionCoeff object
+    std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real>> create_absorption_coeff(const GetPot & input, const std::string & qoi_string);
   };
 }
 #endif // QOI_FACTORY_H

--- a/src/qoi/include/grins/qoi_names.h
+++ b/src/qoi/include/grins/qoi_names.h
@@ -35,5 +35,6 @@ namespace GRINS
   const std::string integrated_function = "integrated_function";
   const std::string spectroscopic_transmission = "spectroscopic_transmission";
   const std::string spectroscopic_absorption = "spectroscopic_absorption";
+  const std::string laser_absorption = "laser_absorption";
 }
 #endif //GRINS_QOI_NAMES_H

--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -241,7 +241,9 @@ namespace GRINS
   template<typename Chemistry>
   std::unique_ptr<libMesh::FEMFunctionBase<libMesh::Real> > AbsorptionCoeff<Chemistry>::clone() const
   {
-    libmesh_not_implemented();
+    std::unique_ptr<AbsorptionCoeff<Chemistry>> clone( new AbsorptionCoeff<Chemistry>(*this) );
+
+    return clone;
   }
 
 

--- a/src/qoi/src/collimated_gaussian_laser_intensity_profile.C
+++ b/src/qoi/src/collimated_gaussian_laser_intensity_profile.C
@@ -1,0 +1,49 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+// GRINS
+#include "grins/collimated_gaussian_laser_intensity_profile.h"
+
+namespace GRINS
+{
+  CollimatedGaussianLaserIntensityProfile::CollimatedGaussianLaserIntensityProfile(libMesh::Real w)
+    : _w(w)
+  {}
+
+  void CollimatedGaussianLaserIntensityProfile::init( const std::vector<libMesh::Point> & quadrature_xyz,
+                                                      const libMesh::Point & laser_centerline)
+  {
+    _intensity_vals.resize(quadrature_xyz.size());
+
+    for (unsigned int i = 0; i < quadrature_xyz.size(); ++i)
+      {
+        libMesh::Real radius = ( quadrature_xyz[i] - laser_centerline).norm();
+        _intensity_vals[i] = std::exp( -2.0 * (radius*radius)/(_w*_w) );;
+      }
+
+  }
+
+}
+

--- a/src/qoi/src/constant_laser_intensity_profile.C
+++ b/src/qoi/src/constant_laser_intensity_profile.C
@@ -1,0 +1,46 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+
+// GRINS
+#include "grins/constant_laser_intensity_profile.h"
+
+namespace GRINS
+{
+  ConstantLaserIntensityProfile::ConstantLaserIntensityProfile(libMesh::Real I0)
+    : _I0(I0)
+  {}
+
+  void ConstantLaserIntensityProfile::init( const std::vector<libMesh::Point> & quadrature_xyz,
+                                            const libMesh::Point & /*laser_centerline*/)
+  {
+    _intensity_vals.resize(quadrature_xyz.size());
+
+    for (unsigned int i = 0; i < quadrature_xyz.size(); ++i)
+      _intensity_vals[i] = _I0;
+
+  }
+
+}
+

--- a/src/qoi/src/laser_absorption.C
+++ b/src/qoi/src/laser_absorption.C
@@ -1,0 +1,151 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// GRINS
+#include "grins/laser_absorption.h"
+#include "grins/fem_function_and_derivative_base.h"
+#include "grins/spectroscopic_transmission.h"
+#include "grins/laser_intensity_profile_base.h"
+
+// libMesh
+#include "libmesh/edge_edge2.h"
+#include "libmesh/quadrature_gauss.h"
+
+namespace GRINS
+{
+  LaserAbsorption::LaserAbsorption( const std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real>> & absorb,
+                                    const libMesh::Point & top_origin, const libMesh::Point & centerline_origin,
+                                    const libMesh::Point & bottom_origin,
+                                    libMesh::Real theta, unsigned int n_quadrature_points,
+                                    std::shared_ptr<LaserIntensityProfileBase> intensity_profile,    
+                                    const std::string & qoi_name)
+    : MultiQoIBase(qoi_name),
+      _intensity_profile(intensity_profile)
+  {
+    // create an EDGE2 elem to represent the start of the laser beam
+    std::shared_ptr<libMesh::Elem> elem( new libMesh::Edge2() );
+    elem->set_node(0) = new libMesh::Node(bottom_origin);
+    elem->set_node(1) = new libMesh::Node(top_origin);
+
+    // now use QGauss to identify the quadratures weights and points on this "laser" elem
+    libMesh::Order order = (libMesh::Order)(2*n_quadrature_points - 1);
+    libMesh::QGauss qbase(elem->dim(),order);
+    qbase.init(elem->type(),order);
+
+    std::unique_ptr< libMesh::FEGenericBase<libMesh::Real> > fe = libMesh::FEGenericBase<libMesh::Real>::build(elem->dim(),libMesh::FEType(libMesh::FIRST,libMesh::LAGRANGE));
+    fe->attach_quadrature_rule( &qbase );
+
+    const std::vector<libMesh::Point> & quadrature_xyz = fe->get_xyz();
+
+    fe->reinit(elem.get());
+
+    _quadrature_weights = qbase.get_weights();
+
+    // init the intensity profile object
+    _intensity_profile->init(quadrature_xyz,centerline_origin);
+
+    // create an internal SpectroscopicTramsmission object at each quadrature node
+    std::shared_ptr<RayfireMesh> rayfire;
+    for(unsigned int p = 0; p < quadrature_xyz.size(); ++p)
+      {
+        libMesh::Point origin = quadrature_xyz[p];
+        rayfire.reset( new RayfireMesh(origin,theta) );
+        SpectroscopicTransmission spec(absorb,rayfire,qoi_name,false);
+
+        this->add_qoi(spec);
+      }
+
+  }
+
+  QoIBase * LaserAbsorption::clone() const
+  {
+    return new LaserAbsorption(*this);
+  }
+
+  void LaserAbsorption::element_qoi(AssemblyContext & context, const unsigned int qoi_index)
+  {
+    // perhaps a bit hacky, but since the Context doesn't know about the internal SpectroscopicTransmission
+    // QoIs, we have to use the Context as a way to pass the QoI contributions to the class
+    // and store them internally in _qoi_vals
+    libMesh::Number & qoi = context.get_qois()[qoi_index];
+    for(unsigned int q = 0; q < this->n_qois(); ++q)
+      {
+        qoi = 0.0;
+
+        _qois[q]->element_qoi(context,qoi_index);
+
+        _qoi_vals[q] += qoi;
+      }
+
+    qoi = 0.0;
+
+  }
+
+  void LaserAbsorption::element_qoi_derivative(AssemblyContext & /*context*/, const unsigned int /*qoi_index*/)
+  {
+    // TODO
+    libmesh_not_implemented();
+  }
+
+  void LaserAbsorption::parallel_op(const libMesh::Parallel::Communicator & communicator,
+                                    libMesh::Number & sys_qoi, libMesh::Number & /*local_qoi*/)
+  {
+    // here we don't care about the local_qoi because we keep track of all the
+    // QoI values internally. So we just do our absorption calculation
+    // and set the sys_qoi and _qoi_value at the end
+
+    // we first need to sum the _qoi_vals from all processors
+    // and do the exponential to get the actual transmission value
+    for (unsigned int i = 0; i < this->n_qois(); ++i)
+      _qois[i]->parallel_op(communicator,_qoi_vals[i],_qoi_vals[i]);
+
+    // calculate the initial laser intensity, Io*
+    libMesh::Real initial = 0.0;
+    for (unsigned int i = 0; i < this->n_qois(); ++i)
+      {
+        libMesh::Real intensity = _intensity_profile->intensity(i);
+        libMesh::Real gq_weight = _quadrature_weights[i];
+
+        initial += gq_weight*intensity;
+      }
+
+    // calculate the final laser intensity, If*
+    libMesh::Real final = 0.0;
+    for (unsigned int i = 0; i < this->n_qois(); ++i)
+      {
+        libMesh::Real gq_weight = _quadrature_weights[i];
+        libMesh::Real intensity = _intensity_profile->intensity(i);
+        libMesh::Real qoi_val = _qoi_vals[i];
+
+        final += gq_weight*intensity*qoi_val;
+      }
+
+    // this is the actual QoI value we are looking for: the total absorbed laser intensity
+    libMesh::Real absorbed_laser_intensity = 1.0 - final/initial;
+
+    sys_qoi = absorbed_laser_intensity;
+    QoIBase::_qoi_value = sys_qoi;
+  }
+
+}

--- a/src/qoi/src/laser_intensity_profile_base.C
+++ b/src/qoi/src/laser_intensity_profile_base.C
@@ -1,0 +1,38 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// GRINS
+#include "grins/laser_intensity_profile_base.h"
+
+namespace GRINS
+{
+  libMesh::Real LaserIntensityProfileBase::intensity(unsigned int i) const
+  {
+    libmesh_assert_less(i,_intensity_vals.size());
+
+    return _intensity_vals[i];
+  }
+
+}
+

--- a/src/qoi/src/multi_qoi_base.C
+++ b/src/qoi/src/multi_qoi_base.C
@@ -1,0 +1,104 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// GRINS
+#include "grins/multi_qoi_base.h"
+
+namespace GRINS
+{
+  MultiQoIBase::MultiQoIBase(const std::string & qoi_name)
+  : QoIBase(qoi_name)
+  {
+    _assemble_sides = false;
+    _assemble_interior = false;
+  }
+
+  MultiQoIBase::~MultiQoIBase()
+  {
+    for(std::vector<std::unique_ptr<QoIBase>>::iterator qoi = _qois.begin(); qoi != _qois.end(); ++qoi)
+        delete ((*qoi).release());
+
+  }
+
+  MultiQoIBase::MultiQoIBase(const MultiQoIBase & original)
+    : QoIBase(original)
+  {
+    libmesh_assert_equal_to(original._qois.size(), original._qoi_vals.size());
+
+    for (unsigned int q = 0; q < original._qois.size(); ++q)
+      {
+        this->add_qoi( *(original._qois[q].get()) );
+        _qoi_vals[q] = original._qoi_vals[q];
+      }
+
+  }
+
+  void MultiQoIBase::add_qoi(const QoIBase & qoi)
+  {
+    _qois.push_back(std::unique_ptr<QoIBase>(qoi.clone()));
+    _qoi_vals.push_back(0.0);
+
+    if(qoi.assemble_on_sides())
+        _assemble_sides = true;
+
+    if(qoi.assemble_on_interior())
+        _assemble_interior = true;
+
+  }
+
+  QoIBase * MultiQoIBase::clone() const
+  {
+    MultiQoIBase * clone = new MultiQoIBase(_qoi_name);
+
+    for(unsigned int q = 0; q < this->n_qois(); ++q)
+        clone->add_qoi(this->get_qoi(q));
+
+    return new MultiQoIBase(*clone);
+  }
+
+  void MultiQoIBase::init( const GetPot & input,
+                     const MultiphysicsSystem & system,
+                     unsigned int /*qoi_num*/)
+  {
+    for(unsigned int q = 0; q < this->n_qois(); ++q)
+      _qois[q]->init(input,system,q);
+
+  }
+
+  void MultiQoIBase::init_context(AssemblyContext & context)
+  {
+    for(std::vector<std::unique_ptr<QoIBase>>::iterator qoi = _qois.begin(); qoi != _qois.end(); ++qoi)
+        (*qoi)->init_context(context);
+
+  }
+
+  void MultiQoIBase::reinit(MultiphysicsSystem & system)
+  {
+    for (unsigned int q = 0; q < this->n_qois(); ++q)
+      (this->get_qoi(q)).reinit(system);
+
+  }
+
+}
+


### PR DESCRIPTION
Here we add a new QoI that can compute the total absorbed laser intensity across a two-dimensional "laser beam". We use Gauss quadrature to integrate the initial and final laser intensity profiles, and then take their ratio and subtract from 1 to get the absorption QoI value. To calculate the final intensity profile, we needed to do a transmission calculation at each quadrature point.

As such, we needed a QoI object similar to `CompositeQoI` that could store QoI objects internally but was itself derived from `QoIBase`. Hence, `MultiQoIBase` was created as an amalgamation of `QoIBase` and `CompositeQoI`. The `LaserAbsorption` class was then derived from this new class and stores `SpectroscopicTransmission` objects internally.

We also added new classes to evaluate the laser intensity at a given radius from the beam centerline. Currently, we have `ConstantLaserIntensityProfile` for a constant intensity across the beam width, and `CollimatedGaussianLaserIntensityProfile` for when the profile is gaussian but does not change along the optical path (i.e. collimated). New intensity profiles can be added by subclassing the `LaserIntensityProfileBase` class.

This PR does *not* provide support for AMR based on this QoI, so `element_qoi_derivative()` is left as `libmesh_not_implemented()`. This PR also only supports 2D meshes; 3D support will be added in future PR(s).

Intensity profile calculations were validated with MATLAB (since they are simple calculations).

Validation of the LaserAbsorption results was done by comparing with a separate iimplementation of the same calculation that can be found on [this branch](https://github.com/tradowsk/grins/tree/2d_abs) and was included in a recent AIAA journal paper. The absorption results using the same non-trivial test case were identical to the 16th decimal place.