### PR TITLE
LaserAbsorption QoI 3D support and CPPUnit tests

### DIFF
--- a/src/qoi/include/grins/laser_absorption.h
+++ b/src/qoi/include/grins/laser_absorption.h
@@ -34,26 +34,29 @@
 
 namespace GRINS
 {
+  /*!
+    The LaserAbsorption class is a 2D/3D analogue of SpectroscopicAbsorption that
+    can calculate the total absorbed laser intensity of a two-dimensional
+    laser beam across a given flow field.
+    
+    It uses Gauss quadrature to integrate the initial and final laser intensity profiles.
+    
+    Each quadrature point has a corresponding SpectroscopicTransmission object to calculate the
+    transmitted laser intensity along its respective optical path (i.e. RayfireMesh).
+  */
   class LaserAbsorption : public MultiQoIBase
   {
   public:
-
     /*!
-      The LaserAbsorption class is a 2D analogue of SpectroscopicAbsorption that
-      can calculate the total absorbed laser intensity of a two-dimensional
-      laser beam across a given flow field.
-      
-      It uses Gauss quadrature to integrate the initial and final laser intensity profiles.
-      
-      Each quadrature point has a corresponding SpectroscopicTransmission object to calculate the
-      transmitted laser intensity along its respective optical path (i.e. RayfireMesh).
+      Two-dimensional class constructor
 
       @param absorb An AbsorptionCoeff object that will be shared by all internal SpectroscopicTransmission classes
       @param top_origin A point on the mesh boundary at the top of the 2D laser
       @param centerline_origin A point on the mesh boundary at the centerline of the 2D laser
       @param bottom_origin A point on the mesh boundary at the bottom of the 2D laser
-      @param theta angle in the xy-plane for the laser path (measured from the positive x-axis)
-      @param n_quadrature_point The number of quadrature points used to integral the intensity profile.
+      @param theta angle in the xy-plane for the laser path, measured from the positive x-axis
+                    with counterclockwise being positive; \f$-2\pi \leq \theta \leq +2\pi\f$
+      @param n_quadrature_point The number of quadrature points used to integrate the intensity profile.
                                 Each quadrature point will have a separate SpectroscopicTransmission class
       @param intensity_profile A LaserIntensityProfileBase object
       @param qoi_name The name of the QoI
@@ -62,6 +65,33 @@ namespace GRINS
                     const libMesh::Point & top_origin, const libMesh::Point & centerline_origin,
                     const libMesh::Point & bottom_origin,
                     libMesh::Real theta, unsigned int n_quadrature_points,
+                    std::shared_ptr<LaserIntensityProfileBase> intensity_profile,   
+                    const std::string & qoi_name);
+
+      /*!
+      Three-dimensional class constructor
+      
+      <b>top_origin, centerline_origin, and bottom_origin must not all be colinear</b>
+
+      @param absorb An AbsorptionCoeff object that will be shared by all internal SpectroscopicTransmission classes
+      @param top_origin A point on the mesh boundary on the outside edge of the circular 3D laser
+      @param centerline_origin A point on the mesh boundary at the centerline of the 3D circular laser
+      @param bottom_origin A different point on the mesh boundary on the outside edge of the circular 3D laser.
+                          Must not be colinear with other 2 origin points
+      @param theta angle in the xy-plane for the laser path, measured from the positive x-axis
+                    with counterclockwise being positive; \f$-2\pi \leq \theta \leq +2\pi\f$
+      @param phi angle from the positive z-axis, with \f$\phi = \pi/2\f$ being the xy-plane;
+                  \f$ 0 \leq \phi \leq \pi \f$
+      @param n_quadrature_point The number of quadrature points *in each dimension* used to integrate the intensity profile.
+                                For example, n_quadrature_points='4' will result in a total of 16 quadrature points (4 in each dimension).
+                                Each quadrature point will have a separate SpectroscopicTransmission class
+      @param intensity_profile A LaserIntensityProfileBase object
+      @param qoi_name The name of the QoI
+    */
+    LaserAbsorption(const std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real>> & absorb,
+                    const libMesh::Point & top_origin, const libMesh::Point & centerline_origin,
+                    const libMesh::Point & bottom_origin,
+                    libMesh::Real theta, libMesh::Real phi, unsigned int n_quadrature_points,
                     std::shared_ptr<LaserIntensityProfileBase> intensity_profile,   
                     const std::string & qoi_name);
 

--- a/src/qoi/src/laser_absorption.C
+++ b/src/qoi/src/laser_absorption.C
@@ -27,13 +27,17 @@
 #include "grins/fem_function_and_derivative_base.h"
 #include "grins/spectroscopic_transmission.h"
 #include "grins/laser_intensity_profile_base.h"
+#include "grins/math_constants.h"
 
 // libMesh
 #include "libmesh/edge_edge2.h"
+#include "libmesh/face_quad9.h"
 #include "libmesh/quadrature_gauss.h"
+#include "libmesh/serial_mesh.h"
 
 namespace GRINS
 {
+  // 2D constructor
   LaserAbsorption::LaserAbsorption( const std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real>> & absorb,
                                     const libMesh::Point & top_origin, const libMesh::Point & centerline_origin,
                                     const libMesh::Point & bottom_origin,
@@ -76,6 +80,95 @@ namespace GRINS
         this->add_qoi(spec);
       }
 
+  }
+
+  // 3D constructor
+  LaserAbsorption::LaserAbsorption(const std::shared_ptr<FEMFunctionAndDerivativeBase<libMesh::Real>> & absorb,
+                    const libMesh::Point & top_origin, const libMesh::Point & centerline_origin,
+                    const libMesh::Point & bottom_origin,
+                    libMesh::Real theta, libMesh::Real phi, unsigned int n_quadrature_points,
+                    std::shared_ptr<LaserIntensityProfileBase> intensity_profile,   
+                    const std::string & qoi_name)
+    : MultiQoIBase(qoi_name),
+      _intensity_profile(intensity_profile)
+  {
+    libMesh::Point P0(centerline_origin);
+    libMesh::Point P1(top_origin);
+    libMesh::Point P2(bottom_origin);
+
+    libMesh::Point P01(P1-P0);
+    libMesh::Point P02(P2-P0);
+    libMesh::Point n = P01.cross(P02);
+
+    libMesh::Point w = n.cross(P01);
+
+    libMesh::Real a = std::acos( (P01*P02) / (P01.norm() * P02.norm()));
+    if ( (a < libMesh::TOLERANCE) || ( std::abs(a - Constants::pi) < libMesh::TOLERANCE) )
+      libmesh_error_msg("Error in LaserAbsorption: top_origin, centerline_origin, and bottom_origin points cannot be colinear");
+
+    libMesh::Real radius = P01.norm();
+
+    // make sure the radius is constant
+    libmesh_assert_less(std::abs(radius-P02.norm()),libMesh::TOLERANCE); 
+
+    libMesh::Point p = P01;
+
+    std::shared_ptr<libMesh::Elem> elem( new libMesh::Quad9() );
+
+    elem->set_node(0) = new libMesh::Node(p);
+    elem->get_node(0)->set_id(0);
+
+    for (unsigned int s = 1; s < 8; ++s)
+      {
+        libMesh::Real angle = Constants::pi/2.0;
+
+        if (s == 4)
+          angle += (Constants::pi/4.0);
+
+        libMesh::Real x1 = std::cos(angle)/radius;
+        libMesh::Real x2 = std::sin(angle)/(w.norm());
+
+        libMesh::Point node = radius*(x1*p + x2*w);
+
+        elem->set_node(s) = new libMesh::Node(node);
+        elem->get_node(s)->set_id(s);
+
+        p = node;
+      }
+
+    elem->set_node(8) = new libMesh::Node(centerline_origin);
+    elem->get_node(8)->set_id(8);
+
+    // need a dummy ID to get through several asserts
+    elem->set_id(0);
+
+    // now use QGauss to identify the quadratures weights and points on this "laser" elem
+    libMesh::Order order = (libMesh::Order)(2*n_quadrature_points - 1);
+    libMesh::QGauss qbase(elem->dim(),order);
+    qbase.init(elem->type(),order);
+
+    std::unique_ptr< libMesh::FEGenericBase<libMesh::Real> > fe = libMesh::FEGenericBase<libMesh::Real>::build(elem->dim(),libMesh::FEType(libMesh::FIRST,libMesh::LAGRANGE));
+    fe->attach_quadrature_rule( &qbase );
+
+    const std::vector<libMesh::Point> & quadrature_xyz = fe->get_xyz();
+
+    fe->reinit(elem.get());
+
+    _quadrature_weights = qbase.get_weights();
+
+    // init the intensity profile object
+    _intensity_profile->init(quadrature_xyz,centerline_origin);
+
+    // create an internal SpectroscopicTramsmission object at each quadrature node
+    std::shared_ptr<RayfireMesh> rayfire;
+    for(unsigned int p = 0; p < quadrature_xyz.size(); ++p)
+      {
+        libMesh::Point origin = quadrature_xyz[p];
+        rayfire.reset( new RayfireMesh(origin,theta,phi) );
+        SpectroscopicTransmission spec(absorb,rayfire,qoi_name,false);
+
+        this->add_qoi(spec);
+      }
   }
 
   QoIBase * LaserAbsorption::clone() const

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -120,7 +120,8 @@ unit_driver_SOURCES = unit/unit_driver.C \
                       unit/spectroscopic_absorption_test.C \
                       unit/nonlinear_solver_options.C \
                       unit/overlapping_fluid_solid_mesh.C \
-                      unit/parsed_property.C
+                      unit/parsed_property.C \
+                      unit/laser_absorption_test.C
 
 antioch_mixture_SOURCES = unit/antioch_mixture.C
 arrhenius_catalycity_SOURCES = unit/arrhenius_catalycity.C

--- a/test/interface/spectroscopic_test_base.h
+++ b/test/interface/spectroscopic_test_base.h
@@ -217,6 +217,40 @@ namespace GRINSTesting
       return text;
     }
 
+    std::string laser_string_2D(const std::string & qoi_name, const std::string & qoi_string,
+                             const std::string & top_origin, const std::string & centerline_origin, const std::string & bottom_origin,
+                             libMesh::Real theta, unsigned int nx, unsigned int ny)
+    {
+      std::string text = "[Mesh]\n";
+                  text +=  "[./Generation]\n";
+                  text +=    "n_elems_x = '"+std::to_string(nx)+"'\n";
+                  text +=    "n_elems_y = '"+std::to_string(ny)+"'\n";
+                  text += "[]\n";
+                  text += "[QoI]\n";
+                  text +=   "enabled_qois = '"+qoi_name+"'\n";
+                  text +=   "[./"+qoi_string+"]\n";
+                  text +=     "material = 'TestMaterial'\n";
+                  text +=     "species_of_interest = 'CO2'\n";
+                  text +=     "hitran_data_file = './test_data/CO2_data.dat'\n";
+                  text +=     "hitran_partition_function_file = './test_data/CO2_partition_function.dat'\n";
+                  text +=     "partition_temperatures = '290 310 0.01'\n";
+                  text +=     "desired_wavenumber = '3682.7649'\n";
+                  text +=     "min_wavenumber = '3682.69'\n";
+                  text +=     "max_wavenumber = '3682.8'\n";
+                  text +=     "calc_thermo_pressure = 'false'\n";
+                  text +=     "n_quadrature_points = '4'\n";
+                  text +=     "intensity_profile = 'collimated gaussian'\n";
+                  text +=     "w = '0.000848725'\n";
+                  text +=     "top_origin = '"+top_origin+"'\n";
+                  text +=     "centerline_origin = '"+centerline_origin+"'\n";
+                  text +=     "bottom_origin = '"+bottom_origin+"'\n";
+                  text +=       "[./Rayfire]\n";
+                  text +=         "theta = '"+std::to_string(theta)+"'\n";
+                  text += "[]";
+
+      return text;
+    }
+
   private:
     void T_param_derivatives(std::shared_ptr<AbsorptionCoeffTesting<GRINS::AntiochChemistry> >absorb, libMesh::Real T, libMesh::Real P, std::vector<libMesh::Real> & Y, unsigned int i)
     {

--- a/test/interface/spectroscopic_test_base.h
+++ b/test/interface/spectroscopic_test_base.h
@@ -194,9 +194,13 @@ namespace GRINSTesting
     {
       std::string text = "[Mesh]\n";
                   text +=  "[./Generation]\n";
+                  text +=    "dimension = '2'\n";
+                  text +=    "elem_type = 'QUAD4'\n";
                   text +=    "n_elems_x = '"+std::to_string(nx)+"'\n";
                   text +=    "n_elems_y = '"+std::to_string(ny)+"'\n";
                   text += "[]\n";
+                  text += "[BoundaryConditions]\n";
+                  text +=    "bc_ids = '0:1:2:3'\n";
                   text += "[QoI]\n";
                   text +=   "enabled_qois = '"+qoi_name+"'\n";
                   text +=   "[./"+qoi_string+"]\n";
@@ -212,6 +216,12 @@ namespace GRINSTesting
                   text +=       "[./Rayfire]\n";
                   text +=         "origin = '0.0 0.025'\n";
                   text +=         "theta = '0.0'\n";
+                  text += "[]\n";
+                  text += "[Variables]\n";
+                  text +=   "[./Velocity]\n";
+                  text +=     "names = 'Ux Uy'\n";
+                  text +=     "fe_family = 'LAGRANGE'\n";
+                  text +=     "order = 'FIRST'\n";
                   text += "[]";
 
       return text;
@@ -223,9 +233,13 @@ namespace GRINSTesting
     {
       std::string text = "[Mesh]\n";
                   text +=  "[./Generation]\n";
+                  text +=    "dimension = '2'\n";
+                  text +=    "elem_type = 'QUAD4'\n";
                   text +=    "n_elems_x = '"+std::to_string(nx)+"'\n";
                   text +=    "n_elems_y = '"+std::to_string(ny)+"'\n";
                   text += "[]\n";
+                  text += "[BoundaryConditions]\n";
+                  text +=    "bc_ids = '0:1:2:3'\n";
                   text += "[QoI]\n";
                   text +=   "enabled_qois = '"+qoi_name+"'\n";
                   text +=   "[./"+qoi_string+"]\n";
@@ -246,6 +260,60 @@ namespace GRINSTesting
                   text +=     "bottom_origin = '"+bottom_origin+"'\n";
                   text +=       "[./Rayfire]\n";
                   text +=         "theta = '"+std::to_string(theta)+"'\n";
+                  text += "[]\n";
+                  text += "[Variables]\n";
+                  text +=   "[./Velocity]\n";
+                  text +=     "names = 'Ux Uy'\n";
+                  text +=     "fe_family = 'LAGRANGE'\n";
+                  text +=     "order = 'FIRST'\n";
+                  text += "[]";
+
+      return text;
+    }
+
+    std::string laser_string_3D(const std::string & qoi_name, const std::string & qoi_string,
+                             const std::string & top_origin, const std::string & centerline_origin, const std::string & bottom_origin,
+                             libMesh::Real theta, libMesh::Real phi, unsigned int nx, unsigned int ny, unsigned int nz)
+    {
+      std::string text = "[Mesh]\n";
+                  text +=  "[./Generation]\n";
+                  text +=    "dimension = '3'\n";
+                  text +=    "elem_type = 'HEX8'\n";
+                  text +=    "z_min = '0.0'\n";
+                  text +=    "z_max = '0.1'\n";
+                  text +=    "n_elems_x = '"+std::to_string(nx)+"'\n";
+                  text +=    "n_elems_y = '"+std::to_string(ny)+"'\n";
+                  text +=    "n_elems_z = '"+std::to_string(nz)+"'\n";
+                  text += "[]\n";
+                  text += "[BoundaryConditions]\n";
+                  text +=    "bc_ids = '0:1:2:3:4:5'\n";
+                  text += "[QoI]\n";
+                  text +=   "enabled_qois = '"+qoi_name+"'\n";
+                  text +=   "[./"+qoi_string+"]\n";
+                  text +=     "material = 'TestMaterial'\n";
+                  text +=     "species_of_interest = 'CO2'\n";
+                  text +=     "hitran_data_file = './test_data/CO2_data.dat'\n";
+                  text +=     "hitran_partition_function_file = './test_data/CO2_partition_function.dat'\n";
+                  text +=     "partition_temperatures = '290 310 0.01'\n";
+                  text +=     "desired_wavenumber = '3682.7649'\n";
+                  text +=     "min_wavenumber = '3682.69'\n";
+                  text +=     "max_wavenumber = '3682.8'\n";
+                  text +=     "calc_thermo_pressure = 'false'\n";
+                  text +=     "n_quadrature_points = '4'\n";
+                  text +=     "intensity_profile = 'collimated gaussian'\n";
+                  text +=     "w = '0.000848725'\n";
+                  text +=     "top_origin = '"+top_origin+"'\n";
+                  text +=     "centerline_origin = '"+centerline_origin+"'\n";
+                  text +=     "bottom_origin = '"+bottom_origin+"'\n";
+                  text +=       "[./Rayfire]\n";
+                  text +=         "theta = '"+std::to_string(theta)+"'\n";
+                  text +=         "phi = '"+std::to_string(phi)+"'\n";
+                  text += "[]\n";
+                  text += "[Variables]\n";
+                  text +=   "[./Velocity]\n";
+                  text +=     "names = 'Ux Uy Uz'\n";
+                  text +=     "fe_family = 'LAGRANGE'\n";
+                  text +=     "order = 'FIRST'\n";
                   text += "[]";
 
       return text;

--- a/test/unit/input_files/spectroscopic_base.in
+++ b/test/unit/input_files/spectroscopic_base.in
@@ -48,7 +48,6 @@
 []
 
 [BoundaryConditions]
-    bc_ids = '0:1:2:3'
     bc_id_name_map = 'Dirichlet'
 
     [./Dirichlet]
@@ -75,10 +74,10 @@
       fe_family = 'LAGRANGE'
       order = 'FIRST'
 
-    [../Velocity]
-      names = 'Ux Uy'
-      fe_family = 'LAGRANGE'
-      order = 'FIRST'
+#    [../Velocity]
+#      names = 'Ux Uy'
+#      fe_family = 'LAGRANGE'
+#      order = 'FIRST'
 
     [../Pressure]
       names = 'p'
@@ -94,12 +93,10 @@
 
 [Mesh]
    [./Generation]
-      dimension = '2'
       x_min = '0.0'
       x_max = '0.10'
       y_min = '0.0'
       y_max = '0.10'
-      element_type = 'QUAD4'
 []
 
 [linear-nonlinear-solver]

--- a/test/unit/laser_absorption_test.C
+++ b/test/unit/laser_absorption_test.C
@@ -1,0 +1,96 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// GRINS - General Reacting Incompressible Navier-Stokes
+//
+// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2010-2013 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "grins_config.h"
+
+#ifdef GRINS_HAVE_CPPUNIT
+
+#ifdef GRINS_HAVE_ANTIOCH
+
+#include <libmesh/ignore_warnings.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+#include <libmesh/restore_warnings.h>
+
+#include "test_comm.h"
+#include "grins_test_paths.h"
+
+#include "spectroscopic_test_base.h"
+
+// GRINS
+#include "grins/math_constants.h"
+#include "grins/grins_enums.h"
+
+// libMesh
+#include "libmesh/parsed_function.h"
+
+// Ignore warnings from auto_ptr in CPPUNIT_TEST_SUITE_END()
+#include <libmesh/ignore_warnings.h>
+
+namespace GRINSTesting
+{
+  class LaserAbsorptionTest : public CppUnit::TestCase,
+                              public SpectroscopicTestBase
+  {
+  public:
+    CPPUNIT_TEST_SUITE( LaserAbsorptionTest );
+    CPPUNIT_TEST( two_dimension_mesh );
+    CPPUNIT_TEST_SUITE_END();
+
+  public:
+
+    void tearDown()
+    {
+      // Clear out the VariableWarehouse so it doesn't interfere with other tests.
+      GRINS::GRINSPrivate::VariableWarehouse::clear();
+    }
+
+    //! 10x10 mesh of QUAD4 with simple, non-moving flow. Hence, orientation and position of the optical paths
+    //! should not change the QoI value
+    void two_dimension_mesh()
+    {
+      libMesh::Real calc_answer = 4.7959591239712063e-01;
+
+      std::stringstream ss;
+
+      // left to right
+      ss << this->laser_string_2D("laser_absorption","LaserAbsorption","0.0 0.0501","0.0 0.0500","0.0 0.0499",0.0,10,10);
+      this->run_test(ss,calc_answer);
+
+      this->tearDown();
+
+      // bottom to top
+      std::stringstream ss2;
+      ss2 << this->laser_string_2D("laser_absorption","LaserAbsorption","0.0501 0.0","0.0500 0.0","0.0499 0.0",1.57079632679,10,10);
+      this->run_test(ss2,calc_answer);
+    }
+
+  };
+
+  CPPUNIT_TEST_SUITE_REGISTRATION( LaserAbsorptionTest );
+
+} // end namespace GRINSTesting
+
+#endif // GRINS_HAVE_ANTIOCH
+#endif // GRINS_HAVE_CPPUNIT

--- a/test/unit/laser_absorption_test.C
+++ b/test/unit/laser_absorption_test.C
@@ -56,6 +56,7 @@ namespace GRINSTesting
   public:
     CPPUNIT_TEST_SUITE( LaserAbsorptionTest );
     CPPUNIT_TEST( two_dimension_mesh );
+    CPPUNIT_TEST( three_dimension_mesh );
     CPPUNIT_TEST_SUITE_END();
 
   public:
@@ -72,9 +73,8 @@ namespace GRINSTesting
     {
       libMesh::Real calc_answer = 4.7959591239712063e-01;
 
-      std::stringstream ss;
-
       // left to right
+      std::stringstream ss;
       ss << this->laser_string_2D("laser_absorption","LaserAbsorption","0.0 0.0501","0.0 0.0500","0.0 0.0499",0.0,10,10);
       this->run_test(ss,calc_answer);
 
@@ -84,6 +84,32 @@ namespace GRINSTesting
       std::stringstream ss2;
       ss2 << this->laser_string_2D("laser_absorption","LaserAbsorption","0.0501 0.0","0.0500 0.0","0.0499 0.0",1.57079632679,10,10);
       this->run_test(ss2,calc_answer);
+    }
+
+    //! 3x3x3 mesh of HEX8 with simple, non-moving flow. Hence, orientation and position of the optical paths
+    //! should not change the QoI value
+    void three_dimension_mesh()
+    {
+      libMesh::Real calc_answer = 4.7959591239712063e-01;
+
+      // left to right
+      std::stringstream ss;
+      ss << this->laser_string_3D("laser_absorption","LaserAbsorption","0.0500 0.0501 0.0","0.0500 0.0500 0.0","0.0501 0.0500 0.0",0.0,0.0,3,3,3);
+      this->run_test(ss,calc_answer);
+
+      this->tearDown();
+
+      // bottom to top
+      std::stringstream ss2;
+      ss2 << this->laser_string_3D("laser_absorption","LaserAbsorption","0.0 0.0500 0.0501","0.0 0.0500 0.0500","0.0 0.0501 0.0500",0.0,1.57079632679,3,3,3);
+      this->run_test(ss2,calc_answer);
+
+      this->tearDown();
+
+      // front to back
+      std::stringstream ss3;
+      ss3 << this->laser_string_3D("laser_absorption","LaserAbsorption","0.0500 0.0 0.0501","0.0500 0.0 0.0500","0.0501 0.0 0.0500",1.57079632679,1.57079632679,3,3,3);
+      this->run_test(ss3,calc_answer);
     }
 
   };


### PR DESCRIPTION
We add support for using the `LaserAbsorption` QoI on 3D meshes, as an extension to #567. We also add CPPUnit tests on 2D and 3D meshes that use the same flow field as the `spectroscopic` tests, and hence should yield the same QoI values.

For 3D, we use a `QUAD9` elem to define the shape of the circular laser cross-section. We use vector algebra to define the nodes of the QUAD9 from the given 3 points and then attach a quadrature rule. The rest proceeds exactly as in the 2D scenario.

Note that AMR support is **not** included in this PR.