### PR TITLE
Add in options to be used in input file for mesh refinement settings.

### DIFF
--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -142,6 +142,15 @@
        # If the value is less than zero, no refinements will be done.
        locally_h_refine = '(9-x)/4.5+(abs(y)<.2)'
 
+       # Specify if you wish for the mesh to not be renumbered upon refinement. Default = true
+       allow_renumbering = 'false'
+
+       # Allow remote element removal during refinement? Default = true
+       allow_remote_elem_deletion = 'false'
+
+       # Optionally disable the partitioner during refinement. Default = enabled
+       disable_partitioning = 'true'
+
    # Options related to input-based mesh redistribution
    [../Redistribution]
 
@@ -222,7 +231,7 @@
            # variable is not used and not needed.
            gas_mixture = 'air4sp'
 
-           
+
            # The type of transport model. Currently accepted values
            # are: constant, mixture_averaged
            transport_model = 'constant'
@@ -263,7 +272,7 @@
            #   eucken (transport_model = mixture_averaged, requires thermo_model = stat_mech)
            #   kinetics_theory (* transport_model = mixture_averaged,
            #                    * requires transport_data if using ASCII parsing or have data in XML file
-           #                      if using XML parsing 
+           #                      if using XML parsing
            #                    * requires viscosity_model and mass_diffusivity_model
            #                      to be kinetics_theory)
            #

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -36,6 +36,7 @@
 #include "libmesh/mesh_modification.h"
 #include "libmesh/mesh_refinement.h"
 #include "libmesh/parallel_mesh.h"
+#include "libmesh/partitioner.h"
 #include "libmesh/parsed_function.h"
 #include "libmesh/serial_mesh.h"
 #include "libmesh/elem.h"
@@ -385,6 +386,18 @@ namespace GRINS
             mesh.all_second_order();
           }
       }
+
+    bool allow_remote_elem_deletion = input("Mesh/Refinement/allow_remote_elem_deletion", true);
+    if (allow_remote_elem_deletion == false)
+      mesh.allow_remote_element_removal(false);
+
+    bool allow_renumbering = input("Mesh/Refinement/allow_renumbering", true);
+    if (allow_renumbering == false)
+      mesh.allow_renumbering(false);
+
+    bool disable_partitioning = input("Mesh/Refinement/disable_partitioning", false);
+    if (disable_partitioning == true)
+      mesh.partitioner() = nullptr;
 
     int uniformly_refine = input("Mesh/Refinement/uniformly_refine", 0);
     this->deprecated_option( input, "mesh-options/uniformly_refine", "Mesh/Refinement/uniformly_refine", 0, uniformly_refine );


### PR DESCRIPTION
Default behavior is unchanged, but these can be useful for example
to cut out unneeded work when constructing a GMG hierarchy.