### PR TITLE
Update libMesh Minimum Version, Copyright Year, Other Source Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In addition to a C++11 compiler, GRINS requires an up-to-date installation of th
 
 libMesh
 -------
-GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is 2d9b8bc, as of GRINS [PR #520](https://github.com/grinsfem/grins/pull/528).
+GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is 943d5d0 [PR #2088](https://github.com/libMesh/libmesh/pull/2088), as of GRINS [PR #577](https://github.com/grinsfem/grins/pull/577).
 GRINS release 0.5.0 can use libMesh versions as old as 0.9.4. Subsequent to
 the 0.5.0 release requires at least libMesh 1.0.0.
 

--- a/examples/cavity_benchmark/cavity.C
+++ b/examples/cavity_benchmark/cavity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/examples/elastic_sheet/displacement_continuation_solver.C
+++ b/examples/elastic_sheet/displacement_continuation_solver.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/examples/elastic_sheet/displacement_continuation_solver.h
+++ b/examples/elastic_sheet/displacement_continuation_solver.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/examples/elastic_sheet/stretching_sheet.C
+++ b/examples/elastic_sheet/stretching_sheet.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/examples/inflating_sheet/inflating_sheet.C
+++ b/examples/inflating_sheet/inflating_sheet.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/examples/inflating_sheet/pressure_continuation_solver.C
+++ b/examples/inflating_sheet/pressure_continuation_solver.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/examples/inflating_sheet/pressure_continuation_solver.h
+++ b/examples/inflating_sheet/pressure_continuation_solver.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/examples/spectroscopy/spectroscopy.C
+++ b/examples/spectroscopy/spectroscopy.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/apps/antioch_kinetic_rates.C
+++ b/src/apps/antioch_kinetic_rates.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/apps/antioch_thermo_tables.C
+++ b/src/apps/antioch_thermo_tables.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/apps/antioch_transport_values.C
+++ b/src/apps/antioch_transport_values.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/apps/cantera_kinetic_rates.C
+++ b/src/apps/cantera_kinetic_rates.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/apps/grins.C
+++ b/src/apps/grins.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/arrhenius_catalycity.h
+++ b/src/boundary_conditions/include/grins/arrhenius_catalycity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/bc_builder.h
+++ b/src/boundary_conditions/include/grins/bc_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/bc_factory_abstract.h
+++ b/src/boundary_conditions/include/grins/bc_factory_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/boundary_condition_factory_initializer.h
+++ b/src/boundary_conditions/include/grins/boundary_condition_factory_initializer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/boundary_condition_names.h
+++ b/src/boundary_conditions/include/grins/boundary_condition_names.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/catalycity_base.h
+++ b/src/boundary_conditions/include/grins/catalycity_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/catalycity_factories.h
+++ b/src/boundary_conditions/include/grins/catalycity_factories.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/catalycity_factories_old_style.h
+++ b/src/boundary_conditions/include/grins/catalycity_factories_old_style.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/catalycity_factory_abstract.h
+++ b/src/boundary_conditions/include/grins/catalycity_factory_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/catalycity_factory_old_style_base.h
+++ b/src/boundary_conditions/include/grins/catalycity_factory_old_style_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/catalytic_wall_base.h
+++ b/src/boundary_conditions/include/grins/catalytic_wall_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/catalytic_wall_neumann_bc_factory_base.h
+++ b/src/boundary_conditions/include/grins/catalytic_wall_neumann_bc_factory_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/catalytic_wall_neumann_bc_factory_common.h
+++ b/src/boundary_conditions/include/grins/catalytic_wall_neumann_bc_factory_common.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/catalytic_wall_neumann_bc_old_style_factory_base.h
+++ b/src/boundary_conditions/include/grins/catalytic_wall_neumann_bc_old_style_factory_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/constant_catalycity.h
+++ b/src/boundary_conditions/include/grins/constant_catalycity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/constant_function_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/constant_function_dirichlet_bc_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/default_bc_builder.h
+++ b/src/boundary_conditions/include/grins/default_bc_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/dirichlet_bc_factory_abstract.h
+++ b/src/boundary_conditions/include/grins/dirichlet_bc_factory_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_base.h
+++ b/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_old_style_base.h
+++ b/src/boundary_conditions/include/grins/dirichlet_bc_factory_function_old_style_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/gas_catalytic_wall_neumann_bc_factories.h
+++ b/src/boundary_conditions/include/grins/gas_catalytic_wall_neumann_bc_factories.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/gas_catalytic_wall_neumann_bc_old_style_factories.h
+++ b/src/boundary_conditions/include/grins/gas_catalytic_wall_neumann_bc_old_style_factories.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/gas_recombination_catalytic_wall.h
+++ b/src/boundary_conditions/include/grins/gas_recombination_catalytic_wall.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/gas_recombination_catalytic_wall_neumann_bc_factory_impl.h
+++ b/src/boundary_conditions/include/grins/gas_recombination_catalytic_wall_neumann_bc_factory_impl.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/gas_solid_catalytic_wall.h
+++ b/src/boundary_conditions/include/grins/gas_solid_catalytic_wall.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/gas_solid_catalytic_wall_neumann_bc_factory_impl.h
+++ b/src/boundary_conditions/include/grins/gas_solid_catalytic_wall_neumann_bc_factory_impl.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/homogeneous_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/homogeneous_dirichlet_bc_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/homogeneous_neumann_bc_factory.h
+++ b/src/boundary_conditions/include/grins/homogeneous_neumann_bc_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/isothermal_dirichlet_old_style_bc_factory.h
+++ b/src/boundary_conditions/include/grins/isothermal_dirichlet_old_style_bc_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/neumann_bc_abstract.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/neumann_bc_container.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_container.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/neumann_bc_factory_abstract.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_factory_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/neumann_bc_function_base.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_function_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/neumann_bc_old_style_factory_abstract.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_old_style_factory_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/neumann_bc_parsed.h
+++ b/src/boundary_conditions/include/grins/neumann_bc_parsed.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/old_style_bc_builder.h
+++ b/src/boundary_conditions/include/grins/old_style_bc_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/parsed_function_dirichlet_old_style_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_dirichlet_old_style_bc_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/parsed_function_factory_helper.h
+++ b/src/boundary_conditions/include/grins/parsed_function_factory_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/parsed_function_neumann_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_neumann_bc_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/parsed_function_neumann_bc_factory_helper.h
+++ b/src/boundary_conditions/include/grins/parsed_function_neumann_bc_factory_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/parsed_function_neumann_old_style_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_neumann_old_style_bc_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/parsed_function_traits.h
+++ b/src/boundary_conditions/include/grins/parsed_function_traits.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/power_law_catalycity.h
+++ b/src/boundary_conditions/include/grins/power_law_catalycity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/prescribed_vector_value_dirichlet_old_style_bc_factory.h
+++ b/src/boundary_conditions/include/grins/prescribed_vector_value_dirichlet_old_style_bc_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/pressure_pinning.h
+++ b/src/boundary_conditions/include/grins/pressure_pinning.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/include/grins/pressure_pinning.h
+++ b/src/boundary_conditions/include/grins/pressure_pinning.h
@@ -66,7 +66,7 @@ namespace GRINS
       a null space - e.g. pressure for IncompressibleNavierStokes. */
     void pin_value( libMesh::DiffContext& context,
                     const bool request_jacobian,
-                    const GRINS::VariableIndex var,
+                    const VariableIndex var,
                     const double penalty = 1.0 );
 
   private:

--- a/src/boundary_conditions/include/grins/symmetry_type_bc_factories.h
+++ b/src/boundary_conditions/include/grins/symmetry_type_bc_factories.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/arrhenius_catalycity.C
+++ b/src/boundary_conditions/src/arrhenius_catalycity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/bc_builder.C
+++ b/src/boundary_conditions/src/bc_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/boundary_condition_factory_initializer.C
+++ b/src/boundary_conditions/src/boundary_condition_factory_initializer.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/catalycity_base.C
+++ b/src/boundary_conditions/src/catalycity_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/catalycity_factory_abstract.C
+++ b/src/boundary_conditions/src/catalycity_factory_abstract.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/catalycity_factory_old_style_base.C
+++ b/src/boundary_conditions/src/catalycity_factory_old_style_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/catalytic_wall_base.C
+++ b/src/boundary_conditions/src/catalytic_wall_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/catalytic_wall_base.C
+++ b/src/boundary_conditions/src/catalytic_wall_base.C
@@ -45,7 +45,7 @@ namespace GRINS
     : _chem_ptr(chem),
       _chemistry(*(chem.get())),// This will be removed after NeumannBC refactoring
       _gamma_ptr(gamma),
-      _C( std::sqrt( chem->R(reactant_species_idx)/(GRINS::Constants::two_pi) ) ),
+      _C( std::sqrt( chem->R(reactant_species_idx)/(Constants::two_pi) ) ),
       _species_vars(species_vars),
       _T_var(T_var),
       _p0(p0)
@@ -57,7 +57,7 @@ namespace GRINS
                                                    const unsigned int reactant_species_idx )
     : _chemistry(chemistry),
       _gamma_s( gamma.clone() ),
-      _C( std::sqrt( chemistry.R(reactant_species_idx)/(GRINS::Constants::two_pi) ) )
+      _C( std::sqrt( chemistry.R(reactant_species_idx)/(Constants::two_pi) ) )
   {}
 
   template<typename Chemistry>

--- a/src/boundary_conditions/src/catalytic_wall_instantiate.C
+++ b/src/boundary_conditions/src/catalytic_wall_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/catalytic_wall_neumann_bc_factory_base.C
+++ b/src/boundary_conditions/src/catalytic_wall_neumann_bc_factory_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/catalytic_wall_neumann_bc_factory_common.C
+++ b/src/boundary_conditions/src/catalytic_wall_neumann_bc_factory_common.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/catalytic_wall_neumann_bc_factory_common.C
+++ b/src/boundary_conditions/src/catalytic_wall_neumann_bc_factory_common.C
@@ -84,7 +84,7 @@ namespace GRINS
   {
     // This will throw an error is the temperature variables are not there
     const FEVariablesBase& temp_fe_var_base =
-      GRINS::GRINSPrivate::VariableWarehouse::get_variable(VariablesParsing::temperature_section());
+      GRINSPrivate::VariableWarehouse::get_variable(VariablesParsing::temperature_section());
 
     const PrimitiveTempFEVariables& temp_fe_var =
       libMesh::cast_ref<const PrimitiveTempFEVariables&>(temp_fe_var_base);

--- a/src/boundary_conditions/src/catalytic_wall_neumann_bc_old_style_factory_base.C
+++ b/src/boundary_conditions/src/catalytic_wall_neumann_bc_old_style_factory_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/constant_catalycity.C
+++ b/src/boundary_conditions/src/constant_catalycity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/constant_function_dirichlet_bc_factory.C
+++ b/src/boundary_conditions/src/constant_function_dirichlet_bc_factory.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/default_bc_builder.C
+++ b/src/boundary_conditions/src/default_bc_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/default_bc_builder.C
+++ b/src/boundary_conditions/src/default_bc_builder.C
@@ -158,7 +158,7 @@ namespace GRINS
 
         // Grab FEVariable
         const FEVariablesBase& fe_var =
-          GRINS::GRINSPrivate::VariableWarehouse::get_variable(var_section);
+          GRINSPrivate::VariableWarehouse::get_variable(var_section);
 
         // We don't need to do anything for constraint variables
         if( fe_var.is_constraint_var() )

--- a/src/boundary_conditions/src/dirichlet_bc_factory_abstract.C
+++ b/src/boundary_conditions/src/dirichlet_bc_factory_abstract.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/dirichlet_bc_factory_function_base.C
+++ b/src/boundary_conditions/src/dirichlet_bc_factory_function_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/dirichlet_bc_factory_function_old_style_base.C
+++ b/src/boundary_conditions/src/dirichlet_bc_factory_function_old_style_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/gas_recombination_catalytic_wall.C
+++ b/src/boundary_conditions/src/gas_recombination_catalytic_wall.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/gas_recombination_catalytic_wall_neumann_bc_factory_impl.C
+++ b/src/boundary_conditions/src/gas_recombination_catalytic_wall_neumann_bc_factory_impl.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/gas_solid_catalytic_wall.C
+++ b/src/boundary_conditions/src/gas_solid_catalytic_wall.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/gas_solid_catalytic_wall_neumann_bc_factory_impl.C
+++ b/src/boundary_conditions/src/gas_solid_catalytic_wall_neumann_bc_factory_impl.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/neumann_bc_factory_abstract.C
+++ b/src/boundary_conditions/src/neumann_bc_factory_abstract.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/neumann_bc_function_base.C
+++ b/src/boundary_conditions/src/neumann_bc_function_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/neumann_bc_old_style_factory_abstract.C
+++ b/src/boundary_conditions/src/neumann_bc_old_style_factory_abstract.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/neumann_bc_parsed.C
+++ b/src/boundary_conditions/src/neumann_bc_parsed.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/old_style_bc_builder.C
+++ b/src/boundary_conditions/src/old_style_bc_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/parsed_function_dirichlet_bc_factory.C
+++ b/src/boundary_conditions/src/parsed_function_dirichlet_bc_factory.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/parsed_function_dirichlet_old_style_bc_factory.C
+++ b/src/boundary_conditions/src/parsed_function_dirichlet_old_style_bc_factory.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/parsed_function_factory_helper.C
+++ b/src/boundary_conditions/src/parsed_function_factory_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/parsed_function_neumann_bc_factory_helper.C
+++ b/src/boundary_conditions/src/parsed_function_neumann_bc_factory_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/power_law_catalycity.C
+++ b/src/boundary_conditions/src/power_law_catalycity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/prescribed_vector_value_dirichlet_old_style_bc_factory.C
+++ b/src/boundary_conditions/src/prescribed_vector_value_dirichlet_old_style_bc_factory.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/boundary_conditions/src/pressure_pinning.C
+++ b/src/boundary_conditions/src/pressure_pinning.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/common/include/grins/builder_helper.h
+++ b/src/common/include/grins/builder_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/common/include/grins/common.h
+++ b/src/common/include/grins/common.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/common/include/grins/factory_abstract.h
+++ b/src/common/include/grins/factory_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/common/include/grins/factory_with_getpot.h
+++ b/src/common/include/grins/factory_with_getpot.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/common/include/grins/factory_with_getpot_physics_name.h
+++ b/src/common/include/grins/factory_with_getpot_physics_name.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/common/src/builder_helper.C
+++ b/src/common/src/builder_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/constraints/include/grins/constrained_points.h
+++ b/src/constraints/include/grins/constrained_points.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/constraints/include/grins/constraint_builder.h
+++ b/src/constraints/include/grins/constraint_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/constraints/src/constrained_points.C
+++ b/src/constraints/src/constrained_points.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/constraints/src/constraint_builder.C
+++ b/src/constraints/src/constraint_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/ic_handling/include/grins/generic_ic_handler.h
+++ b/src/ic_handling/include/grins/generic_ic_handler.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/ic_handling/include/grins/ic_handling_base.h
+++ b/src/ic_handling/include/grins/ic_handling_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/ic_handling/src/generic_ic_handler.C
+++ b/src/ic_handling/src/generic_ic_handler.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/ic_handling/src/ic_handling_base.C
+++ b/src/ic_handling/src/ic_handling_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/antioch_instantiation_macro.h
+++ b/src/physics/include/grins/antioch_instantiation_macro.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/assembly_context.h
+++ b/src/physics/include/grins/assembly_context.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/averaged_fan.h
+++ b/src/physics/include/grins/averaged_fan.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/averaged_fan_adjoint_stab.h
+++ b/src/physics/include/grins/averaged_fan_adjoint_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/averaged_fan_base.h
+++ b/src/physics/include/grins/averaged_fan_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/averaged_turbine.h
+++ b/src/physics/include/grins/averaged_turbine.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/averaged_turbine_adjoint_stab.h
+++ b/src/physics/include/grins/averaged_turbine_adjoint_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/averaged_turbine_base.h
+++ b/src/physics/include/grins/averaged_turbine_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/axisym_boussinesq_buoyancy.h
+++ b/src/physics/include/grins/axisym_boussinesq_buoyancy.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/axisym_heat_transfer.h
+++ b/src/physics/include/grins/axisym_heat_transfer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/boussinesq_buoyancy.h
+++ b/src/physics/include/grins/boussinesq_buoyancy.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/boussinesq_buoyancy_adjoint_stab.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_adjoint_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/boussinesq_buoyancy_base.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
+++ b/src/physics/include/grins/boussinesq_buoyancy_spgsm_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/constant_source_term.h
+++ b/src/physics/include/grins/constant_source_term.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/convection_diffusion.h
+++ b/src/physics/include/grins/convection_diffusion.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/convection_diffusion.h
+++ b/src/physics/include/grins/convection_diffusion.h
@@ -41,7 +41,7 @@ namespace GRINS
   {
   public:
 
-    ConvectionDiffusion( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    ConvectionDiffusion( const PhysicsName& physics_name, const GetPot& input );
 
     virtual ~ConvectionDiffusion(){};
 

--- a/src/physics/include/grins/elastic_cable.h
+++ b/src/physics/include/grins/elastic_cable.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/elastic_cable_abstract.h
+++ b/src/physics/include/grins/elastic_cable_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/elastic_cable_abstract.h
+++ b/src/physics/include/grins/elastic_cable_abstract.h
@@ -38,7 +38,7 @@ namespace GRINS
   {
   public:
 
-    ElasticCableAbstract( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    ElasticCableAbstract( const PhysicsName& physics_name, const GetPot& input );
 
     virtual ~ElasticCableAbstract(){};
 

--- a/src/physics/include/grins/elastic_cable_base.h
+++ b/src/physics/include/grins/elastic_cable_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/elastic_cable_base.h
+++ b/src/physics/include/grins/elastic_cable_base.h
@@ -35,7 +35,7 @@ namespace GRINS
   {
   public:
 
-    ElasticCableBase( const GRINS::PhysicsName& physics_name,
+    ElasticCableBase( const PhysicsName& physics_name,
                       const GetPot& input,
                       bool is_compressible);
 

--- a/src/physics/include/grins/elastic_cable_rayleigh_damping.h
+++ b/src/physics/include/grins/elastic_cable_rayleigh_damping.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/elastic_membrane.h
+++ b/src/physics/include/grins/elastic_membrane.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/elastic_membrane.h
+++ b/src/physics/include/grins/elastic_membrane.h
@@ -36,7 +36,7 @@ namespace GRINS
   {
   public:
 
-    ElasticMembrane( const GRINS::PhysicsName& physics_name, const GetPot& input,
+    ElasticMembrane( const PhysicsName& physics_name, const GetPot& input,
                      bool is_compressible );
 
     virtual ~ElasticMembrane(){};

--- a/src/physics/include/grins/elastic_membrane_abstract.h
+++ b/src/physics/include/grins/elastic_membrane_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/elastic_membrane_abstract.h
+++ b/src/physics/include/grins/elastic_membrane_abstract.h
@@ -38,7 +38,7 @@ namespace GRINS
   {
   public:
 
-    ElasticMembraneAbstract( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    ElasticMembraneAbstract( const PhysicsName& physics_name, const GetPot& input );
 
     virtual ~ElasticMembraneAbstract(){};
 

--- a/src/physics/include/grins/elastic_membrane_base.h
+++ b/src/physics/include/grins/elastic_membrane_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/elastic_membrane_base.h
+++ b/src/physics/include/grins/elastic_membrane_base.h
@@ -35,7 +35,7 @@ namespace GRINS
   {
   public:
 
-    ElasticMembraneBase( const GRINS::PhysicsName& physics_name,
+    ElasticMembraneBase( const PhysicsName& physics_name,
                          const GetPot& input,
                          bool is_compressible);
 

--- a/src/physics/include/grins/elastic_membrane_constant_pressure.h
+++ b/src/physics/include/grins/elastic_membrane_constant_pressure.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/elastic_membrane_pressure.h
+++ b/src/physics/include/grins/elastic_membrane_pressure.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/elastic_membrane_rayleigh_damping.h
+++ b/src/physics/include/grins/elastic_membrane_rayleigh_damping.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/heat_conduction.h
+++ b/src/physics/include/grins/heat_conduction.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/heat_conduction.h
+++ b/src/physics/include/grins/heat_conduction.h
@@ -38,7 +38,7 @@ namespace GRINS
 
   public:
 
-    HeatConduction( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    HeatConduction( const PhysicsName& physics_name, const GetPot& input );
     ~HeatConduction(){};
 
     virtual void set_time_evolving_vars( libMesh::FEMSystem* system );

--- a/src/physics/include/grins/heat_transfer.h
+++ b/src/physics/include/grins/heat_transfer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/heat_transfer_adjoint_stab.h
+++ b/src/physics/include/grins/heat_transfer_adjoint_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/heat_transfer_adjoint_stab.h
+++ b/src/physics/include/grins/heat_transfer_adjoint_stab.h
@@ -38,7 +38,7 @@ namespace GRINS
 
   public:
 
-    HeatTransferAdjointStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    HeatTransferAdjointStabilization( const PhysicsName& physics_name, const GetPot& input );
     virtual ~HeatTransferAdjointStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,

--- a/src/physics/include/grins/heat_transfer_base.h
+++ b/src/physics/include/grins/heat_transfer_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/heat_transfer_spgsm_stab.h
+++ b/src/physics/include/grins/heat_transfer_spgsm_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/heat_transfer_spgsm_stab.h
+++ b/src/physics/include/grins/heat_transfer_spgsm_stab.h
@@ -38,7 +38,7 @@ namespace GRINS
 
   public:
 
-    HeatTransferSPGSMStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    HeatTransferSPGSMStabilization( const PhysicsName& physics_name, const GetPot& input );
     virtual ~HeatTransferSPGSMStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,

--- a/src/physics/include/grins/heat_transfer_stab_base.h
+++ b/src/physics/include/grins/heat_transfer_stab_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/heat_transfer_stab_base.h
+++ b/src/physics/include/grins/heat_transfer_stab_base.h
@@ -38,7 +38,7 @@ namespace GRINS
 
   public:
 
-    HeatTransferStabilizationBase( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    HeatTransferStabilizationBase( const PhysicsName& physics_name, const GetPot& input );
 
     virtual ~HeatTransferStabilizationBase(){};
 

--- a/src/physics/include/grins/heat_transfer_stab_helper.h
+++ b/src/physics/include/grins/heat_transfer_stab_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/inc_navier_stokes.h
+++ b/src/physics/include/grins/inc_navier_stokes.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/inc_navier_stokes_adjoint_stab.h
+++ b/src/physics/include/grins/inc_navier_stokes_adjoint_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/inc_navier_stokes_adjoint_stab.h
+++ b/src/physics/include/grins/inc_navier_stokes_adjoint_stab.h
@@ -37,7 +37,7 @@ namespace GRINS
 
   public:
 
-    IncompressibleNavierStokesAdjointStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    IncompressibleNavierStokesAdjointStabilization( const PhysicsName& physics_name, const GetPot& input );
     virtual ~IncompressibleNavierStokesAdjointStabilization(){};
 
     virtual void element_time_derivative( bool compute_jacobian,

--- a/src/physics/include/grins/inc_navier_stokes_base.h
+++ b/src/physics/include/grins/inc_navier_stokes_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/inc_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/inc_navier_stokes_spgsm_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/inc_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/inc_navier_stokes_spgsm_stab.h
@@ -37,7 +37,7 @@ namespace GRINS
 
   public:
 
-    IncompressibleNavierStokesSPGSMStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    IncompressibleNavierStokesSPGSMStabilization( const PhysicsName& physics_name, const GetPot& input );
     virtual ~IncompressibleNavierStokesSPGSMStabilization(){};
 
     virtual void element_time_derivative( bool compute_jacobian,

--- a/src/physics/include/grins/inc_navier_stokes_stab_base.h
+++ b/src/physics/include/grins/inc_navier_stokes_stab_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/inc_navier_stokes_stab_base.h
+++ b/src/physics/include/grins/inc_navier_stokes_stab_base.h
@@ -38,7 +38,7 @@ namespace GRINS
 
   public:
 
-    IncompressibleNavierStokesStabilizationBase( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    IncompressibleNavierStokesStabilizationBase( const PhysicsName& physics_name, const GetPot& input );
 
     virtual ~IncompressibleNavierStokesStabilizationBase();
 

--- a/src/physics/include/grins/inc_navier_stokes_stab_helper.h
+++ b/src/physics/include/grins/inc_navier_stokes_stab_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/low_mach_navier_stokes.h
+++ b/src/physics/include/grins/low_mach_navier_stokes.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/low_mach_navier_stokes_braack_stab.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_braack_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/low_mach_navier_stokes_braack_stab.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_braack_stab.h
@@ -38,7 +38,7 @@ namespace GRINS
 
   public:
 
-    LowMachNavierStokesBraackStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    LowMachNavierStokesBraackStabilization( const PhysicsName& physics_name, const GetPot& input );
     virtual ~LowMachNavierStokesBraackStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,

--- a/src/physics/include/grins/low_mach_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_spgsm_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/low_mach_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_spgsm_stab.h
@@ -37,7 +37,7 @@ namespace GRINS
 
   public:
 
-    LowMachNavierStokesSPGSMStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    LowMachNavierStokesSPGSMStabilization( const PhysicsName& physics_name, const GetPot& input );
     virtual ~LowMachNavierStokesSPGSMStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,

--- a/src/physics/include/grins/low_mach_navier_stokes_stab_base.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_stab_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/low_mach_navier_stokes_stab_base.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_stab_base.h
@@ -39,7 +39,7 @@ namespace GRINS
 
   public:
 
-    LowMachNavierStokesStabilizationBase( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    LowMachNavierStokesStabilizationBase( const PhysicsName& physics_name, const GetPot& input );
 
     virtual ~LowMachNavierStokesStabilizationBase(){};
 

--- a/src/physics/include/grins/low_mach_navier_stokes_stab_helper.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_stab_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/low_mach_navier_stokes_vms_stab.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_vms_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/low_mach_navier_stokes_vms_stab.h
+++ b/src/physics/include/grins/low_mach_navier_stokes_vms_stab.h
@@ -38,7 +38,7 @@ namespace GRINS
 
   public:
 
-    LowMachNavierStokesVMSStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    LowMachNavierStokesVMSStabilization( const PhysicsName& physics_name, const GetPot& input );
     virtual ~LowMachNavierStokesVMSStabilization();
 
     virtual void element_time_derivative( bool compute_jacobian,

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/multiphysics_sys.h
+++ b/src/physics/include/grins/multiphysics_sys.h
@@ -86,7 +86,7 @@ namespace GRINS
     //! Destructor. Clean up all physics allocations.
     ~MultiphysicsSystem(){};
 
-    //! PhysicsList gets built by GRINS::PhysicsFactory and attached here.
+    //! PhysicsList gets built by PhysicsFactory and attached here.
     void attach_physics_list( PhysicsList physics_list );
 
     const PhysicsList& get_physics_list() const
@@ -174,9 +174,9 @@ namespace GRINS
     //! Query to check if a particular physics has been enabled
     bool has_physics( const std::string physics_name ) const;
 
-    std::shared_ptr<GRINS::Physics> get_physics( const std::string physics_name );
+    std::shared_ptr<Physics> get_physics( const std::string physics_name );
 
-    std::shared_ptr<GRINS::Physics> get_physics( const std::string physics_name ) const;
+    std::shared_ptr<Physics> get_physics( const std::string physics_name ) const;
 
     virtual void compute_postprocessed_quantity( unsigned int quantity_index,
                                                  const AssemblyContext& context,
@@ -191,9 +191,9 @@ namespace GRINS
 
   private:
 
-    //! Container of pointers to GRINS::Physics classes requested at runtime.
+    //! Container of pointers to Physics classes requested at runtime.
     /*! Set using the attach_physics_list method as construction is taken care
-      of by GRINS::PhysicsFactory. */
+      of by PhysicsFactory. */
     PhysicsList _physics_list;
 
     bool _use_numerical_jacobians_only;
@@ -223,8 +223,8 @@ namespace GRINS
 
     // Useful typedef to pointer-to-member functions so we can call all
     // residual and caching functions using a single function (_general_residual)
-    typedef void (GRINS::Physics::*ResFuncType) (bool, AssemblyContext &);
-    typedef void (GRINS::Physics::*CacheFuncType) (AssemblyContext &);
+    typedef void (Physics::*ResFuncType) (bool, AssemblyContext &);
+    typedef void (Physics::*CacheFuncType) (AssemblyContext &);
 
     // Refactored residual evaluation implementation
     bool _general_residual( bool request_jacobian,
@@ -243,7 +243,7 @@ namespace GRINS
   };
 
   inline
-  std::shared_ptr<GRINS::Physics> MultiphysicsSystem::get_physics( const std::string physics_name ) const
+  std::shared_ptr<Physics> MultiphysicsSystem::get_physics( const std::string physics_name ) const
   {
     libmesh_assert(_physics_list.find( physics_name ) != _physics_list.end());
 

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/parsed_source_term.h
+++ b/src/physics/include/grins/parsed_source_term.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/parsed_velocity_source.h
+++ b/src/physics/include/grins/parsed_velocity_source.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/parsed_velocity_source_adjoint_stab.h
+++ b/src/physics/include/grins/parsed_velocity_source_adjoint_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/parsed_velocity_source_base.h
+++ b/src/physics/include/grins/parsed_velocity_source_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics.h
+++ b/src/physics/include/grins/physics.h
@@ -108,7 +108,7 @@ namespace GRINS
 
   public:
 
-    Physics( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    Physics( const PhysicsName& physics_name, const GetPot& input );
     virtual ~Physics();
 
     //! Initialize variables for this physics.
@@ -255,7 +255,7 @@ namespace GRINS
      * in trouble. */
     const PhysicsName _physics_name;
 
-    GRINS::ICHandlingBase* _ic_handler;
+    ICHandlingBase* _ic_handler;
 
     //! Subdomains on which the current Physics class is enabled
     std::set<libMesh::subdomain_id_type> _enabled_subdomains;

--- a/src/physics/include/grins/physics_builder.h
+++ b/src/physics/include/grins/physics_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_base.h
+++ b/src/physics/include/grins/physics_factory_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_basic.h
+++ b/src/physics/include/grins/physics_factory_basic.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_heat_transfer.h
+++ b/src/physics/include/grins/physics_factory_heat_transfer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_incompressible_flow.h
+++ b/src/physics/include/grins/physics_factory_incompressible_flow.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_incompressible_turb_flow.h
+++ b/src/physics/include/grins/physics_factory_incompressible_turb_flow.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_initializer.h
+++ b/src/physics/include/grins/physics_factory_initializer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_one_d_stress_solids.h
+++ b/src/physics/include/grins/physics_factory_one_d_stress_solids.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_plane_stress_solids.h
+++ b/src/physics/include/grins/physics_factory_plane_stress_solids.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_reacting_flows.h
+++ b/src/physics/include/grins/physics_factory_reacting_flows.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_reacting_flows.h
+++ b/src/physics/include/grins/physics_factory_reacting_flows.h
@@ -163,7 +163,7 @@ namespace GRINS
     {
       AntiochConstantTransportMixtureBuilder mix_builder;
 
-      std::unique_ptr<GRINS::AntiochConstantTransportMixture<KineticsThermo,Conductivity> >
+      std::unique_ptr<AntiochConstantTransportMixture<KineticsThermo,Conductivity> >
         gas_mixture = mix_builder.build_mixture<KineticsThermo,Conductivity>(input,material);
 
       new_physics.reset(new DerivedPhysics<AntiochConstantTransportMixture<KineticsThermo,Conductivity>,

--- a/src/physics/include/grins/physics_factory_variable_density_flow.h
+++ b/src/physics/include/grins/physics_factory_variable_density_flow.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_factory_with_core.h
+++ b/src/physics/include/grins/physics_factory_with_core.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/physics_naming.h
+++ b/src/physics/include/grins/physics_naming.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_abstract.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_spgsm_stab.h
@@ -35,7 +35,7 @@ namespace GRINS
   {
   public:
 
-    ReactingLowMachNavierStokesSPGSMStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input,
+    ReactingLowMachNavierStokesSPGSMStabilization( const PhysicsName& physics_name, const GetPot& input,
                                                    std::unique_ptr<Mixture> & gas_mix);
     virtual ~ReactingLowMachNavierStokesSPGSMStabilization(){};
 

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_base.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_base.h
@@ -39,7 +39,7 @@ namespace GRINS
 
   public:
 
-    ReactingLowMachNavierStokesStabilizationBase( const GRINS::PhysicsName& physics_name, const GetPot& input,
+    ReactingLowMachNavierStokesStabilizationBase( const PhysicsName& physics_name, const GetPot& input,
                                                   std::unique_ptr<Mixture> & gas_mix);
 
     virtual ~ReactingLowMachNavierStokesStabilizationBase(){};

--- a/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_helper.h
+++ b/src/physics/include/grins/reacting_low_mach_navier_stokes_stab_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/scalar_ode.h
+++ b/src/physics/include/grins/scalar_ode.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/solid_mechanics_abstract.h
+++ b/src/physics/include/grins/solid_mechanics_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/solid_mechanics_abstract.h
+++ b/src/physics/include/grins/solid_mechanics_abstract.h
@@ -38,7 +38,7 @@ namespace GRINS
   {
   public:
 
-    SolidMechanicsAbstract( const GRINS::PhysicsName& physics_name,
+    SolidMechanicsAbstract( const PhysicsName& physics_name,
                             const GetPot& input );
 
     virtual ~SolidMechanicsAbstract(){};

--- a/src/physics/include/grins/source_term_base.h
+++ b/src/physics/include/grins/source_term_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/spalart_allmaras.h
+++ b/src/physics/include/grins/spalart_allmaras.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/spalart_allmaras_helper.h
+++ b/src/physics/include/grins/spalart_allmaras_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/spalart_allmaras_parameters.h
+++ b/src/physics/include/grins/spalart_allmaras_parameters.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/spalart_allmaras_spgsm_stab.h
+++ b/src/physics/include/grins/spalart_allmaras_spgsm_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/spalart_allmaras_spgsm_stab.h
+++ b/src/physics/include/grins/spalart_allmaras_spgsm_stab.h
@@ -38,7 +38,7 @@ namespace GRINS
 
   public:
 
-    SpalartAllmarasSPGSMStabilization( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    SpalartAllmarasSPGSMStabilization( const PhysicsName& physics_name, const GetPot& input );
     virtual ~SpalartAllmarasSPGSMStabilization(){};
 
     virtual void init_variables( libMesh::FEMSystem* system );

--- a/src/physics/include/grins/spalart_allmaras_stab_base.h
+++ b/src/physics/include/grins/spalart_allmaras_stab_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/spalart_allmaras_stab_base.h
+++ b/src/physics/include/grins/spalart_allmaras_stab_base.h
@@ -38,7 +38,7 @@ namespace GRINS
 
   public:
 
-    SpalartAllmarasStabilizationBase( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    SpalartAllmarasStabilizationBase( const PhysicsName& physics_name, const GetPot& input );
 
     virtual ~SpalartAllmarasStabilizationBase(){};
 

--- a/src/physics/include/grins/spalart_allmaras_stab_helper.h
+++ b/src/physics/include/grins/spalart_allmaras_stab_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/stab_helper.h
+++ b/src/physics/include/grins/stab_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/stokes.h
+++ b/src/physics/include/grins/stokes.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/turbulence_models_base.h
+++ b/src/physics/include/grins/turbulence_models_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/var_typedefs.h
+++ b/src/physics/include/grins/var_typedefs.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/var_typedefs.h
+++ b/src/physics/include/grins/var_typedefs.h
@@ -55,11 +55,11 @@ namespace GRINS
   /*! We make it a short int to be compatible with libMesh */
   typedef libMesh::boundary_id_type BoundaryID;
 
-  //! Container for GRINS::Physics object pointers
-  typedef std::map< std::string,std::shared_ptr<GRINS::Physics> > PhysicsList;
+  //! Container for Physics object pointers
+  typedef std::map< std::string,std::shared_ptr<Physics> > PhysicsList;
 
   //! Iterator for PhysicsList
-  typedef std::map< std::string,std::shared_ptr<GRINS::Physics> >::const_iterator PhysicsListIter;
+  typedef std::map< std::string,std::shared_ptr<Physics> >::const_iterator PhysicsListIter;
 
 }
 #endif //GRINS_VAR_TYPEDEFS_H

--- a/src/physics/include/grins/variable_pinning.h
+++ b/src/physics/include/grins/variable_pinning.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/variable_pinning.h
+++ b/src/physics/include/grins/variable_pinning.h
@@ -37,7 +37,7 @@ namespace GRINS
 
   public:
 
-    VariablePinning( const GRINS::PhysicsName& physics_name, const GetPot& input );
+    VariablePinning( const PhysicsName& physics_name, const GetPot& input );
     ~VariablePinning(){};
 
     //! Initialize context for added physics variables

--- a/src/physics/include/grins/velocity_drag.h
+++ b/src/physics/include/grins/velocity_drag.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/velocity_drag_adjoint_stab.h
+++ b/src/physics/include/grins/velocity_drag_adjoint_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/velocity_drag_base.h
+++ b/src/physics/include/grins/velocity_drag_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/velocity_penalty.h
+++ b/src/physics/include/grins/velocity_penalty.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/velocity_penalty_adjoint_stab.h
+++ b/src/physics/include/grins/velocity_penalty_adjoint_stab.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/include/grins/velocity_penalty_base.h
+++ b/src/physics/include/grins/velocity_penalty_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/assembly_context.C
+++ b/src/physics/src/assembly_context.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/averaged_fan.C
+++ b/src/physics/src/averaged_fan.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/averaged_fan_adjoint_stab.C
+++ b/src/physics/src/averaged_fan_adjoint_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/averaged_fan_base.C
+++ b/src/physics/src/averaged_fan_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/averaged_turbine.C
+++ b/src/physics/src/averaged_turbine.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/averaged_turbine_adjoint_stab.C
+++ b/src/physics/src/averaged_turbine_adjoint_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/averaged_turbine_base.C
+++ b/src/physics/src/averaged_turbine_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/axisym_boussinesq_buoyancy.C
+++ b/src/physics/src/axisym_boussinesq_buoyancy.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/axisym_heat_transfer.C
+++ b/src/physics/src/axisym_heat_transfer.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/boussinesq_buoyancy.C
+++ b/src/physics/src/boussinesq_buoyancy.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_adjoint_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/boussinesq_buoyancy_base.C
+++ b/src/physics/src/boussinesq_buoyancy_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
+++ b/src/physics/src/boussinesq_buoyancy_spgsm_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/constant_source_term.C
+++ b/src/physics/src/constant_source_term.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/convection_diffusion.C
+++ b/src/physics/src/convection_diffusion.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/convection_diffusion.C
+++ b/src/physics/src/convection_diffusion.C
@@ -42,7 +42,7 @@
 
 namespace GRINS
 {
-  ConvectionDiffusion::ConvectionDiffusion( const GRINS::PhysicsName& physics_name,
+  ConvectionDiffusion::ConvectionDiffusion( const PhysicsName& physics_name,
                                             const GetPot& input )
     : Physics(physics_name,input),
       _v(3,libMesh::ParsedFunction<libMesh::Number>("0.0") ),

--- a/src/physics/src/elastic_cable.C
+++ b/src/physics/src/elastic_cable.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/elastic_cable_abstract.C
+++ b/src/physics/src/elastic_cable_abstract.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/elastic_cable_base.C
+++ b/src/physics/src/elastic_cable_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/elastic_cable_rayleigh_damping.C
+++ b/src/physics/src/elastic_cable_rayleigh_damping.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/elastic_membrane.C
+++ b/src/physics/src/elastic_membrane.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/elastic_membrane.C
+++ b/src/physics/src/elastic_membrane.C
@@ -44,7 +44,7 @@
 namespace GRINS
 {
   template<typename StressStrainLaw>
-  ElasticMembrane<StressStrainLaw>::ElasticMembrane( const GRINS::PhysicsName& physics_name, const GetPot& input,
+  ElasticMembrane<StressStrainLaw>::ElasticMembrane( const PhysicsName& physics_name, const GetPot& input,
                                                      bool is_compressible )
     : ElasticMembraneBase<StressStrainLaw>(physics_name,input,is_compressible)
   {

--- a/src/physics/src/elastic_membrane_abstract.C
+++ b/src/physics/src/elastic_membrane_abstract.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/elastic_membrane_base.C
+++ b/src/physics/src/elastic_membrane_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/elastic_membrane_base.C
+++ b/src/physics/src/elastic_membrane_base.C
@@ -38,7 +38,7 @@
 namespace GRINS
 {
   template<typename StressStrainLaw>
-  ElasticMembraneBase<StressStrainLaw>::ElasticMembraneBase( const GRINS::PhysicsName& physics_name,
+  ElasticMembraneBase<StressStrainLaw>::ElasticMembraneBase( const PhysicsName& physics_name,
                                                              const GetPot& input,
                                                              bool is_compressible )
     : ElasticMembraneAbstract(physics_name,input),

--- a/src/physics/src/elastic_membrane_pressure.C
+++ b/src/physics/src/elastic_membrane_pressure.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/elastic_membrane_rayleigh_damping.C
+++ b/src/physics/src/elastic_membrane_rayleigh_damping.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/heat_conduction.C
+++ b/src/physics/src/heat_conduction.C
@@ -44,7 +44,7 @@ namespace GRINS
 {
 
   template<class K>
-  HeatConduction<K>::HeatConduction( const GRINS::PhysicsName& physics_name, const GetPot& input )
+  HeatConduction<K>::HeatConduction( const PhysicsName& physics_name, const GetPot& input )
     : Physics(physics_name,input),
       _temp_vars(GRINSPrivate::VariableWarehouse::get_variable_subclass<PrimitiveTempFEVariables>(VariablesParsing::temp_variable_name(input,physics_name,VariablesParsing::PHYSICS))),
       _rho(0.0),

--- a/src/physics/src/heat_transfer.C
+++ b/src/physics/src/heat_transfer.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/heat_transfer_adjoint_stab.C
+++ b/src/physics/src/heat_transfer_adjoint_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/heat_transfer_base.C
+++ b/src/physics/src/heat_transfer_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/heat_transfer_spgsm_stab.C
+++ b/src/physics/src/heat_transfer_spgsm_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/heat_transfer_stab_base.C
+++ b/src/physics/src/heat_transfer_stab_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/heat_transfer_stab_helper.C
+++ b/src/physics/src/heat_transfer_stab_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/inc_navier_stokes.C
+++ b/src/physics/src/inc_navier_stokes.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/inc_navier_stokes_adjoint_stab.C
+++ b/src/physics/src/inc_navier_stokes_adjoint_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/inc_navier_stokes_base.C
+++ b/src/physics/src/inc_navier_stokes_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/inc_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/inc_navier_stokes_spgsm_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/inc_navier_stokes_stab_base.C
+++ b/src/physics/src/inc_navier_stokes_stab_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/inc_navier_stokes_stab_helper.C
+++ b/src/physics/src/inc_navier_stokes_stab_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/low_mach_navier_stokes.C
+++ b/src/physics/src/low_mach_navier_stokes.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/low_mach_navier_stokes_base.C
+++ b/src/physics/src/low_mach_navier_stokes_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/low_mach_navier_stokes_braack_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_braack_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_spgsm_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/low_mach_navier_stokes_stab_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/low_mach_navier_stokes_stab_helper.C
+++ b/src/physics/src/low_mach_navier_stokes_stab_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/low_mach_navier_stokes_vms_stab.C
+++ b/src/physics/src/low_mach_navier_stokes_vms_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -335,8 +335,8 @@ namespace GRINS
     return this->_general_residual
       (request_jacobian,
        context,
-       &GRINS::Physics::element_time_derivative,
-       &GRINS::Physics::compute_element_time_derivative_cache);
+       &Physics::element_time_derivative,
+       &Physics::compute_element_time_derivative_cache);
   }
 
   bool MultiphysicsSystem::side_time_derivative( bool request_jacobian,
@@ -349,8 +349,8 @@ namespace GRINS
       this->_general_residual
       (request_jacobian,
        context,
-       &GRINS::Physics::side_time_derivative,
-       &GRINS::Physics::compute_side_time_derivative_cache);
+       &Physics::side_time_derivative,
+       &Physics::compute_side_time_derivative_cache);
 
     return jacobian_computed;
   }
@@ -361,8 +361,8 @@ namespace GRINS
     return this->_general_residual
       (request_jacobian,
        context,
-       &GRINS::Physics::nonlocal_time_derivative,
-       &GRINS::Physics::compute_nonlocal_time_derivative_cache);
+       &Physics::nonlocal_time_derivative,
+       &Physics::compute_nonlocal_time_derivative_cache);
   }
 
   bool MultiphysicsSystem::element_constraint( bool request_jacobian,
@@ -371,8 +371,8 @@ namespace GRINS
     return this->_general_residual
       (request_jacobian,
        context,
-       &GRINS::Physics::element_constraint,
-       &GRINS::Physics::compute_element_constraint_cache);
+       &Physics::element_constraint,
+       &Physics::compute_element_constraint_cache);
   }
 
   bool MultiphysicsSystem::side_constraint( bool request_jacobian,
@@ -381,8 +381,8 @@ namespace GRINS
     return this->_general_residual
       (request_jacobian,
        context,
-       &GRINS::Physics::side_constraint,
-       &GRINS::Physics::compute_side_constraint_cache);
+       &Physics::side_constraint,
+       &Physics::compute_side_constraint_cache);
   }
 
   bool MultiphysicsSystem::nonlocal_constraint( bool request_jacobian,
@@ -391,8 +391,8 @@ namespace GRINS
     return this->_general_residual
       (request_jacobian,
        context,
-       &GRINS::Physics::nonlocal_constraint,
-       &GRINS::Physics::compute_nonlocal_constraint_cache);
+       &Physics::nonlocal_constraint,
+       &Physics::compute_nonlocal_constraint_cache);
   }
 
   bool MultiphysicsSystem::damping_residual( bool request_jacobian,
@@ -401,8 +401,8 @@ namespace GRINS
     return this->_general_residual
       (request_jacobian,
        context,
-       &GRINS::Physics::damping_residual,
-       &GRINS::Physics::compute_damping_residual_cache);
+       &Physics::damping_residual,
+       &Physics::compute_damping_residual_cache);
   }
 
   bool MultiphysicsSystem::mass_residual( bool request_jacobian,
@@ -411,8 +411,8 @@ namespace GRINS
     return this->_general_residual
       (request_jacobian,
        context,
-       &GRINS::Physics::mass_residual,
-       &GRINS::Physics::compute_mass_residual_cache);
+       &Physics::mass_residual,
+       &Physics::compute_mass_residual_cache);
   }
 
   bool MultiphysicsSystem::nonlocal_mass_residual( bool request_jacobian,
@@ -421,8 +421,8 @@ namespace GRINS
     return this->_general_residual
       (request_jacobian,
        context,
-       &GRINS::Physics::nonlocal_mass_residual,
-       &GRINS::Physics::compute_nonlocal_mass_residual_cache);
+       &Physics::nonlocal_mass_residual,
+       &Physics::compute_nonlocal_mass_residual_cache);
   }
 
   std::shared_ptr<Physics> MultiphysicsSystem::get_physics( const std::string physics_name )

--- a/src/physics/src/nonlinear_elasticity_instantiate.C
+++ b/src/physics/src/nonlinear_elasticity_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/parsed_source_term.C
+++ b/src/physics/src/parsed_source_term.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/parsed_velocity_source.C
+++ b/src/physics/src/parsed_velocity_source.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/parsed_velocity_source_adjoint_stab.C
+++ b/src/physics/src/parsed_velocity_source_adjoint_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/parsed_velocity_source_base.C
+++ b/src/physics/src/parsed_velocity_source_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/physics.C
+++ b/src/physics/src/physics.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/physics_builder.C
+++ b/src/physics/src/physics_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/physics_factory_base.C
+++ b/src/physics/src/physics_factory_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/physics_factory_initializer.C
+++ b/src/physics/src/physics_factory_initializer.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/physics_factory_with_core.C
+++ b/src/physics/src/physics_factory_with_core.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/physics_naming.C
+++ b/src/physics/src/physics_naming.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/reacting_low_mach_navier_stokes.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_abstract.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/reacting_low_mach_navier_stokes_instantiate.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_spgsm_stab.C
@@ -35,7 +35,7 @@ namespace GRINS
 {
   template<typename Mixture, typename Evaluator>
   ReactingLowMachNavierStokesSPGSMStabilization<Mixture,Evaluator>::ReactingLowMachNavierStokesSPGSMStabilization
-  ( const GRINS::PhysicsName& physics_name, const GetPot& input,std::unique_ptr<Mixture> & gas_mix )
+  ( const PhysicsName& physics_name, const GetPot& input,std::unique_ptr<Mixture> & gas_mix )
     : ReactingLowMachNavierStokesStabilizationBase<Mixture,Evaluator>(physics_name,input,gas_mix)
   {}
 

--- a/src/physics/src/reacting_low_mach_navier_stokes_stab_base.C
+++ b/src/physics/src/reacting_low_mach_navier_stokes_stab_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/scalar_ode.C
+++ b/src/physics/src/scalar_ode.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/solid_mechanics_abstract.C
+++ b/src/physics/src/solid_mechanics_abstract.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/source_term_base.C
+++ b/src/physics/src/source_term_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/spalart_allmaras_helper.C
+++ b/src/physics/src/spalart_allmaras_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/spalart_allmaras_parameters.C
+++ b/src/physics/src/spalart_allmaras_parameters.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/spalart_allmaras_spgsm_stab.C
+++ b/src/physics/src/spalart_allmaras_spgsm_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/spalart_allmaras_stab_base.C
+++ b/src/physics/src/spalart_allmaras_stab_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/spalart_allmaras_stab_helper.C
+++ b/src/physics/src/spalart_allmaras_stab_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/stab_helper.C
+++ b/src/physics/src/stab_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/stokes.C
+++ b/src/physics/src/stokes.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/turbulence_models_base.C
+++ b/src/physics/src/turbulence_models_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/variable_pinning.C
+++ b/src/physics/src/variable_pinning.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/variable_pinning.C
+++ b/src/physics/src/variable_pinning.C
@@ -36,7 +36,7 @@
 namespace GRINS
 {
 
-  VariablePinning::VariablePinning( const GRINS::PhysicsName& physics_name, const GetPot& input )
+  VariablePinning::VariablePinning( const PhysicsName& physics_name, const GetPot& input )
     : Physics(physics_name,input),
       _var_pinning(input,physics_name),
       _penalty(input("Physics/" + PhysicsNaming::variable_pinning() + "/penalty", 1e10)),

--- a/src/physics/src/velocity_drag.C
+++ b/src/physics/src/velocity_drag.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/velocity_drag_adjoint_stab.C
+++ b/src/physics/src/velocity_drag_adjoint_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/velocity_drag_base.C
+++ b/src/physics/src/velocity_drag_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/velocity_penalty.C
+++ b/src/physics/src/velocity_penalty.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/velocity_penalty_adjoint_stab.C
+++ b/src/physics/src/velocity_penalty_adjoint_stab.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/physics/src/velocity_penalty_base.C
+++ b/src/physics/src/velocity_penalty_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_chemistry.h
+++ b/src/properties/include/grins/antioch_chemistry.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_constant_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_constant_transport_evaluator.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_constant_transport_mixture.h
+++ b/src/properties/include/grins/antioch_constant_transport_mixture.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_constant_transport_mixture_builder.h
+++ b/src/properties/include/grins/antioch_constant_transport_mixture_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_evaluator.h
+++ b/src/properties/include/grins/antioch_evaluator.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_kinetics.h
+++ b/src/properties/include/grins/antioch_kinetics.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_mixture.h
+++ b/src/properties/include/grins/antioch_mixture.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_evaluator.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_mixture.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_mixture_averaged_transport_mixture_builder.h
+++ b/src/properties/include/grins/antioch_mixture_averaged_transport_mixture_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_mixture_builder_base.h
+++ b/src/properties/include/grins/antioch_mixture_builder_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_options_naming.h
+++ b/src/properties/include/grins/antioch_options_naming.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/antioch_thermo_curve_fit_instantiation_macro.h
+++ b/src/properties/include/grins/antioch_thermo_curve_fit_instantiation_macro.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/cantera_evaluator.h
+++ b/src/properties/include/grins/cantera_evaluator.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/cantera_kinetics.h
+++ b/src/properties/include/grins/cantera_kinetics.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/cantera_mixture.h
+++ b/src/properties/include/grins/cantera_mixture.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/cantera_thermo.h
+++ b/src/properties/include/grins/cantera_thermo.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/cantera_transport.h
+++ b/src/properties/include/grins/cantera_transport.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/chemistry_builder.h
+++ b/src/properties/include/grins/chemistry_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/constant_conductivity.h
+++ b/src/properties/include/grins/constant_conductivity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/constant_prandtl_conductivity.h
+++ b/src/properties/include/grins/constant_prandtl_conductivity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/constant_pressure.h
+++ b/src/properties/include/grins/constant_pressure.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/constant_property_base.h
+++ b/src/properties/include/grins/constant_property_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/constant_source_func.h
+++ b/src/properties/include/grins/constant_source_func.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/constant_specific_heat.h
+++ b/src/properties/include/grins/constant_specific_heat.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/constant_viscosity.h
+++ b/src/properties/include/grins/constant_viscosity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/elasticity_tensor.h
+++ b/src/properties/include/grins/elasticity_tensor.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/gas_mixture.h
+++ b/src/properties/include/grins/gas_mixture.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/hookes_law.h
+++ b/src/properties/include/grins/hookes_law.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/hookes_law_1d.h
+++ b/src/properties/include/grins/hookes_law_1d.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/hyperelastic_strain_energy.h
+++ b/src/properties/include/grins/hyperelastic_strain_energy.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/hyperelasticity.h
+++ b/src/properties/include/grins/hyperelasticity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/incompressible_plane_stress_hyperelasticity.h
+++ b/src/properties/include/grins/incompressible_plane_stress_hyperelasticity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/materials_parsing.h
+++ b/src/properties/include/grins/materials_parsing.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/mooney_rivlin.h
+++ b/src/properties/include/grins/mooney_rivlin.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/parsed_conductivity.h
+++ b/src/properties/include/grins/parsed_conductivity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/parsed_pressure.h
+++ b/src/properties/include/grins/parsed_pressure.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/parsed_property_base.h
+++ b/src/properties/include/grins/parsed_property_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/parsed_viscosity.h
+++ b/src/properties/include/grins/parsed_viscosity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/property_base.h
+++ b/src/properties/include/grins/property_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/property_types.h
+++ b/src/properties/include/grins/property_types.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/spalart_allmaras_viscosity.h
+++ b/src/properties/include/grins/spalart_allmaras_viscosity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/stress_strain_law.h
+++ b/src/properties/include/grins/stress_strain_law.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/include/grins/viscosity_base.h
+++ b/src/properties/include/grins/viscosity_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_chemistry.C
+++ b/src/properties/src/antioch_chemistry.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_constant_transport_evaluator.C
+++ b/src/properties/src/antioch_constant_transport_evaluator.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_constant_transport_instantiate.C
+++ b/src/properties/src/antioch_constant_transport_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_constant_transport_mixture.C
+++ b/src/properties/src/antioch_constant_transport_mixture.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_evaluator.C
+++ b/src/properties/src/antioch_evaluator.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_evaluator_instantiate.C
+++ b/src/properties/src/antioch_evaluator_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_kinetics.C
+++ b/src/properties/src/antioch_kinetics.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_kinetics_instantiate.C
+++ b/src/properties/src/antioch_kinetics_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_mixture.C
+++ b/src/properties/src/antioch_mixture.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_evaluator.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_mixture_averaged_transport_evaluator_instantiate.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_evaluator_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_mixture_averaged_transport_mixture.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_mixture.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_mixture_averaged_transport_mixture_builder.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_mixture_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_mixture_averaged_transport_mixture_instantiate.C
+++ b/src/properties/src/antioch_mixture_averaged_transport_mixture_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_mixture_builder_base.C
+++ b/src/properties/src/antioch_mixture_builder_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/antioch_mixture_instantiate.C
+++ b/src/properties/src/antioch_mixture_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/cantera_evaluator.C
+++ b/src/properties/src/cantera_evaluator.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/cantera_kinetics.C
+++ b/src/properties/src/cantera_kinetics.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/cantera_mixture.C
+++ b/src/properties/src/cantera_mixture.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/cantera_thermo.C
+++ b/src/properties/src/cantera_thermo.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/cantera_transport.C
+++ b/src/properties/src/cantera_transport.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/chemistry_builder.C
+++ b/src/properties/src/chemistry_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/constant_conductivity.C
+++ b/src/properties/src/constant_conductivity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/constant_prandtl_conductivity.C
+++ b/src/properties/src/constant_prandtl_conductivity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/constant_source_func.C
+++ b/src/properties/src/constant_source_func.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/constant_specific_heat.C
+++ b/src/properties/src/constant_specific_heat.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/constant_viscosity.C
+++ b/src/properties/src/constant_viscosity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/gas_mixture.C
+++ b/src/properties/src/gas_mixture.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/hookes_law.C
+++ b/src/properties/src/hookes_law.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/hookes_law_1d.C
+++ b/src/properties/src/hookes_law_1d.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/hyperelasticity.C
+++ b/src/properties/src/hyperelasticity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/hyperelasticity_instantiate.C
+++ b/src/properties/src/hyperelasticity_instantiate.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/incompressible_plane_stress_hyperelasticity.C
+++ b/src/properties/src/incompressible_plane_stress_hyperelasticity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/materials_parsing.C
+++ b/src/properties/src/materials_parsing.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/mooney_rivlin.C
+++ b/src/properties/src/mooney_rivlin.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/parsed_viscosity.C
+++ b/src/properties/src/parsed_viscosity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/properties/src/viscosity_base.C
+++ b/src/properties/src/viscosity_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/absorption_coeff.h
+++ b/src/qoi/include/grins/absorption_coeff.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/absorption_coeff_base.h
+++ b/src/qoi/include/grins/absorption_coeff_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/average_nusselt_number.h
+++ b/src/qoi/include/grins/average_nusselt_number.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/collimated_gaussian_laser_intensity_profile.h
+++ b/src/qoi/include/grins/collimated_gaussian_laser_intensity_profile.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/composite_qoi.h
+++ b/src/qoi/include/grins/composite_qoi.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/constant_laser_intensity_profile.h
+++ b/src/qoi/include/grins/constant_laser_intensity_profile.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/fem_function_and_derivative_base.h
+++ b/src/qoi/include/grins/fem_function_and_derivative_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/hitran.h
+++ b/src/qoi/include/grins/hitran.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/integrated_function.h
+++ b/src/qoi/include/grins/integrated_function.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/laser_absorption.h
+++ b/src/qoi/include/grins/laser_absorption.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/laser_intensity_profile_base.h
+++ b/src/qoi/include/grins/laser_intensity_profile_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/multi_qoi_base.h
+++ b/src/qoi/include/grins/multi_qoi_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/parsed_boundary_qoi.h
+++ b/src/qoi/include/grins/parsed_boundary_qoi.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/parsed_interior_qoi.h
+++ b/src/qoi/include/grins/parsed_interior_qoi.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/qoi_base.h
+++ b/src/qoi/include/grins/qoi_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/qoi_factory.h
+++ b/src/qoi/include/grins/qoi_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/qoi_names.h
+++ b/src/qoi/include/grins/qoi_names.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/qoi_options.h
+++ b/src/qoi/include/grins/qoi_options.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/qoi_output.h
+++ b/src/qoi/include/grins/qoi_output.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/rayfire_mesh.h
+++ b/src/qoi/include/grins/rayfire_mesh.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/spectroscopic_absorption.h
+++ b/src/qoi/include/grins/spectroscopic_absorption.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/spectroscopic_qoi_base.h
+++ b/src/qoi/include/grins/spectroscopic_qoi_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/spectroscopic_transmission.h
+++ b/src/qoi/include/grins/spectroscopic_transmission.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/vorticity.h
+++ b/src/qoi/include/grins/vorticity.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/include/grins/weighted_flux_qoi.h
+++ b/src/qoi/include/grins/weighted_flux_qoi.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/average_nusselt_number.C
+++ b/src/qoi/src/average_nusselt_number.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/collimated_gaussian_laser_intensity_profile.C
+++ b/src/qoi/src/collimated_gaussian_laser_intensity_profile.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/composite_qoi.C
+++ b/src/qoi/src/composite_qoi.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/constant_laser_intensity_profile.C
+++ b/src/qoi/src/constant_laser_intensity_profile.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/hitran.C
+++ b/src/qoi/src/hitran.C
@@ -4,7 +4,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/hitran.C
+++ b/src/qoi/src/hitran.C
@@ -75,7 +75,7 @@ namespace GRINS
 
         std::vector<libMesh::Real> vals;
 
-        GRINS::StringUtilities::split_string_real(line,",",vals);
+        StringUtilities::split_string_real(line,",",vals);
 
         libmesh_assert_equal_to(vals.size(),8);
 
@@ -131,7 +131,7 @@ namespace GRINS
 
         _qT.push_back(std::vector<libMesh::Real>());
 
-        GRINS::StringUtilities::split_string_real(line,",",_qT[counter]);
+        StringUtilities::split_string_real(line,",",_qT[counter]);
 
         // we should have a partition function value for each temperature
         libmesh_assert_equal_to(num_T,_qT[counter].size());

--- a/src/qoi/src/integrated_function.C
+++ b/src/qoi/src/integrated_function.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/laser_absorption.C
+++ b/src/qoi/src/laser_absorption.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/laser_intensity_profile_base.C
+++ b/src/qoi/src/laser_intensity_profile_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/multi_qoi_base.C
+++ b/src/qoi/src/multi_qoi_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/parsed_boundary_qoi.C
+++ b/src/qoi/src/parsed_boundary_qoi.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/parsed_interior_qoi.C
+++ b/src/qoi/src/parsed_interior_qoi.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/qoi_base.C
+++ b/src/qoi/src/qoi_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/qoi_factory.C
+++ b/src/qoi/src/qoi_factory.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/qoi_output.C
+++ b/src/qoi/src/qoi_output.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/spectroscopic_absorption.C
+++ b/src/qoi/src/spectroscopic_absorption.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/spectroscopic_qoi_base.C
+++ b/src/qoi/src/spectroscopic_qoi_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/spectroscopic_transmission.C
+++ b/src/qoi/src/spectroscopic_transmission.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/vorticity.C
+++ b/src/qoi/src/vorticity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/qoi/src/weighted_flux_qoi.C
+++ b/src/qoi/src/weighted_flux_qoi.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/diff_solver_factory.h
+++ b/src/solver/include/grins/diff_solver_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/diff_solver_factory_initializer.h
+++ b/src/solver/include/grins/diff_solver_factory_initializer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/diff_solver_names.h
+++ b/src/solver/include/grins/diff_solver_names.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/mesh_adaptive_solver_base.h
+++ b/src/solver/include/grins/mesh_adaptive_solver_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/mesh_builder.h
+++ b/src/solver/include/grins/mesh_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/nonlinear_solver_options.h
+++ b/src/solver/include/grins/nonlinear_solver_options.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/parameter_manager.h
+++ b/src/solver/include/grins/parameter_manager.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/parameter_manager.h
+++ b/src/solver/include/grins/parameter_manager.h
@@ -52,8 +52,8 @@ namespace GRINS
 
     virtual void initialize( const GetPot& input,
                              const std::string & parameters_varname,
-                             GRINS::MultiphysicsSystem & system,
-                             GRINS::CompositeQoI * qoi);
+                             MultiphysicsSystem & system,
+                             CompositeQoI * qoi);
 
     /*
      * Ordered list of names of independent parameters to study

--- a/src/solver/include/grins/parameter_user.h
+++ b/src/solver/include/grins/parameter_user.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/runner.h
+++ b/src/solver/include/grins/runner.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/simulation.h
+++ b/src/solver/include/grins/simulation.h
@@ -115,15 +115,15 @@ namespace GRINS
 
     std::shared_ptr<libMesh::EquationSystems> _equation_system;
 
-    std::unique_ptr<GRINS::Solver> _solver;
+    std::unique_ptr<Solver> _solver;
 
-    //! GRINS::Multiphysics system name
+    //! Multiphysics system name
     std::string _system_name;
 
     // This needs to be a standard pointer, as _equation_system will own and destroy the object.
-    GRINS::MultiphysicsSystem* _multiphysics_system;
+    MultiphysicsSystem* _multiphysics_system;
 
-    std::shared_ptr<GRINS::Visualization> _vis;
+    std::shared_ptr<Visualization> _vis;
 
     std::shared_ptr<PostProcessedQuantities<libMesh::Real> > _postprocessing;
 

--- a/src/solver/include/grins/simulation_builder.h
+++ b/src/solver/include/grins/simulation_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/simulation_builder.h
+++ b/src/solver/include/grins/simulation_builder.h
@@ -47,7 +47,7 @@ namespace GRINS
       const libMesh::Parallel::Communicator &comm
       LIBMESH_CAN_DEFAULT_TO_COMMWORLD );
 
-    std::shared_ptr<GRINS::Visualization> build_vis
+    std::shared_ptr<Visualization> build_vis
     ( const GetPot& input,
       const libMesh::Parallel::Communicator &comm
       LIBMESH_CAN_DEFAULT_TO_COMMWORLD );

--- a/src/solver/include/grins/simulation_initializer.h
+++ b/src/solver/include/grins/simulation_initializer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/simulation_parsing.h
+++ b/src/solver/include/grins/simulation_parsing.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/solver.h
+++ b/src/solver/include/grins/solver.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/solver.h
+++ b/src/solver/include/grins/solver.h
@@ -59,7 +59,7 @@ namespace GRINS
 
     virtual void initialize( const GetPot& input,
                              std::shared_ptr<libMesh::EquationSystems> equation_system,
-                             GRINS::MultiphysicsSystem* system );
+                             MultiphysicsSystem* system );
 
     virtual void solve( SolverContext& context )=0;
 
@@ -102,7 +102,7 @@ namespace GRINS
 
     void set_solver_options( libMesh::DiffSolver& solver );
 
-    virtual void init_time_solver(GRINS::MultiphysicsSystem* system)=0;
+    virtual void init_time_solver(MultiphysicsSystem* system)=0;
 
     void build_diff_solver( const NonlinearSolverOptions & options,
                             MultiphysicsSystem * system );

--- a/src/solver/include/grins/solver_context.h
+++ b/src/solver/include/grins/solver_context.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/solver_context.h
+++ b/src/solver/include/grins/solver_context.h
@@ -55,9 +55,9 @@ namespace GRINS
     SolverContext();
     ~SolverContext(){};
 
-    GRINS::MultiphysicsSystem* system;
+    MultiphysicsSystem* system;
     std::shared_ptr<libMesh::EquationSystems> equation_system;
-    std::shared_ptr<GRINS::Visualization> vis;
+    std::shared_ptr<Visualization> vis;
     unsigned int timesteps_per_vis;
     unsigned int timesteps_per_perflog;
     bool output_vis;

--- a/src/solver/include/grins/solver_factory_abstract.h
+++ b/src/solver/include/grins/solver_factory_abstract.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/solver_factory_basic.h
+++ b/src/solver/include/grins/solver_factory_basic.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/solver_factory_initializer.h
+++ b/src/solver/include/grins/solver_factory_initializer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/solver_names.h
+++ b/src/solver/include/grins/solver_names.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/solver_parsing.h
+++ b/src/solver/include/grins/solver_parsing.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/steady_mesh_adaptive_solver.h
+++ b/src/solver/include/grins/steady_mesh_adaptive_solver.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/steady_solver.h
+++ b/src/solver/include/grins/steady_solver.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/steady_solver.h
+++ b/src/solver/include/grins/steady_solver.h
@@ -54,7 +54,7 @@ namespace GRINS
 
   protected:
 
-    virtual void init_time_solver(GRINS::MultiphysicsSystem* system);
+    virtual void init_time_solver(MultiphysicsSystem* system);
 
   };
 } // namespace GRINS

--- a/src/solver/include/grins/time_stepping_parsing.h
+++ b/src/solver/include/grins/time_stepping_parsing.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/unsteady_mesh_adaptive_solver.h
+++ b/src/solver/include/grins/unsteady_mesh_adaptive_solver.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/unsteady_solver.h
+++ b/src/solver/include/grins/unsteady_solver.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/include/grins/unsteady_solver.h
+++ b/src/solver/include/grins/unsteady_solver.h
@@ -47,7 +47,7 @@ namespace GRINS
 
   protected:
 
-    virtual void init_time_solver(GRINS::MultiphysicsSystem* system);
+    virtual void init_time_solver(MultiphysicsSystem* system);
 
     template <typename T>
     void set_theta( libMesh::UnsteadySolver* time_solver );

--- a/src/solver/src/diff_solver_factory.C
+++ b/src/solver/src/diff_solver_factory.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/mesh_adaptive_solver_base.C
+++ b/src/solver/src/mesh_adaptive_solver_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/mesh_builder.C
+++ b/src/solver/src/mesh_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/nonlinear_solver_options.C
+++ b/src/solver/src/nonlinear_solver_options.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/parameter_manager.C
+++ b/src/solver/src/parameter_manager.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/parameter_user.C
+++ b/src/solver/src/parameter_user.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/runner.C
+++ b/src/solver/src/runner.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/simulation_builder.C
+++ b/src/solver/src/simulation_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/simulation_builder.C
+++ b/src/solver/src/simulation_builder.C
@@ -68,7 +68,7 @@ namespace GRINS
     return (this->_mesh_builder)->build(input, comm);
   }
 
-  std::shared_ptr<GRINS::Visualization> SimulationBuilder::build_vis
+  std::shared_ptr<Visualization> SimulationBuilder::build_vis
   ( const GetPot& input,
     const libMesh::Parallel::Communicator &comm)
   {

--- a/src/solver/src/simulation_initializer.C
+++ b/src/solver/src/simulation_initializer.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/solver.C
+++ b/src/solver/src/solver.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/solver_context.C
+++ b/src/solver/src/solver_context.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/solver_context.C
+++ b/src/solver/src/solver_context.C
@@ -34,7 +34,7 @@ namespace GRINS
   SolverContext::SolverContext()
     : system(NULL),
       equation_system( std::shared_ptr<libMesh::EquationSystems>() ),
-      vis( std::shared_ptr<GRINS::Visualization>() ),
+      vis( std::shared_ptr<Visualization>() ),
       timesteps_per_vis( 1 ),
       timesteps_per_perflog( 1 ),
       output_vis( false ),

--- a/src/solver/src/solver_factory_abstract.C
+++ b/src/solver/src/solver_factory_abstract.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/solver_factory_initializer.C
+++ b/src/solver/src/solver_factory_initializer.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/solver_parsing.C
+++ b/src/solver/src/solver_parsing.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/steady_solver.C
+++ b/src/solver/src/steady_solver.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/time_stepping_parsing.C
+++ b/src/solver/src/time_stepping_parsing.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/unsteady_mesh_adaptive_solver.C
+++ b/src/solver/src/unsteady_mesh_adaptive_solver.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/solver/src/unsteady_solver.C
+++ b/src/solver/src/unsteady_solver.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/include/grins/adaptive_time_stepping_options.h
+++ b/src/strategies/include/grins/adaptive_time_stepping_options.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/include/grins/adjoint_error_estimator_factories.h
+++ b/src/strategies/include/grins/adjoint_error_estimator_factories.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/include/grins/error_estimator_factory_base.h
+++ b/src/strategies/include/grins/error_estimator_factory_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/include/grins/error_estimator_factory_basic.h
+++ b/src/strategies/include/grins/error_estimator_factory_basic.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/include/grins/error_estimator_factory_initializer.h
+++ b/src/strategies/include/grins/error_estimator_factory_initializer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/include/grins/error_estimator_options.h
+++ b/src/strategies/include/grins/error_estimator_options.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/include/grins/strategies_parsing.h
+++ b/src/strategies/include/grins/strategies_parsing.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/src/adaptive_time_stepping_options.C
+++ b/src/strategies/src/adaptive_time_stepping_options.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/src/adjoint_error_estimator_factories.C
+++ b/src/strategies/src/adjoint_error_estimator_factories.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/src/error_estimator_factory_base.C
+++ b/src/strategies/src/error_estimator_factory_base.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/src/error_estimator_factory_initializer.C
+++ b/src/strategies/src/error_estimator_factory_initializer.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/src/error_estimator_options.C
+++ b/src/strategies/src/error_estimator_options.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/strategies/src/strategies_parsing.C
+++ b/src/strategies/src/strategies_parsing.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/cached_quantities_enum.h
+++ b/src/utilities/include/grins/cached_quantities_enum.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/cached_values.h
+++ b/src/utilities/include/grins/cached_values.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/distance_function.h
+++ b/src/utilities/include/grins/distance_function.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/grins_enums.h
+++ b/src/utilities/include/grins/grins_enums.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/input_utils.h
+++ b/src/utilities/include/grins/input_utils.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/math_constants.h
+++ b/src/utilities/include/grins/math_constants.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/output_parsing.h
+++ b/src/utilities/include/grins/output_parsing.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/parameter_antioch_reset.h
+++ b/src/utilities/include/grins/parameter_antioch_reset.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/physical_constants.h
+++ b/src/utilities/include/grins/physical_constants.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/include/grins/string_utils.h
+++ b/src/utilities/include/grins/string_utils.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/src/cached_values.C
+++ b/src/utilities/src/cached_values.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/src/grins_version.C
+++ b/src/utilities/src/grins_version.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/src/input_utils.C
+++ b/src/utilities/src/input_utils.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/src/parameter_antioch_reset.C
+++ b/src/utilities/src/parameter_antioch_reset.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/src/string_utils.C
+++ b/src/utilities/src/string_utils.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/utilities/src/version.C
+++ b/src/utilities/src/version.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/default_variable_builder.h
+++ b/src/variables/include/grins/default_variable_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/fe_variables_base.h
+++ b/src/variables/include/grins/fe_variables_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/multi_component_vector_variable.h
+++ b/src/variables/include/grins/multi_component_vector_variable.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/multicomponent_variable.h
+++ b/src/variables/include/grins/multicomponent_variable.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/single_variable.h
+++ b/src/variables/include/grins/single_variable.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/variable_builder.h
+++ b/src/variables/include/grins/variable_builder.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/variable_factory.h
+++ b/src/variables/include/grins/variable_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/variable_factory_initializer.h
+++ b/src/variables/include/grins/variable_factory_initializer.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/variable_name_defaults.h
+++ b/src/variables/include/grins/variable_name_defaults.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/variable_warehouse.h
+++ b/src/variables/include/grins/variable_warehouse.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/include/grins/variables_parsing.h
+++ b/src/variables/include/grins/variables_parsing.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/src/default_variable_builder.C
+++ b/src/variables/src/default_variable_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/src/variable_builder.C
+++ b/src/variables/src/variable_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/src/variable_factory.C
+++ b/src/variables/src/variable_factory.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/src/variable_factory_initializer.C
+++ b/src/variables/src/variable_factory_initializer.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/src/variable_warehouse.C
+++ b/src/variables/src/variable_warehouse.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/variables/src/variables_parsing.C
+++ b/src/variables/src/variables_parsing.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/include/grins/postprocessed_quantities.h
+++ b/src/visualization/include/grins/postprocessed_quantities.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/include/grins/postprocessing_factory.h
+++ b/src/visualization/include/grins/postprocessing_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/include/grins/steady_visualization.h
+++ b/src/visualization/include/grins/steady_visualization.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/include/grins/steady_visualization.h
+++ b/src/visualization/include/grins/steady_visualization.h
@@ -40,25 +40,25 @@ namespace GRINS
     ~SteadyVisualization();
 
     virtual void output_residual( std::shared_ptr<libMesh::EquationSystems> equation_system,
-                                  GRINS::MultiphysicsSystem* system,
+                                  MultiphysicsSystem* system,
                                   const unsigned int time_step,
                                   const libMesh::Real time );
 
     virtual void output_residual_sensitivities
     (std::shared_ptr<libMesh::EquationSystems> equation_system,
-     GRINS::MultiphysicsSystem* system,
+     MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int time_step,
      const libMesh::Real time );
 
     virtual void output_adjoint( std::shared_ptr<libMesh::EquationSystems> equation_system,
-                                 GRINS::MultiphysicsSystem* system,
+                                 MultiphysicsSystem* system,
                                  const unsigned int time_step,
                                  const libMesh::Real time );
 
     virtual void output_solution_sensitivities
     (std::shared_ptr<libMesh::EquationSystems> equation_system,
-     GRINS::MultiphysicsSystem* system,
+     MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int time_step,
      const libMesh::Real time );

--- a/src/visualization/include/grins/unsteady_visualization.h
+++ b/src/visualization/include/grins/unsteady_visualization.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/include/grins/unsteady_visualization.h
+++ b/src/visualization/include/grins/unsteady_visualization.h
@@ -41,25 +41,25 @@ namespace GRINS
     ~UnsteadyVisualization();
 
     virtual void output_residual( std::shared_ptr<libMesh::EquationSystems> equation_system,
-                                  GRINS::MultiphysicsSystem* system,
+                                  MultiphysicsSystem* system,
                                   const unsigned int time_step,
                                   const libMesh::Real time);
 
     virtual void output_residual_sensitivities
     (std::shared_ptr<libMesh::EquationSystems> equation_system,
-     GRINS::MultiphysicsSystem* system,
+     MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int time_step,
      const libMesh::Real time);
 
     virtual void output_adjoint( std::shared_ptr<libMesh::EquationSystems> equation_system,
-                                 GRINS::MultiphysicsSystem* system,
+                                 MultiphysicsSystem* system,
                                  const unsigned int time_step,
                                  const libMesh::Real time );
 
     virtual void output_solution_sensitivities
     (std::shared_ptr<libMesh::EquationSystems> equation_system,
-     GRINS::MultiphysicsSystem* system,
+     MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int time_step,
      const libMesh::Real time);

--- a/src/visualization/include/grins/visualization.h
+++ b/src/visualization/include/grins/visualization.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/include/grins/visualization.h
+++ b/src/visualization/include/grins/visualization.h
@@ -62,39 +62,39 @@ namespace GRINS
                  const unsigned int time_step, const libMesh::Real time );
 
     void output_residual( std::shared_ptr<libMesh::EquationSystems> equation_system,
-                          GRINS::MultiphysicsSystem* system );
+                          MultiphysicsSystem* system );
 
     virtual void output_residual( std::shared_ptr<libMesh::EquationSystems> equation_system,
-                                  GRINS::MultiphysicsSystem* system,
+                                  MultiphysicsSystem* system,
                                   const unsigned int time_step, const libMesh::Real time ) =0;
 
     void output_residual_sensitivities
     (std::shared_ptr<libMesh::EquationSystems> equation_system,
-     GRINS::MultiphysicsSystem* system,
+     MultiphysicsSystem* system,
      const libMesh::ParameterVector & params);
 
     virtual void output_residual_sensitivities
     (std::shared_ptr<libMesh::EquationSystems> equation_system,
-     GRINS::MultiphysicsSystem* system,
+     MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int time_step, const libMesh::Real time ) =0;
 
     void output_adjoint( std::shared_ptr<libMesh::EquationSystems> equation_system,
-                         GRINS::MultiphysicsSystem* system );
+                         MultiphysicsSystem* system );
 
     virtual void output_adjoint( std::shared_ptr<libMesh::EquationSystems> equation_system,
-                                 GRINS::MultiphysicsSystem* system,
+                                 MultiphysicsSystem* system,
                                  const unsigned int time_step,
                                  const libMesh::Real time ) =0;
 
     void output_solution_sensitivities
     (std::shared_ptr<libMesh::EquationSystems> equation_system,
-     GRINS::MultiphysicsSystem* system,
+     MultiphysicsSystem* system,
      const libMesh::ParameterVector & params);
 
     virtual void output_solution_sensitivities
     (std::shared_ptr<libMesh::EquationSystems> equation_system,
-     GRINS::MultiphysicsSystem* system,
+     MultiphysicsSystem* system,
      const libMesh::ParameterVector & params,
      const unsigned int time_step, const libMesh::Real time ) =0;
 

--- a/src/visualization/include/grins/visualization_factory.h
+++ b/src/visualization/include/grins/visualization_factory.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/include/grins/visualization_factory.h
+++ b/src/visualization/include/grins/visualization_factory.h
@@ -38,7 +38,7 @@ namespace GRINS
     VisualizationFactory();
     virtual ~VisualizationFactory();
 
-    virtual std::shared_ptr<GRINS::Visualization> build
+    virtual std::shared_ptr<Visualization> build
     ( const GetPot& input,
       const libMesh::Parallel::Communicator &comm
       LIBMESH_CAN_DEFAULT_TO_COMMWORLD );

--- a/src/visualization/src/postprocessed_quantities.C
+++ b/src/visualization/src/postprocessed_quantities.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/src/postprocessing_factory.C
+++ b/src/visualization/src/postprocessing_factory.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/src/steady_visualization.C
+++ b/src/visualization/src/steady_visualization.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/src/unsteady_visualization.C
+++ b/src/visualization/src/unsteady_visualization.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/src/visualization.C
+++ b/src/visualization/src/visualization.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/src/visualization/src/visualization_factory.C
+++ b/src/visualization/src/visualization_factory.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/amr/generic_amr_testing_app.C
+++ b/test/amr/generic_amr_testing_app.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/common/regression_helper.h
+++ b/test/common/regression_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/common/system_helper.h
+++ b/test/common/system_helper.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/common/testing_utils.h
+++ b/test/common/testing_utils.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/exact_soln/generic_exact_solution_testing_app.C
+++ b/test/exact_soln/generic_exact_solution_testing_app.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/exact_soln/vorticity_qoi.C
+++ b/test/exact_soln/vorticity_qoi.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/absorption_coeff_testing.h
+++ b/test/interface/absorption_coeff_testing.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/air_5sp.C
+++ b/test/interface/air_5sp.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/antioch_mixture_averaged_transport_evaluator_regression.C
+++ b/test/interface/antioch_mixture_averaged_transport_evaluator_regression.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/antioch_test_base.h
+++ b/test/interface/antioch_test_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/cantera_test_base.h
+++ b/test/interface/cantera_test_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/cantera_transport_regression.C
+++ b/test/interface/cantera_transport_regression.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/interface_driver.C
+++ b/test/interface/interface_driver.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/kinetics_test_base.h
+++ b/test/interface/kinetics_test_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/nasa_thermo_test_base.h
+++ b/test/interface/nasa_thermo_test_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/rayfire_test_base.h
+++ b/test/interface/rayfire_test_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/species_test_base.h
+++ b/test/interface/species_test_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/spectroscopic_test_base.h
+++ b/test/interface/spectroscopic_test_base.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/interface/thermochem_test_common.h
+++ b/test/interface/thermochem_test_common.h
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/regression/3d_low_mach_jacobians.C
+++ b/test/regression/3d_low_mach_jacobians.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/regression/elastic_sheet_regression.C
+++ b/test/regression/elastic_sheet_regression.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/regression/gaussian_profiles.C
+++ b/test/regression/gaussian_profiles.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/regression/generic_solution_regression.C
+++ b/test/regression/generic_solution_regression.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/regression/grins_flow_regression.C
+++ b/test/regression/grins_flow_regression.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/regression/low_mach_cavity_benchmark_regression.C
+++ b/test/regression/low_mach_cavity_benchmark_regression.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/regression/regression_testing_app.C
+++ b/test/regression/regression_testing_app.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/regression/test_turbulent_channel.C
+++ b/test/regression/test_turbulent_channel.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/antioch_mixture.C
+++ b/test/unit/antioch_mixture.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/arrhenius_catalycity.C
+++ b/test/unit/arrhenius_catalycity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/builder_helper.C
+++ b/test/unit/builder_helper.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/cantera_mixture.C
+++ b/test/unit/cantera_mixture.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/composite_function.C
+++ b/test/unit/composite_function.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/constant_catalycity.C
+++ b/test/unit/constant_catalycity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/default_bc_builder.C
+++ b/test/unit/default_bc_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/gas_recombination_catalytic_wall.C
+++ b/test/unit/gas_recombination_catalytic_wall.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/gas_solid_catalytic_wall.C
+++ b/test/unit/gas_solid_catalytic_wall.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/hitran_test.C
+++ b/test/unit/hitran_test.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/integrated_function_test.C
+++ b/test/unit/integrated_function_test.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/laser_absorption_test.C
+++ b/test/unit/laser_absorption_test.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/mesh_builder.C
+++ b/test/unit/mesh_builder.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/nonlinear_solver_options.C
+++ b/test/unit/nonlinear_solver_options.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/overlapping_fluid_solid_mesh.C
+++ b/test/unit/overlapping_fluid_solid_mesh.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/parsed_property.C
+++ b/test/unit/parsed_property.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/power_law_catalycity.C
+++ b/test/unit/power_law_catalycity.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/rayfireAMR_test_2d.C
+++ b/test/unit/rayfireAMR_test_2d.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/rayfireAMR_test_3d.C
+++ b/test/unit/rayfireAMR_test_3d.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/rayfire_test_2d.C
+++ b/test/unit/rayfire_test_2d.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/rayfire_test_3d.C
+++ b/test/unit/rayfire_test_3d.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/spectroscopic_absorption_test.C
+++ b/test/unit/spectroscopic_absorption_test.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/spectroscopic_transmission_test.C
+++ b/test/unit/spectroscopic_transmission_test.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/string_utils.C
+++ b/test/unit/string_utils.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/unit_driver.C
+++ b/test/unit/unit_driver.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or

--- a/test/unit/variables.C
+++ b/test/unit/variables.C
@@ -3,7 +3,7 @@
 //
 // GRINS - General Reacting Incompressible Navier-Stokes
 //
-// Copyright (C) 2014-2017 Paul T. Bauman, Roy H. Stogner
+// Copyright (C) 2014-2019 Paul T. Bauman, Roy H. Stogner
 // Copyright (C) 2010-2013 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or


### PR DESCRIPTION
#576 and #572 need a newer version of libMesh. I'm pushing the minimum libMesh version to following the merge of libMesh/libmesh#2088 since we'll need that for the variational IBM stuff coming down the pipe anyway and for which #576 is intended to support.

I've also updated the copyright year 2019 in the head. Finally, there was some lingering `GRINS::` used inside GRINS namespace that I cleaned up in another branch so I just cherry-picked on this one.