### PR TITLE
Enable OverlappingFluidSolidMap to use old solution

### DIFF
--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -93,6 +93,8 @@ namespace GRINS
 
     void map_error(const libMesh::dof_id_type id, const std::string & type) const;
 
+    void swap_old_solution( MultiphysicsSystem & system );
+
     //! Vector of element ids overlapping each solid id
     std::map<libMesh::dof_id_type,std::set<libMesh::dof_id_type>> _overlapping_fluid_ids;
 

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -52,7 +52,9 @@ namespace GRINS
                               const std::set<libMesh::subdomain_id_type> & fluid_ids,
                               const DisplacementVariable & solid_disp_vars );
 
-    virtual ~OverlappingFluidSolidMap(){};
+    virtual ~OverlappingFluidSolidMap() = default;
+
+    OverlappingFluidSolidMap() = delete;
 
     bool has_overlapping_fluid_elem(const libMesh::dof_id_type elem_id) const
     { return _overlapping_fluid_ids.find(elem_id) != _overlapping_fluid_ids.end(); }
@@ -74,8 +76,6 @@ namespace GRINS
     ( const libMesh::dof_id_type fluid_id ) const;
 
   private:
-
-    OverlappingFluidSolidMap();
 
     void build_maps( MultiphysicsSystem & system,
                      const libMesh::PointLocatorBase & point_locator,

--- a/src/physics/include/grins/overlapping_fluid_solid_map.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_map.h
@@ -50,7 +50,8 @@ namespace GRINS
                               const libMesh::PointLocatorBase & point_locator,
                               const std::set<libMesh::subdomain_id_type> & solid_ids,
                               const std::set<libMesh::subdomain_id_type> & fluid_ids,
-                              const DisplacementVariable & solid_disp_vars );
+                              const DisplacementVariable & solid_disp_vars,
+                              bool use_old_solution = false );
 
     virtual ~OverlappingFluidSolidMap() = default;
 
@@ -99,6 +100,8 @@ namespace GRINS
     _solid_to_fluid_map;
 
     std::map<libMesh::dof_id_type,std::set<libMesh::dof_id_type>> _fluid_to_solid_map;
+
+    bool _use_old_solution;
   };
 
 } // end namespace GRINS

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -67,6 +67,10 @@ namespace GRINS
     libMesh::UniquePtr<libMesh::FEMContext>
       fem_context( libMesh::cast_ptr<libMesh::FEMContext *>(raw_context.release()) );
 
+    // Swap current_local_solution with old_local_nonlinear_solution
+    if(_use_old_solution)
+      this->swap_old_solution(system);
+
     if( !mesh.is_serial() )
       libmesh_error_msg("ERROR: build_maps currently only implemented for ReplicatedMesh!");
 
@@ -138,6 +142,10 @@ namespace GRINS
 
         _overlapping_fluid_ids.insert(std::make_pair(solid_id,fluid_ids));
       }
+
+    // Swap back current_local_solution with old_local_nonlinear_solution
+    if(_use_old_solution)
+      this->swap_old_solution(system);
   }
 
 

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -39,7 +39,9 @@ namespace GRINS
                                                       const libMesh::PointLocatorBase & point_locator,
                                                       const std::set<libMesh::subdomain_id_type> & solid_ids,
                                                       const std::set<libMesh::subdomain_id_type> & fluid_ids,
-                                                      const DisplacementVariable & solid_disp_vars )
+                                                      const DisplacementVariable & solid_disp_vars,
+                                                      bool use_old_solution )
+  : _use_old_solution(use_old_solution)
   {
     if( solid_ids.empty() )
       libmesh_error_msg("ERROR: Must have at least one solid subdomain id!");

--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -32,6 +32,7 @@
 // libMesh
 #include "libmesh/elem.h"
 #include "libmesh/parallel_sync.h"
+#include "libmesh/unsteady_solver.h"
 
 namespace GRINS
 {
@@ -262,6 +263,20 @@ namespace GRINS
     ss << std::string("ERROR: Could not find ")+type+std::string(" element corresponding to element id ")
        << id << std::string(" !");
     libmesh_error_msg(ss.str());
+  }
+
+  void OverlappingFluidSolidMap::swap_old_solution( MultiphysicsSystem & system )
+  {
+    // Extract old nonlinear solution from TimeSolver
+    // Error out if this is not an UnsteadySolver
+    libMesh::TimeSolver & time_solver = system.get_time_solver();
+
+    libMesh::UnsteadySolver * unsteady_solver = dynamic_cast<libMesh::UnsteadySolver*>(&time_solver);
+
+    if( !unsteady_solver )
+      libmesh_error_msg("ERROR: Can only call swap_old_solution when using an UnsteadySolver!");
+
+    std::swap( unsteady_solver->old_local_nonlinear_solution, system.current_local_solution );
   }
 
 } // end namespace GRINS


### PR DESCRIPTION
Builds on #583. Will rebase when that's merged.

This adds an optional flag to `OverlappingFluidSolidMap` construction to allow the user to specify if they want to use an old solution. If so, then we swap in `UnsteadySolver::old_local_nonlinear_solution` for `System::current_local_solution`, build the overlapping map, and then swap back. This will allow us to easily do a semi-implicit vs. fully-implicit treatment in the immersed boundary stuff.