### PR TITLE
parsed_dirichlet_component Boundary Condition Option

### DIFF
--- a/examples/master_example_inputfile.in
+++ b/examples/master_example_inputfile.in
@@ -613,9 +613,17 @@
       #                       function of (x,y,z,t), where x,y,z are
       #                       spatial coordinates and t is time.
       #
+      #  parsed_dirichlet_component - Same as parsed_dirichlet, but does not
+      #                               zero unspecified components (see discussion
+      #                               below).
+      #
       #  parsed_fem_dirichlet - Dirichlet boundary condition specified
       #                         by a parsed expression that can be
       #                         function of solution variables.
+      #
+      #  parsed_fem_dirichlet_component - Same as parsed_fem_dirichlet, but
+      #                                   does not zero unspecified components
+      #                                   (see discussion below).
       #
       #  homogeneous_dirichlet - Zero-valued Dirichlet boundary conditions
       #
@@ -639,7 +647,14 @@
       # the variable name. See below. Furthermore, for variable
       # components that are *not* specified, it is assumed they are
       # zero. However, there must be at least one component specified
-      # or an error will be thrown. For the homogeneous types, no
+      # or an error will be thrown. If you wish for the non-specified
+      # components to remain unspecified rather than set to zero, you can
+      # instead use parsed_dirichlet_component and parsed_fem_dirichlet_component.
+      # The specification is idential to parsed_dirichlet and
+      # parsed_fem_dirichlet, respectively, but now the other components will
+      # not be pinned to zero, but rather will remain unconstrained.
+      #
+      # For the homogeneous types, no
       # components should be specified: all components will be set to
       # zero.
       #

--- a/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
@@ -60,7 +60,7 @@ namespace GRINS
     build_func( const GetPot& input,
                 MultiphysicsSystem& system,
                 std::vector<std::string>& var_names,
-                const std::string& section );
+                const std::string& section ) override;
 
   };
 

--- a/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
@@ -88,6 +88,24 @@ namespace GRINS
     {}
   };
 
+  //! For notational convenience
+  class ParsedDirichletComponentBCFactory : public ParsedFunctionDirichletBCFactory<libMesh::FunctionBase<libMesh::Number> >
+  {
+  public:
+    ParsedDirichletComponentBCFactory( const std::string& bc_type_name )
+      : ParsedFunctionDirichletBCFactory<libMesh::FunctionBase<libMesh::Number> >(bc_type_name,false)
+    {}
+  };
+
+  //! For notational convenience
+  class ParsedFEMDirichletComponentBCFactory : public ParsedFunctionDirichletBCFactory<libMesh::FEMFunctionBase<libMesh::Number> >
+  {
+  public:
+    ParsedFEMDirichletComponentBCFactory( const std::string& bc_type_name )
+      : ParsedFunctionDirichletBCFactory<libMesh::FEMFunctionBase<libMesh::Number> >(bc_type_name,false)
+    {}
+  };
+
 } // end namespace GRINS
 
 #endif // GRINS_PARSED_FUNCTION_DIRICHLET_BC_FACTORY_H

--- a/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
@@ -43,7 +43,9 @@ namespace GRINS
       ParsedFunctionFactoryHelper<FunctionType>()
     {}
 
-    ~ParsedFunctionDirichletBCFactory(){};
+    ParsedFunctionDirichletBCFactory() = delete;
+
+    virtual ~ParsedFunctionDirichletBCFactory() = default;
 
   protected:
     //! Builds the Parsed(FEM)Function objects for boundary conditions

--- a/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
+++ b/src/boundary_conditions/include/grins/parsed_function_dirichlet_bc_factory.h
@@ -38,9 +38,11 @@ namespace GRINS
   {
   public:
 
-    ParsedFunctionDirichletBCFactory( const std::string& bc_type_name )
+    ParsedFunctionDirichletBCFactory( const std::string& bc_type_name,
+                                      bool zero_other_components )
       : DirichletBCFactoryFunctionBase<FunctionType>(bc_type_name),
-      ParsedFunctionFactoryHelper<FunctionType>()
+      ParsedFunctionFactoryHelper<FunctionType>(),
+      _zero_other_components(zero_other_components)
     {}
 
     ParsedFunctionDirichletBCFactory() = delete;
@@ -62,6 +64,10 @@ namespace GRINS
                 std::vector<std::string>& var_names,
                 const std::string& section ) override;
 
+    /*! Set to true at construction time if we want the BC factory
+     *  to zero all other non-specified components, false if not. */
+    bool _zero_other_components;
+
   };
 
   //! For notational convenience
@@ -69,7 +75,7 @@ namespace GRINS
   {
   public:
     ParsedDirichletBCFactory( const std::string& bc_type_name )
-      : ParsedFunctionDirichletBCFactory<libMesh::FunctionBase<libMesh::Number> >(bc_type_name)
+      : ParsedFunctionDirichletBCFactory<libMesh::FunctionBase<libMesh::Number> >(bc_type_name,true)
     {}
   };
 
@@ -78,7 +84,7 @@ namespace GRINS
   {
   public:
     ParsedFEMDirichletBCFactory( const std::string& bc_type_name )
-      : ParsedFunctionDirichletBCFactory<libMesh::FEMFunctionBase<libMesh::Number> >(bc_type_name)
+      : ParsedFunctionDirichletBCFactory<libMesh::FEMFunctionBase<libMesh::Number> >(bc_type_name,true)
     {}
   };
 

--- a/src/boundary_conditions/src/boundary_condition_factory_initializer.C
+++ b/src/boundary_conditions/src/boundary_condition_factory_initializer.C
@@ -75,6 +75,14 @@ namespace GRINS
     static ParsedFEMDirichletBCFactory grins_factory_parsed_fem_dirichlet("parsed_fem_dirichlet");
     static ParsedDirichletBCFactory grins_factory_parsed_displacement("parsed_displacement");
 
+    static ParsedDirichletComponentBCFactory
+      grins_factory_parsed_dirichlet_component("parsed_dirichlet_component");
+    static ParsedFEMDirichletComponentBCFactory
+      grins_factory_parsed_fem_dirichlet_component("parsed_fem_dirichlet_component");
+    static ParsedDirichletComponentBCFactory
+      grins_factory_parsed_displacement_component("parsed_displacement_component");
+
+
     static ParsedFunctionNeumannBCFactory<libMesh::FunctionBase<libMesh::Number> >
       grins_factory_parsed_neumann("parsed_neumann");
 

--- a/src/boundary_conditions/src/parsed_function_dirichlet_bc_factory.C
+++ b/src/boundary_conditions/src/parsed_function_dirichlet_bc_factory.C
@@ -75,11 +75,24 @@ namespace GRINS
               (TypeFrom<FunctionType>::to_parsed(system, expression), var_idx);
           }
         // Otherwise, we set this variable to be zero.
-        else
+        // But only if this object was meant to.
+        else if (_zero_other_components)
           {
             composite_func->attach_subfunction
               (TypeFrom<FunctionType>::to_zero(), var_idx);
           }
+      }
+
+    // If we're not zeroing out the other components then we need to remove
+    // those variable names from var_names so they don't get added to the
+    // DirichletBoundary downstream. In this case we only want var_names
+    // to come out of this function with the entries in vars_found
+    if(!_zero_other_components)
+      {
+        var_names.clear();
+        var_names.reserve(vars_found.size());
+        for( const auto & var : vars_found )
+          var_names.push_back(var);
       }
 
     return all_funcs;


### PR DESCRIPTION
Before this PR, when the user had a multicomponent Variable and only set a subset of the Dirichlet values, the remainder were automatically set to zero (this is useful for example in reacting flow applications were we only want to set a handful of species mass fractions out of a set of 300+). However, there are cases were we don't want them to be zeroed (solid mechanics is where this is cropping up for me). So I've updated the `ParsedDirichletBCFactoryBase` to handle this and instantiated new BCFactories that support this. The option is `parsed_dirichlet_component` which is the new behavior and the previous behavior is kept at `parsed_dirichlet`. Similarly for `parsed_fem_dirichlet_component`. Open to suggestions if someone has a better name.