### PR TITLE
Rayfire 3D fix

### DIFF
--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -250,7 +250,9 @@ namespace GRINS
     */
     unsigned int intersection_2D_second_order(libMesh::Point & initial_point, const libMesh::Elem * cur_elem, libMesh::Point & intersection_point);
 
-    //! Faces of 3D FIRST order elements are planes that can be represented in point-normal form, so there is an analytical solution for the intersection point
+    //! Faces of 3D FIRST order elements are treated as planes that can be represented in point-normal form, so there is an analytical solution for the intersection point
+    //! 
+    //! <b>NB: this will fail for elements whose faces are nonlinear</b>
     unsigned int intersection_3D_first_order(libMesh::Point & initial_point, const libMesh::Elem * cur_elem, libMesh::Point & intersection_point, unsigned int initial_side = libMesh::invalid_uint);
 
     //! Faces of 3D SECOND order elements can be nonlinear, so use a standard Newton iterative solver to find the intersection point
@@ -312,6 +314,10 @@ namespace GRINS
 
     //! Coarsening of a rayfire element whose main mesh counterpart was coarsened
     void coarsen(const libMesh::Elem * rayfire_elem);
+
+    //! Helper function that solves a 3x3 system
+    //! @return false if the matrix A is singular (i.e. there is no solution)
+    bool system_solve_3x3(libMesh::DenseMatrix<libMesh::Real> & A, libMesh::DenseVector<libMesh::Real> & b, libMesh::DenseVector<libMesh::Real> & x);
 
   };
 

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -250,12 +250,7 @@ namespace GRINS
     */
     unsigned int intersection_2D_second_order(libMesh::Point & initial_point, const libMesh::Elem * cur_elem, libMesh::Point & intersection_point);
 
-    //! Faces of 3D FIRST order elements are treated as planes that can be represented in point-normal form, so there is an analytical solution for the intersection point
-    //! 
-    //! <b>NB: this will fail for elements whose faces are nonlinear</b>
-    unsigned int intersection_3D_first_order(libMesh::Point & initial_point, const libMesh::Elem * cur_elem, libMesh::Point & intersection_point, unsigned int initial_side = libMesh::invalid_uint);
-
-    //! Faces of 3D SECOND order elements can be nonlinear, so use a standard Newton iterative solver to find the intersection point
+    //! Faces of 3D elements (of FIRST or SECOND) can be nonlinear, so use a standard Newton iterative solver to find the intersection point
     /*!
       Knowing the starting point \f$(x_r,y_r,z_r)\f$ of the rayfire on the current element,
       the rayfire line can be parameterized as
@@ -304,7 +299,7 @@ namespace GRINS
           = \delta = - J^{-1} F\f$
       and converge when \f$|| \delta || <\f$ libMesh::TOLERANCE
     */
-    unsigned int intersection_3D_second_order(libMesh::Point & initial_point, const libMesh::Elem * cur_elem, libMesh::Point & intersection_point);
+    unsigned int intersection_3D(libMesh::Point & initial_point, const libMesh::Elem * cur_elem, libMesh::Point & intersection_point);
 
     //! Create a FIRST order version of a SECOND order element
     libMesh::Elem * copy_to_first_order(const libMesh::Elem * elem);

--- a/test/unit/rayfire_test_3d.C
+++ b/test/unit/rayfire_test_3d.C
@@ -73,6 +73,7 @@ namespace GRINSTesting
     CPPUNIT_TEST( fire_through_vertex );
     CPPUNIT_TEST( origin_between_elems );
     CPPUNIT_TEST( hex27_from_larger_mesh );
+    CPPUNIT_TEST( another_hex27_from_larger_mesh );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -279,6 +280,60 @@ namespace GRINSTesting
       mesh->add_point( libMesh::Point(0.0022564775245432489, 0.069253246753246733, 0.00064714645067485434),25 );
 
       mesh->add_point( libMesh::Point(0.0022564775245432489, 0.070022727272727264, 0.00064714645067485413),26 );
+
+      libMesh::Elem* elem = mesh->add_elem( new libMesh::Hex27 );
+      for (unsigned int n=0; n<27; n++)
+        elem->set_node(n) = mesh->node_ptr(n);
+
+      mesh->prepare_for_use();
+
+      std::shared_ptr<GRINS::RayfireMesh> rayfire( new GRINS::RayfireMesh(origin,theta,phi) );
+
+      rayfire->init(*mesh);
+
+      // make sure we get a rayfire elem
+      const libMesh::Elem * rayfire_elem = rayfire->map_to_rayfire_elem(0);
+
+      CPPUNIT_ASSERT(rayfire_elem);
+    }
+
+    void another_hex27_from_larger_mesh()
+    {
+      libMesh::Point origin(0.00125,     0.65, 0.00237201);
+      libMesh::Real theta = 1.57079632679;
+      libMesh::Real phi = 1.57079632679;
+
+      std::shared_ptr<libMesh::UnstructuredMesh> mesh( new libMesh::SerialMesh(*TestCommWorld) );
+
+      mesh->set_mesh_dimension(3);
+
+      mesh->add_point( libMesh::Point(0.00164665,0.723,0.00393763),0);
+      mesh->add_point( libMesh::Point(0.0030143,0.723,0.00300646),1);
+      mesh->add_point( libMesh::Point(0.0028715,0.65,0.00285975),2);
+      mesh->add_point( libMesh::Point(0.001577,0.65,0.0037506),3);
+      mesh->add_point( libMesh::Point(0.00108207,0.723,0.00256845),4);
+      mesh->add_point( libMesh::Point(0.00196242,0.723,0.0019608),5);
+      mesh->add_point( libMesh::Point(0.00185348,0.65,0.00185105),6);
+      mesh->add_point( libMesh::Point(0.00103306,0.65,0.0024282),7);
+      mesh->add_point( libMesh::Point(0.00233048,0.723,0.00347205),8);
+      mesh->add_point( libMesh::Point(0.0029429,0.6865,0.0029331),9);
+      mesh->add_point( libMesh::Point(0.00222425,0.65,0.00330517),10);
+      mesh->add_point( libMesh::Point(0.00161182,0.6865,0.00384412),11);
+      mesh->add_point( libMesh::Point(0.00136436,0.723,0.00325304),12);
+      mesh->add_point( libMesh::Point(0.00248836,0.723,0.00248363),13);
+      mesh->add_point( libMesh::Point(0.00236249,0.65,0.0023554),14);
+      mesh->add_point( libMesh::Point(0.00130503,0.65,0.0030894),15);
+      mesh->add_point( libMesh::Point(0.00152225,0.723,0.00226463),16);
+      mesh->add_point( libMesh::Point(0.00190795,0.6865,0.00190593),17);
+      mesh->add_point( libMesh::Point(0.00144327,0.65,0.00213962),18);
+      mesh->add_point( libMesh::Point(0.00105756,0.6865,0.00249832),19);
+      mesh->add_point( libMesh::Point(0.00227736,0.6865,0.00338861),20);
+      mesh->add_point( libMesh::Point(0.00192636,0.723,0.00286834),21);
+      mesh->add_point( libMesh::Point(0.00242543,0.6865,0.00241952),22);
+      mesh->add_point( libMesh::Point(0.00183376,0.65,0.0027224),23);
+      mesh->add_point( libMesh::Point(0.00133469,0.6865,0.00317122),24);
+      mesh->add_point( libMesh::Point(0.00148276,0.6865,0.00220212),25);
+      mesh->add_point( libMesh::Point(0.00188006,0.6865,0.00279537),26);
 
       libMesh::Elem* elem = mesh->add_elem( new libMesh::Hex27 );
       for (unsigned int n=0; n<27; n++)


### PR DESCRIPTION
This PR fixes a failure that was observed in a 3D `HEX27` mesh where the rayfire was unable to calculate an intersection point on certain elements. Inspection of these elements revealed that the `HEX8` version had non-linear faces, and so the `RayfireMesh::intersection_3D_first_order(...)` function would fail since it assumed faces were planes.

To address this issue, we drop the `FIRST` order 3D function and instead use the `SECOND` order newton solver function for all 3D elements. This will account for all nonlinearity (since it operates on the elem reference coordinates `xi` and `eta`).

A new CPPUnit test was added for a 3D `HEX27` that previously caused a failure. This fix was also tested on the larger `HEX27` mesh and no failure was found.