### PR TITLE
Add new getter function to CatalycityBase

### DIFF
--- a/src/boundary_conditions/include/grins/arrhenius_catalycity.h
+++ b/src/boundary_conditions/include/grins/arrhenius_catalycity.h
@@ -42,6 +42,8 @@ namespace GRINS
 
     virtual libMesh::Real dT( const libMesh::Real T ) const;
 
+    virtual void get_params( std::vector<libMesh::Real> & params );
+
     virtual void set_params( const std::vector<libMesh::Real>& params );
 
     //! Creates a new copy of the current class.

--- a/src/boundary_conditions/include/grins/catalycity_base.h
+++ b/src/boundary_conditions/include/grins/catalycity_base.h
@@ -48,6 +48,8 @@ namespace GRINS
 
     virtual libMesh::Real dT( const libMesh::Real T ) const =0;
 
+    virtual void get_params( std::vector<libMesh::Real> & params ) =0;
+
     virtual void set_params( const std::vector<libMesh::Real>& params ) =0;
 
     //! Creates a new copy of the current class.

--- a/src/boundary_conditions/include/grins/catalytic_wall_base.h
+++ b/src/boundary_conditions/include/grins/catalytic_wall_base.h
@@ -82,6 +82,8 @@ namespace GRINS
 
     libMesh::Real domega_dot_dT( const libMesh::Real rho_s, const libMesh::Real T ) const;
 
+    void get_catalycity_params( std::vector<libMesh::Real> & params );
+
     void set_catalycity_params( const std::vector<libMesh::Real>& params );
 
     virtual void register_parameter(  const std::string & param_name,

--- a/src/boundary_conditions/include/grins/constant_catalycity.h
+++ b/src/boundary_conditions/include/grins/constant_catalycity.h
@@ -42,6 +42,8 @@ namespace GRINS
 
     virtual libMesh::Real dT( const libMesh::Real T ) const;
 
+    virtual void get_params( std::vector<libMesh::Real> & params );
+
     virtual void set_params( const std::vector<libMesh::Real>& params );
 
     //! Creates a new copy of the current class.

--- a/src/boundary_conditions/include/grins/power_law_catalycity.h
+++ b/src/boundary_conditions/include/grins/power_law_catalycity.h
@@ -42,6 +42,8 @@ namespace GRINS
 
     virtual libMesh::Real dT( const libMesh::Real T ) const;
 
+    virtual void get_params( std::vector<libMesh::Real> & params );
+
     virtual void set_params( const std::vector<libMesh::Real>& params );
 
     //! Creates a new copy of the current class.

--- a/src/boundary_conditions/src/arrhenius_catalycity.C
+++ b/src/boundary_conditions/src/arrhenius_catalycity.C
@@ -53,6 +53,15 @@ namespace GRINS
     return _gamma0*_Ta/(T*T)*std::exp(-_Ta/T);
   }
 
+  void ArrheniusCatalycity::get_params( std::vector<libMesh::Real> & params )
+  {
+    libmesh_assert_equal_to( params.size(), 2 );
+
+    params[0] = _gamma0;
+
+    params[1] = _Ta;
+  }
+
   void ArrheniusCatalycity::set_params( const std::vector<libMesh::Real>& params )
   {
     libmesh_assert_equal_to( params.size(), 2 );

--- a/src/boundary_conditions/src/catalytic_wall_base.C
+++ b/src/boundary_conditions/src/catalytic_wall_base.C
@@ -61,6 +61,12 @@ namespace GRINS
   {}
 
   template<typename Chemistry>
+  void CatalyticWallBase<Chemistry>::get_catalycity_params( std::vector<libMesh::Real> & params )
+  {
+    _gamma_ptr->get_params( params );
+  }
+
+  template<typename Chemistry>
   void CatalyticWallBase<Chemistry>::set_catalycity_params( const std::vector<libMesh::Real>& params )
   {
     if(_gamma_s)

--- a/src/boundary_conditions/src/constant_catalycity.C
+++ b/src/boundary_conditions/src/constant_catalycity.C
@@ -48,6 +48,13 @@ namespace GRINS
     return 0.0;
   }
 
+  void ConstantCatalycity::get_params( std::vector<libMesh::Real> & params )
+  {
+    libmesh_assert_equal_to( params.size(), 1 );
+
+    params[0] = _gamma;
+  }
+
   void ConstantCatalycity::set_params( const std::vector<libMesh::Real>& params )
   {
     libmesh_assert_equal_to( params.size(), 1 );

--- a/src/boundary_conditions/src/power_law_catalycity.C
+++ b/src/boundary_conditions/src/power_law_catalycity.C
@@ -55,6 +55,17 @@ namespace GRINS
     return (*this)(T)*_alpha/T;
   }
 
+  void PowerLawCatalycity::get_params( std::vector<libMesh::Real> & params )
+  {
+    libmesh_assert_equal_to( params.size(), 3 );
+
+    params[0] = _gamma0;
+
+    params[1] = _Tref;
+
+    params[2] = _alpha;
+  }
+
   void PowerLawCatalycity::set_params( const std::vector<libMesh::Real>& params )
   {
     libmesh_assert_equal_to( params.size(), 3 );


### PR DESCRIPTION
I've probably created this code 3 times over the past year but I keep losing it among all my branches and such, so I was hoping we could merge this.

All this does is return the catalycity parameter values from `CatalycityBase` as a 'getter' complement to `set_params()`.

I use this right now as a debugging helper and outputter for a `QUESO` integration.