### PR TITLE
Refactor OverlappingFluidSolidMap

### DIFF
--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -54,6 +54,10 @@ namespace GRINS
 
     virtual ~OverlappingFluidSolidMap(){};
 
+    //!Returns vector with the element ids of fluid elements that overlap with the given solid elem id
+    const std::set<libMesh::dof_id_type> & get_overlapping_fluid_elems
+    ( const libMesh::dof_id_type solid_id ) const;
+
     const std::map<libMesh::dof_id_type,std::map<libMesh::dof_id_type,std::vector<unsigned int> > > &
     solid_map() const
     { return _solid_to_fluid_map; }
@@ -73,6 +77,9 @@ namespace GRINS
                      const DisplacementVariable & solid_disp_vars );
 
     void map_error(const libMesh::dof_id_type id, const std::string & type) const;
+
+    //! Vector of element ids overlapping each solid id
+    std::map<libMesh::dof_id_type,std::set<libMesh::dof_id_type>> _overlapping_fluid_ids;
 
     std::map<libMesh::dof_id_type,std::map<libMesh::dof_id_type,std::vector<unsigned int> > >
     _solid_to_fluid_map;

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -63,6 +63,9 @@ namespace GRINS
     const std::vector<unsigned int> & get_solid_qps( const libMesh::dof_id_type solid_id,
                                                      const libMesh::dof_id_type fluid_id ) const;
 
+    //!Returns vector with the element ids of solid elements that overlap with the given fluid elem id
+    const std::set<libMesh::dof_id_type> & get_overlapping_solid_elems
+    ( const libMesh::dof_id_type fluid_id ) const;
 
   private:
 

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -54,6 +54,12 @@ namespace GRINS
 
     virtual ~OverlappingFluidSolidMap(){};
 
+    bool has_overlapping_fluid_elem(const libMesh::dof_id_type elem_id) const
+    { return _overlapping_fluid_ids.find(elem_id) != _overlapping_fluid_ids.end(); }
+
+    bool has_overlapping_solid_elem(const libMesh::dof_id_type elem_id) const
+    { return _fluid_to_solid_map.find(elem_id) != _fluid_to_solid_map.end(); }
+
     //!Returns vector with the element ids of fluid elements that overlap with the given solid elem id
     const std::set<libMesh::dof_id_type> & get_overlapping_fluid_elems
     ( const libMesh::dof_id_type solid_id ) const;

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -77,6 +77,11 @@ namespace GRINS
                      const std::set<libMesh::subdomain_id_type> & fluid_ids,
                      const DisplacementVariable & solid_disp_vars );
 
+    void pack_ids_to_push
+    ( const libMesh::MeshBase & mesh,
+      std::map<libMesh::processor_id_type,
+      std::vector<std::pair<libMesh::dof_id_type,libMesh::dof_id_type>>> & ids_to_push ) const;
+
     void map_error(const libMesh::dof_id_type id, const std::string & type) const;
 
     //! Vector of element ids overlapping each solid id

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -63,9 +63,6 @@ namespace GRINS
     const std::vector<unsigned int> & get_solid_qps( const libMesh::dof_id_type solid_id,
                                                      const libMesh::dof_id_type fluid_id ) const;
 
-    const std::map<libMesh::dof_id_type,std::map<libMesh::dof_id_type,std::vector<unsigned int> > > &
-    solid_map() const
-    { return _solid_to_fluid_map; }
 
     const std::map<libMesh::dof_id_type,std::map<libMesh::dof_id_type,std::vector<unsigned int> > > &
     fluid_map() const

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -64,10 +64,6 @@ namespace GRINS
                                                      const libMesh::dof_id_type fluid_id ) const;
 
 
-    const std::map<libMesh::dof_id_type,std::map<libMesh::dof_id_type,std::vector<unsigned int> > > &
-    fluid_map() const
-    { return _fluid_to_solid_map; }
-
   private:
 
     OverlappingFluidSolidMap();

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -77,6 +77,8 @@ namespace GRINS
                      const std::set<libMesh::subdomain_id_type> & fluid_ids,
                      const DisplacementVariable & solid_disp_vars );
 
+    void parallel_sync( MultiphysicsSystem & system );
+
     void pack_ids_to_push
     ( const libMesh::MeshBase & mesh,
       std::map<libMesh::processor_id_type,

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -58,6 +58,11 @@ namespace GRINS
     const std::set<libMesh::dof_id_type> & get_overlapping_fluid_elems
     ( const libMesh::dof_id_type solid_id ) const;
 
+    /*! Returns the quadrature point indices corresponding to those solid quadrature points
+      contained in the fluid element given by fluid_id. */
+    const std::vector<unsigned int> & get_solid_qps( const libMesh::dof_id_type solid_id,
+                                                     const libMesh::dof_id_type fluid_id ) const;
+
     const std::map<libMesh::dof_id_type,std::map<libMesh::dof_id_type,std::vector<unsigned int> > > &
     solid_map() const
     { return _solid_to_fluid_map; }

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -82,8 +82,7 @@ namespace GRINS
     std::map<libMesh::dof_id_type,std::map<libMesh::dof_id_type,std::vector<unsigned int> > >
     _solid_to_fluid_map;
 
-    std::map<libMesh::dof_id_type,std::map<libMesh::dof_id_type,std::vector<unsigned int> > >
-    _fluid_to_solid_map;
+    std::map<libMesh::dof_id_type,std::set<libMesh::dof_id_type>> _fluid_to_solid_map;
   };
 
 } // end namespace GRINS

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -72,6 +72,8 @@ namespace GRINS
                      const std::set<libMesh::subdomain_id_type> & fluid_ids,
                      const DisplacementVariable & solid_disp_vars );
 
+    void map_error(const libMesh::dof_id_type id, const std::string & type) const;
+
     std::map<libMesh::dof_id_type,std::map<libMesh::dof_id_type,std::vector<unsigned int> > >
     _solid_to_fluid_map;
 

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -129,4 +129,12 @@ namespace GRINS
         }
   }
 
+  void OverlappingFluidSolidMap::map_error(const libMesh::dof_id_type id, const std::string & type) const
+  {
+    std::stringstream ss;
+    ss << std::string("ERROR: Could not find ")+type+std::string(" element corresponding to element id ")
+       << id << std::string(" !");
+    libmesh_error_msg(ss.str());
+  }
+
 } // end namespace GRINS

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -107,11 +107,11 @@ namespace GRINS
               // Now add to the solid elem->overlapping fluid elems map, but only if
               // the solid elem belongs to this processor
               {
-                std::map<libMesh::dof_id_type,std::vector<unsigned int> > & fluid_elem_map =
+                std::map<libMesh::dof_id_type,std::vector<unsigned int> > & map =
                   _solid_to_fluid_map[solid_elem->id()];
 
                 // The solid quadrature point that are in this overlapping fluid/solid element pair
-                std::vector<unsigned int>& solid_qps = fluid_elem_map[fluid_elem->id()];
+                std::vector<unsigned int> & solid_qps = map[fluid_elem->id()];
                 solid_qps.push_back(qp);
               }
 

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -151,6 +151,17 @@ namespace GRINS
     return it->second;
   }
 
+  const std::set<libMesh::dof_id_type> & OverlappingFluidSolidMap::get_overlapping_solid_elems
+  ( const libMesh::dof_id_type fluid_id ) const
+  {
+    const auto & it = _fluid_to_solid_map.find(fluid_id);
+
+    if( it == _fluid_to_solid_map.end() )
+      this->map_error(fluid_id,"fluid");
+
+    return it->second;
+  }
+
   const std::vector<unsigned int> & OverlappingFluidSolidMap::get_solid_qps
   ( const libMesh::dof_id_type solid_id, const libMesh::dof_id_type fluid_id ) const
   {

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -115,15 +115,10 @@ namespace GRINS
                 solid_qps.push_back(qp);
               }
 
-              // Now add to the fluid elem->overlapping solid elems map, but only if
-              // the fluid elem belongs to this processor
+              // Now add to the fluid elem->overlapping solid elems map
               {
-                std::map<libMesh::dof_id_type,std::vector<unsigned int> > & solid_elem_map =
-                  _fluid_to_solid_map[fluid_elem->id()];
-
-                // The solid quadrature point that are in this overlapping fluid/solid element pair
-                std::vector<unsigned int>& solid_qps = solid_elem_map[solid_elem->id()];
-                solid_qps.push_back(qp);
+                std::set<libMesh::dof_id_type> & solid_set = _fluid_to_solid_map[fluid_elem->id()];
+                solid_set.insert(solid_elem->id());
               }
             }
         }

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -127,6 +127,33 @@ namespace GRINS
               }
             }
         }
+
+    // Populate _overlapping_fluid_ids
+    // This is technically redundant information, but is a (premature...)
+    // optimization for fetching the list of fluid element ids later.
+    for( const auto & solid_it : _solid_to_fluid_map )
+      {
+        libMesh::dof_id_type solid_id = solid_it.first;
+        const auto & fluid_map = solid_it.second;
+
+        std::set<libMesh::dof_id_type> fluid_ids;
+        for( const auto fluid_it : fluid_map )
+          fluid_ids.insert(fluid_it.first);
+
+        _overlapping_fluid_ids.insert(std::make_pair(solid_id,fluid_ids));
+      }
+  }
+
+
+  const std::set<libMesh::dof_id_type> & OverlappingFluidSolidMap::get_overlapping_fluid_elems
+  ( const libMesh::dof_id_type solid_id ) const
+  {
+    const auto & it = _overlapping_fluid_ids.find(solid_id);
+
+    if( it == _overlapping_fluid_ids.end() )
+      this->map_error(solid_id,"solid");
+
+    return it->second;
   }
 
   void OverlappingFluidSolidMap::map_error(const libMesh::dof_id_type id, const std::string & type) const

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -61,20 +61,15 @@ namespace GRINS
     const libMesh::MeshBase & mesh = system.get_mesh();
 
     libMesh::UniquePtr<libMesh::DiffContext> raw_context = system.build_context();
-    libMesh::UniquePtr<libMesh::FEMContext> fem_context( libMesh::cast_ptr<libMesh::FEMContext *>(raw_context.release()) );
+    libMesh::UniquePtr<libMesh::FEMContext>
+      fem_context( libMesh::cast_ptr<libMesh::FEMContext *>(raw_context.release()) );
 
     if( !mesh.is_serial() )
       libmesh_error_msg("ERROR: build_maps currently only implemented for ReplicatedMesh!");
 
-    for( std::set<libMesh::subdomain_id_type>::const_iterator solid_id_it = solid_ids.begin();
-         solid_id_it != solid_ids.end(); ++solid_id_it )
-      for( libMesh::MeshBase::const_element_iterator e = mesh.active_subdomain_elements_begin(*solid_id_it);
-           e != mesh.active_local_subdomain_elements_end(*solid_id_it);
-           ++e )
+    for( const auto & solid_subdomain_id : solid_ids )
+      for( const auto & solid_elem : mesh.active_local_subdomain_elements_ptr_range(solid_subdomain_id) )
         {
-          // Convenience
-          const libMesh::Elem * solid_elem = *e;
-
           // Setup FEMContext for computing solid displacements
           const std::vector<libMesh::Point>& qpoints =
             fem_context->get_element_fe(solid_disp_vars.u(),2)->get_xyz();

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -156,6 +156,24 @@ namespace GRINS
     return it->second;
   }
 
+  const std::vector<unsigned int> & OverlappingFluidSolidMap::get_solid_qps
+  ( const libMesh::dof_id_type solid_id, const libMesh::dof_id_type fluid_id ) const
+  {
+    const auto & solid_it = _solid_to_fluid_map.find(solid_id);
+
+    if( solid_it == _solid_to_fluid_map.end())
+      this->map_error(solid_id,"solid");
+
+    const auto & fluid_map = solid_it->second;
+
+    const auto & fluid_it = fluid_map.find(fluid_id);
+
+    if( fluid_it == fluid_map.end() )
+      this->map_error(fluid_id,"fluid");
+
+    return fluid_it->second;
+  }
+
   void OverlappingFluidSolidMap::map_error(const libMesh::dof_id_type id, const std::string & type) const
   {
     std::stringstream ss;

--- a/test/unit/overlapping_fluid_solid_mesh.C
+++ b/test/unit/overlapping_fluid_solid_mesh.C
@@ -160,6 +160,22 @@ namespace GRINSTesting
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
       }
 
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(1);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
+      }
+
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(2);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
+      }
+
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();
     }
@@ -312,6 +328,22 @@ namespace GRINSTesting
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
       }
 
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(1);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
+      }
+
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(2);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
+      }
+
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();
     }
@@ -460,6 +492,22 @@ namespace GRINSTesting
 
         for( unsigned int i = 0; i < 2; i++ )
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
+      }
+
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(1);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
+      }
+
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(2);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
       }
 
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
@@ -611,6 +659,22 @@ namespace GRINSTesting
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
       }
 
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(1);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
+      }
+
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(2);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
+      }
+
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();
     }
@@ -736,6 +800,22 @@ namespace GRINSTesting
 
         for( unsigned int i = 0; i < 2; i++ )
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
+      }
+
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(1);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
+      }
+
+      {
+        const std::set<libMesh::dof_id_type> & solid_elem_ids =
+          mesh_overlap.get_overlapping_solid_elems(2);
+
+        CPPUNIT_ASSERT_EQUAL(1,(int)solid_elem_ids.size());
+        CPPUNIT_ASSERT(solid_elem_ids.find(0) != solid_elem_ids.end());
       }
 
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.

--- a/test/unit/overlapping_fluid_solid_mesh.C
+++ b/test/unit/overlapping_fluid_solid_mesh.C
@@ -134,6 +134,12 @@ namespace GRINSTesting
         }
 
       // There should be 1 "solid" element mapping to other two fluid elements
+      {
+        const std::set<libMesh::dof_id_type> & fluid_elem_ids =
+          mesh_overlap.get_overlapping_fluid_elems(0);
+        CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
+      }
+
       CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
       CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());
 
@@ -294,10 +300,16 @@ namespace GRINSTesting
         (GRINS::VariablesParsing::displacement_section());
 
       _es->init();
-      
+
       libMesh::UniquePtr<libMesh::PointLocatorBase> point_locator = mesh->sub_point_locator();
 
       GRINS::OverlappingFluidSolidMap mesh_overlap( (*_system), (*point_locator), solid_ids, fluid_ids, disp_vars );
+
+      {
+        const std::set<libMesh::dof_id_type> & fluid_elem_ids =
+          mesh_overlap.get_overlapping_fluid_elems(0);
+        CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
+      }
 
       CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
       CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());
@@ -459,6 +471,12 @@ namespace GRINSTesting
 
       GRINS::OverlappingFluidSolidMap mesh_overlap( (*_system), (*point_locator), solid_ids, fluid_ids, disp_vars );
 
+      {
+        const std::set<libMesh::dof_id_type> & fluid_elem_ids =
+          mesh_overlap.get_overlapping_fluid_elems(0);
+        CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
+      }
+
       CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
       CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());
 
@@ -618,6 +636,12 @@ namespace GRINSTesting
 
       GRINS::OverlappingFluidSolidMap mesh_overlap( (*_system), (*point_locator), solid_ids, fluid_ids, disp_vars );
 
+      {
+        const std::set<libMesh::dof_id_type> & fluid_elem_ids =
+          mesh_overlap.get_overlapping_fluid_elems(0);
+        CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
+      }
+
       CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
       CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());
 
@@ -754,6 +778,12 @@ namespace GRINSTesting
       libMesh::UniquePtr<libMesh::PointLocatorBase> point_locator = mesh->sub_point_locator();
 
       GRINS::OverlappingFluidSolidMap mesh_overlap( (*_system), (*point_locator), solid_ids, fluid_ids, disp_vars );
+
+      {
+        const std::set<libMesh::dof_id_type> & fluid_elem_ids =
+          mesh_overlap.get_overlapping_fluid_elems(0);
+        CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
+      }
 
       CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
       CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());

--- a/test/unit/overlapping_fluid_solid_mesh.C
+++ b/test/unit/overlapping_fluid_solid_mesh.C
@@ -140,29 +140,11 @@ namespace GRINSTesting
         CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
       }
 
-      CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());
-
-      // These are a little silly. Morally equivalent to map.find() != map.end()
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.solid_map().find(0)->second).find(1)->first);
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).find(2)->first);
-
-      // Check for the correct number and values of solid quadrature point indices
-      // associated with each of the fluid elements
-      CPPUNIT_ASSERT_EQUAL(6,(int)((mesh_overlap.solid_map().find(0)->second).find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(3,(int)((mesh_overlap.solid_map().find(0)->second).find(2)->second).size());
-
       std::vector<unsigned int> elem1_qps(6);
       elem1_qps[0] = 0; elem1_qps[1] = 1; elem1_qps[2] = 3; elem1_qps[3] = 4; elem1_qps[4] = 6; elem1_qps[5] = 7;
 
       std::vector<unsigned int> elem2_qps(3);
       elem2_qps[0] = 2; elem2_qps[1] = 5; elem2_qps[2] = 8;
-
-      for( unsigned int i = 0; i < 6; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.solid_map().find(0)->second).find(1)->second)[i]);
-
-      for( unsigned int i = 0; i < 3; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
 
       {
         const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);
@@ -325,26 +307,11 @@ namespace GRINSTesting
         CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
       }
 
-      CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());
-
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.solid_map().find(0)->second).find(1)->first);
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).find(2)->first);
-
-      CPPUNIT_ASSERT_EQUAL(6,(int)((mesh_overlap.solid_map().find(0)->second).find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(3,(int)((mesh_overlap.solid_map().find(0)->second).find(2)->second).size());
-
       std::vector<unsigned int> elem1_qps(6);
       elem1_qps[0] = 0; elem1_qps[1] = 1; elem1_qps[2] = 3; elem1_qps[3] = 4; elem1_qps[4] = 6; elem1_qps[5] = 7;
 
       std::vector<unsigned int> elem2_qps(3);
       elem2_qps[0] = 2; elem2_qps[1] = 5; elem2_qps[2] = 8;
-
-      for( unsigned int i = 0; i < 6; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.solid_map().find(0)->second).find(1)->second)[i]);
-
-      for( unsigned int i = 0; i < 3; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
 
       {
         const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);
@@ -504,26 +471,11 @@ namespace GRINSTesting
         CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
       }
 
-      CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());
-
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.solid_map().find(0)->second).find(1)->first);
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).find(2)->first);
-
-      CPPUNIT_ASSERT_EQUAL(5,(int)((mesh_overlap.solid_map().find(0)->second).find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(2,(int)((mesh_overlap.solid_map().find(0)->second).find(2)->second).size());
-
       std::vector<unsigned int> elem1_qps(5);
       elem1_qps[0] = 0; elem1_qps[1] = 1; elem1_qps[2] = 3; elem1_qps[3] = 4; elem1_qps[4] = 5;
 
       std::vector<unsigned int> elem2_qps(2);
       elem2_qps[0] = 2; elem2_qps[1] = 6;
-
-      for( unsigned int i = 0; i < 5; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.solid_map().find(0)->second).find(1)->second)[i]);
-
-      for( unsigned int i = 0; i < 2; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
 
       {
         const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);
@@ -682,27 +634,11 @@ namespace GRINSTesting
         CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
       }
 
-      CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());
-
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.solid_map().find(0)->second).find(1)->first);
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).find(2)->first);
-
-      CPPUNIT_ASSERT_EQUAL(6,(int)((mesh_overlap.solid_map().find(0)->second).find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(3,(int)((mesh_overlap.solid_map().find(0)->second).find(2)->second).size());
-
       std::vector<unsigned int> elem1_qps(6);
       elem1_qps[0] = 0; elem1_qps[1] = 3; elem1_qps[2] = 4; elem1_qps[3] = 6; elem1_qps[4] = 7; elem1_qps[5] = 8;
 
       std::vector<unsigned int> elem2_qps(3);
       elem2_qps[0] = 1; elem2_qps[1] = 2; elem2_qps[2] = 5;
-
-      for( unsigned int i = 0; i < 6; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.solid_map().find(0)->second).find(1)->second)[i]);
-
-      for( unsigned int i = 0; i < 3; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
-
 
       {
         const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);
@@ -839,27 +775,11 @@ namespace GRINSTesting
         CPPUNIT_ASSERT_EQUAL(2,(int)fluid_elem_ids.size());
       }
 
-      CPPUNIT_ASSERT_EQUAL(1,(int)mesh_overlap.solid_map().size());
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).size());
-
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.solid_map().find(0)->second).find(1)->first);
-      CPPUNIT_ASSERT_EQUAL(2,(int)(mesh_overlap.solid_map().find(0)->second).find(2)->first);
-
-      CPPUNIT_ASSERT_EQUAL(5,(int)((mesh_overlap.solid_map().find(0)->second).find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(2,(int)((mesh_overlap.solid_map().find(0)->second).find(2)->second).size());
-
       std::vector<unsigned int> elem1_qps(5);
       elem1_qps[0] = 0; elem1_qps[1] = 1; elem1_qps[2] = 3; elem1_qps[3] = 5; elem1_qps[4] = 6;
 
       std::vector<unsigned int> elem2_qps(2);
       elem2_qps[0] = 2; elem2_qps[1] = 4;
-
-      for( unsigned int i = 0; i < 5; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.solid_map().find(0)->second).find(1)->second)[i]);
-
-      for( unsigned int i = 0; i < 2; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
-
 
       {
         const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);

--- a/test/unit/overlapping_fluid_solid_mesh.C
+++ b/test/unit/overlapping_fluid_solid_mesh.C
@@ -160,21 +160,6 @@ namespace GRINSTesting
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
       }
 
-      // There should be 2 "fluid" elements, each mapping to the solid element
-      CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(2)->second).size());
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(1)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(2)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(6,(int)((mesh_overlap.fluid_map().find(1)->second).find(0)->second).size());
-      CPPUNIT_ASSERT_EQUAL(3,(int)((mesh_overlap.fluid_map().find(2)->second).find(0)->second).size());
-
-      for( unsigned int i = 0; i < 6; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.fluid_map().find(1)->second).find(0)->second)[i]);
-
-      for( unsigned int i = 0; i < 3; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.fluid_map().find(2)->second).find(0)->second)[i]);
-
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();
     }
@@ -327,20 +312,6 @@ namespace GRINSTesting
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
       }
 
-      CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(2)->second).size());
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(1)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(2)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(6,(int)((mesh_overlap.fluid_map().find(1)->second).find(0)->second).size());
-      CPPUNIT_ASSERT_EQUAL(3,(int)((mesh_overlap.fluid_map().find(2)->second).find(0)->second).size());
-
-      for( unsigned int i = 0; i < 6; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.fluid_map().find(1)->second).find(0)->second)[i]);
-
-      for( unsigned int i = 0; i < 3; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.fluid_map().find(2)->second).find(0)->second)[i]);
-
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();
     }
@@ -491,20 +462,6 @@ namespace GRINSTesting
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
       }
 
-      CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(2)->second).size());
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(1)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(2)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(5,(int)((mesh_overlap.fluid_map().find(1)->second).find(0)->second).size());
-      CPPUNIT_ASSERT_EQUAL(2,(int)((mesh_overlap.fluid_map().find(2)->second).find(0)->second).size());
-
-      for( unsigned int i = 0; i < 5; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.fluid_map().find(1)->second).find(0)->second)[i]);
-
-      for( unsigned int i = 0; i < 2; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.fluid_map().find(2)->second).find(0)->second)[i]);
-
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();
     }
@@ -654,20 +611,6 @@ namespace GRINSTesting
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
       }
 
-      CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(2)->second).size());
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(1)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(2)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(6,(int)((mesh_overlap.fluid_map().find(1)->second).find(0)->second).size());
-      CPPUNIT_ASSERT_EQUAL(3,(int)((mesh_overlap.fluid_map().find(2)->second).find(0)->second).size());
-
-      for( unsigned int i = 0; i < 6; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.fluid_map().find(1)->second).find(0)->second)[i]);
-
-      for( unsigned int i = 0; i < 3; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.fluid_map().find(2)->second).find(0)->second)[i]);
-
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();
     }
@@ -794,20 +737,6 @@ namespace GRINSTesting
         for( unsigned int i = 0; i < 2; i++ )
           CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
       }
-
-      CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());
-      CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(2)->second).size());
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(1)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(0,(int)(mesh_overlap.fluid_map().find(2)->second).find(0)->first);
-      CPPUNIT_ASSERT_EQUAL(5,(int)((mesh_overlap.fluid_map().find(1)->second).find(0)->second).size());
-      CPPUNIT_ASSERT_EQUAL(2,(int)((mesh_overlap.fluid_map().find(2)->second).find(0)->second).size());
-
-      for( unsigned int i = 0; i < 5; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.fluid_map().find(1)->second).find(0)->second)[i]);
-
-      for( unsigned int i = 0; i < 2; i++ )
-        CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.fluid_map().find(2)->second).find(0)->second)[i]);
 
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();

--- a/test/unit/overlapping_fluid_solid_mesh.C
+++ b/test/unit/overlapping_fluid_solid_mesh.C
@@ -76,7 +76,7 @@ namespace GRINSTesting
       this->reset_all();
     }
 
-    //---------------------------------------------QUAD-ON-QUAD-TEST(.exo)------------------------------------------------- 
+    //---------------------------------------------QUAD-ON-QUAD-TEST(.exo)-------------------------------------------------
 
     void one_overlapping_element_test()
     {
@@ -123,7 +123,7 @@ namespace GRINSTesting
        (-1,-1) ------------------------ (-1,1)
 
        */
-      
+
       for( libMesh::MeshBase::element_iterator e = (*_mesh).active_local_elements_begin();
            e != (*_mesh).active_local_elements_end();
            ++e )
@@ -188,7 +188,7 @@ namespace GRINSTesting
     void quad_on_quad_overlapping_test()
     {
       std::string input_file = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/overlap_variables.in";
-      
+
       std::unique_ptr<GetPot> _input;
       _input.reset( new GetPot(input_file) );
 
@@ -208,7 +208,7 @@ namespace GRINSTesting
                |          |          |
                |          |          |
        (-1,-1) ------------------------ (-1,1)
-   
+
       */
 
       mesh->set_mesh_dimension(2);
@@ -228,7 +228,7 @@ namespace GRINSTesting
       elem->subdomain_id() = 1;
       for (unsigned int n=0; n<9; n++)
         elem->set_node(n) = mesh->node_ptr(n);
-      
+
       mesh->add_point( libMesh::Point(1.0,1.0),9 );
       mesh->add_point( libMesh::Point(0.0,1.0),10 );
       mesh->add_point( libMesh::Point(0.0,-1.0),11 );
@@ -251,7 +251,7 @@ namespace GRINSTesting
       elem->set_node(6) = mesh->node_ptr(15);
       elem->set_node(7) = mesh->node_ptr(16);
       elem->set_node(8) = mesh->node_ptr(17);
-      
+
       //mesh->add_point( libMesh::Point(0.0,1.0),10 );
       mesh->add_point( libMesh::Point(-1.0,1.0),18 );
       mesh->add_point( libMesh::Point(-1.0,-1.0),19 );
@@ -274,7 +274,7 @@ namespace GRINSTesting
       elem->set_node(6) = mesh->node_ptr(22);
       elem->set_node(7) = mesh->node_ptr(14);
       elem->set_node(8) = mesh->node_ptr(23);
-      
+
       mesh->prepare_for_use();
 
       std::unique_ptr<libMesh::EquationSystems> _es;
@@ -356,7 +356,7 @@ namespace GRINSTesting
     void tri_on_quad_overlapping_test()
     {
       std::string input_file = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/overlap_variables.in";
-      
+
       std::unique_ptr<GetPot> _input;
       _input.reset( new GetPot(input_file) );
 
@@ -366,7 +366,7 @@ namespace GRINSTesting
         Overlapping element in the interior (TRI6): id = 0, node 0 = (0.0,0.5)
         Right interior element (QUAD9): id = 1, node 0 = (1,1), width = 1,  height is 2
         Left interior element (QUAD9): id = 2, node 0 = (0,1), width = 1,  height is 2
-     
+
         (-1,1) ----------------------- (1,1)
                |          |          |
                |          |          |
@@ -388,13 +388,13 @@ namespace GRINSTesting
       mesh->add_point( libMesh::Point(-0.25,0.0),3 );
       mesh->add_point( libMesh::Point(0.0,-0.5),4 );
       mesh->add_point( libMesh::Point(0.25,0.0),5 );
-      
+
       libMesh::Elem* elem = mesh->add_elem( new libMesh::Tri6 );
       elem->set_id(0);
       elem->subdomain_id() = 1;
       for (unsigned int n=0; n<6; n++)
         elem->set_node(n) = mesh->node_ptr(n);
-      
+
       mesh->add_point( libMesh::Point(1.0,1.0),6 );
       mesh->add_point( libMesh::Point(0.0,1.0),7 );
       mesh->add_point( libMesh::Point(0.0,-1.0),8 );
@@ -417,7 +417,7 @@ namespace GRINSTesting
       elem->set_node(6) = mesh->node_ptr(12);
       elem->set_node(7) = mesh->node_ptr(13);
       elem->set_node(8) = mesh->node_ptr(14);
- 
+
       //mesh->add_point( libMesh::Point(0.0,1.0),7 );
       mesh->add_point( libMesh::Point(-1.0,1.0),15 );
       mesh->add_point( libMesh::Point(-1.0,-1.0),16 );
@@ -440,9 +440,9 @@ namespace GRINSTesting
       elem->set_node(6) = mesh->node_ptr(19);
       elem->set_node(7) = mesh->node_ptr(11);
       elem->set_node(8) = mesh->node_ptr(20);
-      
+
       mesh->prepare_for_use();
-    
+
       std::unique_ptr<libMesh::EquationSystems> _es;
       _es.reset( new libMesh::EquationSystems(*mesh) );
 
@@ -487,10 +487,10 @@ namespace GRINSTesting
       CPPUNIT_ASSERT_EQUAL(2,(int)((mesh_overlap.solid_map().find(0)->second).find(2)->second).size());
 
       std::vector<unsigned int> elem1_qps(5);
-      elem1_qps[0] = 0; elem1_qps[1] = 1; elem1_qps[2] = 3; elem1_qps[3] = 4; elem1_qps[4] = 5; 
+      elem1_qps[0] = 0; elem1_qps[1] = 1; elem1_qps[2] = 3; elem1_qps[3] = 4; elem1_qps[4] = 5;
 
       std::vector<unsigned int> elem2_qps(2);
-      elem2_qps[0] = 2; elem2_qps[1] = 6; 
+      elem2_qps[0] = 2; elem2_qps[1] = 6;
 
       for( unsigned int i = 0; i < 5; i++ )
         CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.solid_map().find(0)->second).find(1)->second)[i]);
@@ -518,21 +518,21 @@ namespace GRINSTesting
     }
 
     //---------------------------------------------QUAD-ON-TRI-TEST-------------------------------------------------
- 
+
     void quad_on_tri_overlapping_test()
     {
       std::string input_file = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/overlap_variables.in";
-      
+
       std::unique_ptr<GetPot> _input;
       _input.reset( new GetPot(input_file) );
 
       std::shared_ptr<libMesh::UnstructuredMesh> mesh( new libMesh::SerialMesh(*TestCommWorld) );
-      
+
       /*
         Overlapping element in the interior(QUAD9): id = 0, node 0 = (0.5,0.5), length is 1 on each edge
-        Right interior element(TRI6): id = 1, node 0 = (1,1) 
+        Right interior element(TRI6): id = 1, node 0 = (1,1)
         Left interior element(TRI6): id = 2, node 0 = (1,1)
-        
+
         (-1,1) ---------------------- (1,1)
                |                   /|
                |                  / |
@@ -551,9 +551,9 @@ namespace GRINSTesting
                | /                  |
                |/                   |
        (-1,-1) ---------------------- (-1,1)
-      
+
       */
-      
+
       mesh->set_mesh_dimension(2);
 
       mesh->add_point( libMesh::Point(0.5,0.5),0 );
@@ -571,14 +571,14 @@ namespace GRINSTesting
       elem->subdomain_id() = 1;
       for (unsigned int n=0; n<9; n++)
         elem->set_node(n) = mesh->node_ptr(n);
-      
+
       mesh->add_point( libMesh::Point(1.0,1.0),9 );
       mesh->add_point( libMesh::Point(-1.0,-1.0),10 );
       mesh->add_point( libMesh::Point(1.0,-1.0),11 );
       mesh->add_point( libMesh::Point(0.0,0.0),12 );
       mesh->add_point( libMesh::Point(0.0,-1.0),13 );
       mesh->add_point( libMesh::Point(1.0,0.0),14 );
-      
+
       elem = mesh->add_elem( new libMesh::Tri6 );
       elem->set_id(1);
       elem->subdomain_id() = 2;
@@ -588,14 +588,14 @@ namespace GRINSTesting
       elem->set_node(3) = mesh->node_ptr(12);
       elem->set_node(4) = mesh->node_ptr(13);
       elem->set_node(5) = mesh->node_ptr(14);
-            
+
       //mesh->add_point( libMesh::Point(1.0,1.0),9 );
       mesh->add_point( libMesh::Point(-1.0,1.0),15 );
       //mesh->add_point( libMesh::Point(-1.0,-1.0),10 );
       mesh->add_point( libMesh::Point(0.0,1.0),16 );
       mesh->add_point( libMesh::Point(-1.0,0.0),17 );
       //mesh->add_point( libMesh::Point(0.0,0.0),12 );
-      
+
       elem = mesh->add_elem( new libMesh::Tri6 );
       elem->set_id(2);
       elem->subdomain_id() = 2;
@@ -605,9 +605,9 @@ namespace GRINSTesting
       elem->set_node(3) = mesh->node_ptr(16);
       elem->set_node(4) = mesh->node_ptr(17);
       elem->set_node(5) = mesh->node_ptr(12);
-            
+
       mesh->prepare_for_use();
-      
+
       std::unique_ptr<libMesh::EquationSystems> _es;
       _es.reset( new libMesh::EquationSystems(*mesh) );
 
@@ -681,13 +681,13 @@ namespace GRINSTesting
       // Clear out the VariableWarehouse so it doesn't interfere with other tests.
       GRINS::GRINSPrivate::VariableWarehouse::clear();
     }
-    
+
     //---------------------------------------------TRI-ON-TRI-TEST-------------------------------------------------
-   
+
     void tri_on_tri_overlapping_test()
     {
       std::string input_file = std::string(GRINS_TEST_UNIT_INPUT_SRCDIR)+"/overlap_variables.in";
-      
+
       std::unique_ptr<GetPot> _input;
       _input.reset( new GetPot(input_file) );
 
@@ -695,9 +695,9 @@ namespace GRINSTesting
 
       /*
         Overlapping element in the interior(TRI6): id = 0, node 0 = (0.0,0.5)
-        Right interior element(TRI6): id = 1, node 0 = (1,1) 
+        Right interior element(TRI6): id = 1, node 0 = (1,1)
         Left interior element(TRI6): id = 2, node 0 = (1,1)
-            
+
       */
 
       mesh->set_mesh_dimension(2);
@@ -738,7 +738,7 @@ namespace GRINSTesting
       mesh->add_point( libMesh::Point(0.0,1.0),13 );
       mesh->add_point( libMesh::Point(-1.0,0.0),14 );
       //mesh->add_point( libMesh::Point(0.0,0.0),9 );
-      
+
       elem = mesh->add_elem( new libMesh::Tri6 );
       elem->set_id(2);
       elem->subdomain_id() = 2;
@@ -795,10 +795,10 @@ namespace GRINSTesting
       CPPUNIT_ASSERT_EQUAL(2,(int)((mesh_overlap.solid_map().find(0)->second).find(2)->second).size());
 
       std::vector<unsigned int> elem1_qps(5);
-      elem1_qps[0] = 0; elem1_qps[1] = 1; elem1_qps[2] = 3; elem1_qps[3] = 5; elem1_qps[4] = 6; 
+      elem1_qps[0] = 0; elem1_qps[1] = 1; elem1_qps[2] = 3; elem1_qps[3] = 5; elem1_qps[4] = 6;
 
       std::vector<unsigned int> elem2_qps(2);
-      elem2_qps[0] = 2; elem2_qps[1] = 4; 
+      elem2_qps[0] = 2; elem2_qps[1] = 4;
 
       for( unsigned int i = 0; i < 5; i++ )
         CPPUNIT_ASSERT_EQUAL(elem1_qps[i],((mesh_overlap.solid_map().find(0)->second).find(1)->second)[i]);

--- a/test/unit/overlapping_fluid_solid_mesh.C
+++ b/test/unit/overlapping_fluid_solid_mesh.C
@@ -164,6 +164,20 @@ namespace GRINSTesting
       for( unsigned int i = 0; i < 3; i++ )
         CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
 
+      {
+        const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);
+        const std::vector<unsigned int> & qps2 = mesh_overlap.get_solid_qps(0,2);
+
+        CPPUNIT_ASSERT_EQUAL(6,(int)qps1.size());
+        CPPUNIT_ASSERT_EQUAL(3,(int)qps2.size());
+
+        for( unsigned int i = 0; i < 6; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem1_qps[i], qps1[i]);
+
+        for( unsigned int i = 0; i < 3; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
+      }
+
       // There should be 2 "fluid" elements, each mapping to the solid element
       CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
       CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());
@@ -332,6 +346,19 @@ namespace GRINSTesting
       for( unsigned int i = 0; i < 3; i++ )
         CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
 
+      {
+        const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);
+        const std::vector<unsigned int> & qps2 = mesh_overlap.get_solid_qps(0,2);
+
+        CPPUNIT_ASSERT_EQUAL(6,(int)qps1.size());
+        CPPUNIT_ASSERT_EQUAL(3,(int)qps2.size());
+
+        for( unsigned int i = 0; i < 6; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem1_qps[i], qps1[i]);
+
+        for( unsigned int i = 0; i < 3; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
+      }
 
       CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
       CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());
@@ -498,6 +525,19 @@ namespace GRINSTesting
       for( unsigned int i = 0; i < 2; i++ )
         CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
 
+      {
+        const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);
+        const std::vector<unsigned int> & qps2 = mesh_overlap.get_solid_qps(0,2);
+
+        CPPUNIT_ASSERT_EQUAL(5,(int)qps1.size());
+        CPPUNIT_ASSERT_EQUAL(2,(int)qps2.size());
+
+        for( unsigned int i = 0; i < 5; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem1_qps[i], qps1[i]);
+
+        for( unsigned int i = 0; i < 2; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
+      }
 
       CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
       CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());
@@ -664,6 +704,20 @@ namespace GRINSTesting
         CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
 
 
+      {
+        const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);
+        const std::vector<unsigned int> & qps2 = mesh_overlap.get_solid_qps(0,2);
+
+        CPPUNIT_ASSERT_EQUAL(6,(int)qps1.size());
+        CPPUNIT_ASSERT_EQUAL(3,(int)qps2.size());
+
+        for( unsigned int i = 0; i < 6; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem1_qps[i], qps1[i]);
+
+        for( unsigned int i = 0; i < 3; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
+      }
+
       CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
       CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());
       CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(2)->second).size());
@@ -806,6 +860,20 @@ namespace GRINSTesting
       for( unsigned int i = 0; i < 2; i++ )
         CPPUNIT_ASSERT_EQUAL(elem2_qps[i],((mesh_overlap.solid_map().find(0)->second).find(2)->second)[i]);
 
+
+      {
+        const std::vector<unsigned int> & qps1 = mesh_overlap.get_solid_qps(0,1);
+        const std::vector<unsigned int> & qps2 = mesh_overlap.get_solid_qps(0,2);
+
+        CPPUNIT_ASSERT_EQUAL(5,(int)qps1.size());
+        CPPUNIT_ASSERT_EQUAL(2,(int)qps2.size());
+
+        for( unsigned int i = 0; i < 5; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem1_qps[i], qps1[i]);
+
+        for( unsigned int i = 0; i < 2; i++ )
+          CPPUNIT_ASSERT_EQUAL(elem2_qps[i], qps2[i]);
+      }
 
       CPPUNIT_ASSERT_EQUAL(2,(int)mesh_overlap.fluid_map().size());
       CPPUNIT_ASSERT_EQUAL(1,(int)(mesh_overlap.fluid_map().find(1)->second).size());


### PR DESCRIPTION
Updated the API to be more user friendly and avoid gross data types. Also now fixed the lack of parallel syncing which was ultimately an issue downstream for getting a `GhostingFunctor` to work correctly. This uses `libMesh::Parallel::push_parallel_vector_data`, which now uses the NBX (non-blocking consensus) algorithm. We'll see if the older libMesh used the same API before this was updated on the libMesh side. If not, then we'll bump the minimum libMesh version (which we're going to do for GMG anyway). ATM, we don't have any unit testing of the parallel_sync (see #575).