### PR TITLE
Add Thermally Coupled GMG Examples

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -396,6 +396,7 @@ AC_CONFIG_FILES(examples/ozone_flame/crun.sh,                 [chmod +x examples
 AC_CONFIG_FILES(examples/spectroscopy/run.sh,                 [chmod +x examples/spectroscopy/run.sh])
 AC_CONFIG_FILES(examples/multigrid/run_poisson.sh,            [chmod +x examples/multigrid/run_poisson.sh])
 AC_CONFIG_FILES(examples/multigrid/run_stokes.sh,             [chmod +x examples/multigrid/run_stokes.sh])
+AC_CONFIG_FILES(examples/multigrid/run_thermo_coupled_flow.sh, [chmod +x examples/multigrid/run_thermo_coupled_flow.sh])
 AC_CONFIG_FILES(examples/torsion_hyperelasticity/run.sh,     [chmod +x examples/torsion_hyperelasticity/run.sh])
 
 dnl-----------------------------------------------

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -246,14 +246,16 @@ spec_SOURCES  = spectroscopy/spectroscopy.C
 spec_LDADD = $(LIBGRINS_LIBS)
 
 #=======================================================================
-# Multigrid Example
+# Multigrid Examples
 #=======================================================================
 multigriddir       = $(prefix)/examples/multigrid
 multigrid_DATA     = $(top_srcdir)/examples/multigrid/forced_poisson.in
 multigrid_DATA    += $(top_srcdir)/examples/multigrid/stokes_fieldsplit.in
+multigrid_DATA    += $(top_srcdir)/examples/multigrid/thermo_coupled_flow.in
 multigrid_DATA    += $(top_srcdir)/examples/multigrid/README
 multigrid_SCRIPTS  = $(top_builddir)/examples/multigrid/run_poisson.sh
 multigrid_SCRIPTS += $(top_builddir)/examples/multigrid/run_stokes.sh
+multigrid_SCRIPTS += $(top_builddir)/examples/multigrid/run_thermo_coupled_flow.sh
 
 EXTRA_DIST += $(multigrid_DATA)
 

--- a/examples/multigrid/README
+++ b/examples/multigrid/README
@@ -9,9 +9,11 @@ vanilla multigrid usage for a forced Poisson problem with homogeneous
 boundary conditions. Next, run_stokes.sh demonstrates the coupling
 between fieldsplit and multigrid capabilities by applying multigrid
 directly to the velocity sub-block of a lid driven cavity Stokes flow
-formulation.
+formulation. Finally, the thermo coupled flow example demonstrates
+recursive fieldsplit capabilities as well as the ability to do GMG on
+multiple subblocks via two different sets of solver configurations.
 
-Both examples contain a set of default solver settings which perform
+These examples contain a set of default solver settings which perform
 adequately, but a large variety of further options can be employed to
 further customize the solve. The single required option is
 -pc_mg_levels which must be specified at all times in order to dictate

--- a/examples/multigrid/run_thermo_coupled_flow.sh.in
+++ b/examples/multigrid/run_thermo_coupled_flow.sh.in
@@ -3,12 +3,11 @@
 GRINS_RUN=${GRINS_RUN:-$LIBMESH_RUN}
 
 GRINS_SOLVER_OPTIONS="--use_petsc_dm --node-major-dofs
-
 -snes_view -snes_monitor -snes_converged_reason
--snes_atol 1.0e-5 -snes_error_if_not_converged
+-snes_rtol 1.0e-5 -snes_error_if_not_converged
 
 -ksp_type fgmres -ksp_converged_reason -ksp_monitor
--ksp_rtol 1.0e-8 -ksp_atol 1.0e-8
+-ksp_rtol 1.0e-6 -ksp_atol 1.0e-6
 -ksp_gmres_modifiedgramschmidt
 
 -pc_type fieldsplit
@@ -21,16 +20,12 @@ GRINS_SOLVER_OPTIONS="--use_petsc_dm --node-major-dofs
 -fieldsplit_T_inner_pc_type lu
 -fieldsplit_T_inner_pc_factor_mat_solver_type superlu_dist
 -fieldsplit_T_inner_ksp_type gmres
--fieldsplit_T_inner_ksp_rtol 1.0e-10
--fieldsplit_T_inner_ksp_converged_reason
--fieldsplit_T_inner_ksp_monitor
+-fieldsplit_T_inner_ksp_rtol 1.0e-8
 
 -fieldsplit_T_upper_pc_type lu
 -fieldsplit_T_upper_pc_factor_mat_solver_type superlu_dist
 -fieldsplit_T_upper_ksp_type gmres
--fieldsplit_T_upper_ksp_rtol 1.0e-10
--fieldsplit_T_upper_ksp_converged_reason
--fieldsplit_T_upper_ksp_monitor
+-fieldsplit_T_upper_ksp_rtol 1.0e-8
 
 -fieldsplit_0_pc_type fieldsplit
 -fieldsplit_0_ksp_monitor
@@ -53,36 +48,31 @@ GRINS_SOLVER_OPTIONS="--use_petsc_dm --node-major-dofs
 -fieldsplit_0_fieldsplit_p_inner_pc_type lu
 -fieldsplit_0_fieldsplit_p_inner_pc_factor_mat_solver_type superlu_dist
 -fieldsplit_0_fieldsplit_p_inner_ksp_type gmres
--fieldsplit_0_fieldsplit_p_inner_ksp_rtol 1.0e-10
--fieldsplit_0_fieldsplit_p_inner_ksp_converged_reason
--fieldsplit_0_fieldsplit_p_inner_ksp_monitor
+-fieldsplit_0_fieldsplit_p_inner_ksp_rtol 1.0e-8
 
 -fieldsplit_0_fieldsplit_p_upper_pc_type lu
 -fieldsplit_0_fieldsplit_p_upper_pc_factor_mat_solver_type superlu_dist
 -fieldsplit_0_fieldsplit_p_upper_ksp_type gmres
--fieldsplit_0_fieldsplit_p_upper_ksp_rtol 1.0e-10
--fieldsplit_0_fieldsplit_p_upper_ksp_converged_reason
--fieldsplit_0_fieldsplit_p_upper_ksp_monitor
+-fieldsplit_0_fieldsplit_p_upper_ksp_rtol 1.0e-8
 
 -fieldsplit_T_pc_type lu
 -fieldsplit_T_pc_factor_mat_solver_type superlu_dist
--fieldsplit_T_ksp_rtol 1.0e-10 -fieldsplit_T_ksp_type gmres
+-fieldsplit_T_ksp_rtol 1.0e-8 -fieldsplit_T_ksp_type gmres
 -fieldsplit_T_ksp_monitor"
 
-echo "Running Thermally Coupled Boussinesq Multigrid Example with: recursive Schur complement settings"
+
+echo "Running Thermally Coupled Boussinesq Multigrid Example with: Recursive Schur Complement with loosened inner Schur solve"
 
 $GRINS_RUN @prefix@/bin/grins @prefix@/examples/multigrid/thermo_coupled_flow.in $GRINS_SOLVER_OPTIONS
 
-
-echo "Running Thermally Coupled Boussinesq Multigrid Example with: multiplicative FS with GMG on velocity and GMG on Temp"
+echo "Running Thermally Coupled Boussinesq Multigrid Example with: Multiplicative Outer Fieldsplit, GMG on velocity block, and GMG on Temperature"
 
 GRINS_SOLVER_OPTIONS="--use_petsc_dm --node-major-dofs
-
 -snes_view -snes_monitor -snes_converged_reason
--snes_rtol 1.0e-5 -snes_error_if_not_converged 0
+-snes_rtol 1.0e-5 -snes_error_if_not_converged
 
 -ksp_type fgmres -ksp_converged_reason -ksp_monitor
--ksp_rtol 1.0e-8 -ksp_atol 1.0e-8
+-ksp_rtol 1.0e-6 -ksp_atol 1.0e-6
 -ksp_gmres_modifiedgramschmidt
 
 -pc_type fieldsplit
@@ -114,23 +104,19 @@ GRINS_SOLVER_OPTIONS="--use_petsc_dm --node-major-dofs
 -fieldsplit_0_fieldsplit_p_pc_factor_mat_solver_type superlu_dist
 -fieldsplit_0_fieldsplit_p_ksp_type gmres
 -fieldsplit_0_fieldsplit_p_ksp_monitor
--fieldsplit_0_fieldsplit_p_ksp_rtol 1.0e-10
+-fieldsplit_0_fieldsplit_p_ksp_rtol 1.0e-8
 
 -fieldsplit_0_fieldsplit_p_inner_pc_type lu
 -fieldsplit_0_fieldsplit_p_inner_pc_factor_mat_solver_type superlu_dist
 -fieldsplit_0_fieldsplit_p_inner_ksp_type gmres
--fieldsplit_0_fieldsplit_p_inner_ksp_rtol 1.0e-10
--fieldsplit_0_fieldsplit_p_inner_ksp_converged_reason
--fieldsplit_0_fieldsplit_p_inner_ksp_monitor
+-fieldsplit_0_fieldsplit_p_inner_ksp_rtol 1.0e-8
 
 -fieldsplit_0_fieldsplit_p_upper_pc_type lu
 -fieldsplit_0_fieldsplit_p_upper_pc_factor_mat_solver_type superlu_dist
 -fieldsplit_0_fieldsplit_p_upper_ksp_type gmres
--fieldsplit_0_fieldsplit_p_upper_ksp_rtol 1.0e-10
--fieldsplit_0_fieldsplit_p_upper_ksp_converged_reason
--fieldsplit_0_fieldsplit_p_upper_ksp_monitor
+-fieldsplit_0_fieldsplit_p_upper_ksp_rtol 1.0e-8
 
--fieldsplit_T_ksp_max_it 5 -fieldsplit_T_ksp_type gmres
+-fieldsplit_T_ksp_type gmres
 -fieldsplit_T_ksp_rtol 1.0e-5
 -fieldsplit_T_ksp_converged_reason -fieldsplit_T_ksp_monitor_true_residual
 
@@ -144,7 +130,6 @@ GRINS_SOLVER_OPTIONS="--use_petsc_dm --node-major-dofs
 -fieldsplit_T_mg_levels_pc_sor_its 5
 -fieldsplit_T_mg_levels_ksp_type richardson
 -fieldsplit_T_mg_levels_ksp_richardson_self_scale
--fieldsplit_T_mg_levels_ksp_max_it 5
 -fieldsplit_T_mg_levels_ksp_monitor
 -fieldsplit_T_mg_levels_ksp_converged_reason"
 

--- a/examples/multigrid/run_thermo_coupled_flow.sh.in
+++ b/examples/multigrid/run_thermo_coupled_flow.sh.in
@@ -1,0 +1,151 @@
+#!/bin/sh
+
+GRINS_RUN=${GRINS_RUN:-$LIBMESH_RUN}
+
+GRINS_SOLVER_OPTIONS="--use_petsc_dm --node-major-dofs
+
+-snes_view -snes_monitor -snes_converged_reason
+-snes_atol 1.0e-5 -snes_error_if_not_converged
+
+-ksp_type fgmres -ksp_converged_reason -ksp_monitor
+-ksp_rtol 1.0e-8 -ksp_atol 1.0e-8
+-ksp_gmres_modifiedgramschmidt
+
+-pc_type fieldsplit
+-pc_fieldsplit_0_fields 0,1,2
+-pc_fieldsplit_1_fields 3
+-pc_fieldsplit_type schur
+-pc_fieldsplit_schur_fact_type full
+-pc_fieldsplit_schur_precondition selfp
+
+-fieldsplit_T_inner_pc_type lu
+-fieldsplit_T_inner_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_T_inner_ksp_type gmres
+-fieldsplit_T_inner_ksp_rtol 1.0e-10
+-fieldsplit_T_inner_ksp_converged_reason
+-fieldsplit_T_inner_ksp_monitor
+
+-fieldsplit_T_upper_pc_type lu
+-fieldsplit_T_upper_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_T_upper_ksp_type gmres
+-fieldsplit_T_upper_ksp_rtol 1.0e-10
+-fieldsplit_T_upper_ksp_converged_reason
+-fieldsplit_T_upper_ksp_monitor
+
+-fieldsplit_0_pc_type fieldsplit
+-fieldsplit_0_ksp_monitor
+-fieldsplit_0_ksp_type gmres
+-fieldsplit_0_pc_fieldsplit_0_fields 0,1 -fieldsplit_0_pc_fieldsplit_1_fields 2
+-fieldsplit_0_pc_fieldsplit_type schur -fieldsplit_0_pc_fieldsplit_schur_fact_type full
+-fieldsplit_0_pc_fieldsplit_schur_precondition selfp
+
+-fieldsplit_0_fieldsplit_0_pc_type lu
+-fieldsplit_0_fieldsplit_0_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_0_fieldsplit_0_ksp_max_it 1 -fieldsplit_0_fieldsplit_0_ksp_type gmres
+-fieldsplit_0_fieldsplit_0_ksp_monitor
+
+-fieldsplit_0_fieldsplit_p_pc_type lu
+-fieldsplit_0_fieldsplit_p_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_0_fieldsplit_p_ksp_type gmres
+-fieldsplit_0_fieldsplit_p_ksp_monitor
+-fieldsplit_0_fieldsplit_p_ksp_rtol 1.0e-5
+
+-fieldsplit_0_fieldsplit_p_inner_pc_type lu
+-fieldsplit_0_fieldsplit_p_inner_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_0_fieldsplit_p_inner_ksp_type gmres
+-fieldsplit_0_fieldsplit_p_inner_ksp_rtol 1.0e-10
+-fieldsplit_0_fieldsplit_p_inner_ksp_converged_reason
+-fieldsplit_0_fieldsplit_p_inner_ksp_monitor
+
+-fieldsplit_0_fieldsplit_p_upper_pc_type lu
+-fieldsplit_0_fieldsplit_p_upper_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_0_fieldsplit_p_upper_ksp_type gmres
+-fieldsplit_0_fieldsplit_p_upper_ksp_rtol 1.0e-10
+-fieldsplit_0_fieldsplit_p_upper_ksp_converged_reason
+-fieldsplit_0_fieldsplit_p_upper_ksp_monitor
+
+-fieldsplit_T_pc_type lu
+-fieldsplit_T_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_T_ksp_rtol 1.0e-10 -fieldsplit_T_ksp_type gmres
+-fieldsplit_T_ksp_monitor"
+
+echo "Running Thermally Coupled Boussinesq Multigrid Example with: recursive Schur complement settings"
+
+$GRINS_RUN @prefix@/bin/grins @prefix@/examples/multigrid/thermo_coupled_flow.in $GRINS_SOLVER_OPTIONS
+
+
+echo "Running Thermally Coupled Boussinesq Multigrid Example with: multiplicative FS with GMG on velocity and GMG on Temp"
+
+GRINS_SOLVER_OPTIONS="--use_petsc_dm --node-major-dofs
+
+-snes_view -snes_monitor -snes_converged_reason
+-snes_rtol 1.0e-5 -snes_error_if_not_converged 0
+
+-ksp_type fgmres -ksp_converged_reason -ksp_monitor
+-ksp_rtol 1.0e-8 -ksp_atol 1.0e-8
+-ksp_gmres_modifiedgramschmidt
+
+-pc_type fieldsplit
+-pc_fieldsplit_0_fields 0,1,2
+-pc_fieldsplit_1_fields 3
+-pc_fieldsplit_type multiplicative
+
+-fieldsplit_0_pc_type fieldsplit
+-fieldsplit_0_ksp_monitor
+-fieldsplit_0_ksp_type gmres
+-fieldsplit_0_pc_fieldsplit_0_fields 0,1 -fieldsplit_0_pc_fieldsplit_1_fields 2
+-fieldsplit_0_pc_fieldsplit_type schur -fieldsplit_0_pc_fieldsplit_schur_fact_type full
+-fieldsplit_0_pc_fieldsplit_schur_precondition selfp
+
+-fieldsplit_0_fieldsplit_0_pc_type mg
+-fieldsplit_0_fieldsplit_0_pc_mg_galerkin both
+-fieldsplit_0_fieldsplit_0_pc_mg_type full
+-pc_mg_levels 3
+-fieldsplit_0_fieldsplit_0_pc_mg_levels 3
+
+-fieldsplit_0_fieldsplit_0_mg_levels_pc_type sor
+-fieldsplit_0_fieldsplit_0_mg_levels_pc_sor_its 5
+-fieldsplit_0_fieldsplit_0_mg_levels_ksp_type richardson
+-fieldsplit_0_fieldsplit_0_mg_levels_ksp_richardson_self_scale
+-fieldsplit_0_fieldsplit_0_mg_levels_ksp_monitor
+-fieldsplit_0_fieldsplit_0_mg_levels_ksp_converged_reason
+
+-fieldsplit_0_fieldsplit_p_pc_type lu
+-fieldsplit_0_fieldsplit_p_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_0_fieldsplit_p_ksp_type gmres
+-fieldsplit_0_fieldsplit_p_ksp_monitor
+-fieldsplit_0_fieldsplit_p_ksp_rtol 1.0e-10
+
+-fieldsplit_0_fieldsplit_p_inner_pc_type lu
+-fieldsplit_0_fieldsplit_p_inner_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_0_fieldsplit_p_inner_ksp_type gmres
+-fieldsplit_0_fieldsplit_p_inner_ksp_rtol 1.0e-10
+-fieldsplit_0_fieldsplit_p_inner_ksp_converged_reason
+-fieldsplit_0_fieldsplit_p_inner_ksp_monitor
+
+-fieldsplit_0_fieldsplit_p_upper_pc_type lu
+-fieldsplit_0_fieldsplit_p_upper_pc_factor_mat_solver_type superlu_dist
+-fieldsplit_0_fieldsplit_p_upper_ksp_type gmres
+-fieldsplit_0_fieldsplit_p_upper_ksp_rtol 1.0e-10
+-fieldsplit_0_fieldsplit_p_upper_ksp_converged_reason
+-fieldsplit_0_fieldsplit_p_upper_ksp_monitor
+
+-fieldsplit_T_ksp_max_it 5 -fieldsplit_T_ksp_type gmres
+-fieldsplit_T_ksp_rtol 1.0e-5
+-fieldsplit_T_ksp_converged_reason -fieldsplit_T_ksp_monitor_true_residual
+
+-fieldsplit_T_pc_type mg
+-fieldsplit_T_pc_mg_galerkin both
+-fieldsplit_T_pc_mg_type full
+-pc_mg_levels 3
+-fieldsplit_T_pc_mg_levels 3
+
+-fieldsplit_T_mg_levels_pc_type sor
+-fieldsplit_T_mg_levels_pc_sor_its 5
+-fieldsplit_T_mg_levels_ksp_type richardson
+-fieldsplit_T_mg_levels_ksp_richardson_self_scale
+-fieldsplit_T_mg_levels_ksp_max_it 5
+-fieldsplit_T_mg_levels_ksp_monitor
+-fieldsplit_T_mg_levels_ksp_converged_reason"
+
+$GRINS_RUN @prefix@/bin/grins @prefix@/examples/multigrid/thermo_coupled_flow.in $GRINS_SOLVER_OPTIONS

--- a/examples/multigrid/thermo_coupled_flow.in
+++ b/examples/multigrid/thermo_coupled_flow.in
@@ -77,7 +77,7 @@
       [../ReferenceTemperature]
          value = '0.5'
       [../ThermalExpansionCoeff]
-         value = '1e5'
+         value = '1e3'
       [../ThermodynamicPressure]
          value = '1'
       [../GasConstant]

--- a/examples/multigrid/thermo_coupled_flow.in
+++ b/examples/multigrid/thermo_coupled_flow.in
@@ -1,0 +1,160 @@
+
+[Physics]
+   enabled_physics = 'IncompressibleNavierStokes HeatTransfer BoussinesqBuoyancy'
+
+   # Options related to all Physics
+   [./IncompressibleNavierStokes]
+      material = 'Gas'
+      pin_pressure = true
+      pin_location = '0.5 0.5'
+      pin_value = '1.0'
+
+   [../]
+    [./HeatTransfer]
+       material = 'Gas'
+       ic_ids = '0'
+       ic_types = 'parsed'
+       ic_variables = 'T'
+       ic_values = 'y'
+    [../]
+    [./BoussinesqBuoyancy]
+       material = 'Gas'
+       # Gravity vector
+       g   = '0.0 -9.81' #[m/s^2]
+    [../]
+
+[]
+
+[Variables]
+   [./Velocity]
+      names = 'Ux Uy'
+      fe_family = 'LAGRANGE'
+      order = 'SECOND'
+   [../Pressure]
+      names = 'p'
+      fe_family = 'LAGRANGE'
+      order = 'FIRST'
+   [../Temperature]
+      names = 'T'
+      fe_family = 'LAGRANGE'
+      order = 'SECOND'
+[]
+
+# Mesh related options
+[Mesh]
+   [./Generation]
+      dimension = '2'
+      element_type = 'QUAD9'
+      x_min = '0.0'
+      x_max = '1.0'
+      y_min = '0.0'
+      y_max = '1.0'
+      n_elems_x = '5'
+      n_elems_y = '5'
+   [../]
+   [./Refinement]
+     uniformly_refine = '2'
+     allow_renumbering = 'true'
+     allow_remote_elem_deletion = 'false'
+     disable_partitioning = 'true'
+   [../]
+[]
+
+# Materials section
+[Materials]
+   [./Gas]
+      [./ThermalConductivity]
+         model = 'constant'
+         value = '1.0'
+      [../Density]
+         value = '1.0'
+      [../Viscosity]
+         model = 'constant'
+         value = '1.0'
+      [../SpecificHeat]
+         model = 'constant'
+         value =  '1.0'
+      [../ReferenceTemperature]
+         value = '0.5'
+      [../ThermalExpansionCoeff]
+         value = '1e5'
+      [../ThermodynamicPressure]
+         value = '1'
+      [../GasConstant]
+         value = '1'
+[]
+
+[BoundaryConditions]
+   bc_ids = '3 1 0 2'
+   bc_id_name_map = 'Left Right Bottom Top'
+
+   [./Left]
+      [./Velocity]
+         type = 'no_slip'
+      [../]
+      [./Temperature]
+         type = 'parsed_dirichlet'
+         T = '1.0'
+      [../]
+   [../]
+
+   [./Right]
+      [./Velocity]
+         type = 'no_slip'
+      [../]
+      [./Temperature]
+         type = 'parsed_dirichlet'
+         T = '2.0'
+      [../]
+   [../]
+
+   [./Bottom]
+      [./Velocity]
+         type = 'no_slip'
+      [../]
+      [./Temperature]
+         type = 'adiabatic'
+      [../]
+   [../]
+
+   [./Top]
+      [./Velocity]
+         type = 'no_slip'
+      [../]
+      [./Temperature]
+         type = 'adiabatic'
+      [../]
+   [../]
+[]
+
+# Options for solvers
+[SolverOptions]
+ solver_type = 'grins_steady_solver'
+[]
+
+#Linear and nonlinear solver options
+[linear-nonlinear-solver]
+  type = 'libmesh_petsc_diff'
+  relative_residual_tolerance = '1.0e-10'
+  verify_analytic_jacobians = '0.0'
+  use_numerical_jacobians_only = 'true'
+[]
+
+# Visualization options
+[vis-options]
+  vis_output_file_prefix = 'thermo_coupled_flow_output'
+  output_vis = 'true'
+  output_residual = 'true'
+  output_format = 'ExodusII'
+[]
+
+# Options for print info to the screen
+[screen-options]
+  system_name = 'thermo_coupled_flow'
+  print_equation_system_info = 'true'
+  print_mesh_info = 'true'
+  print_log_info = 'true'
+  solver_verbose = 'true'
+  solver_quiet = 'false'
+  print_element_jacobians = 'false'
+[]


### PR DESCRIPTION
This PR expands the GMG multigrid coverage by adding a new thermally coupled flow example which uses the fixed up solver configuration settings that were part of the changes in libMesh/libmesh#2151; as such this PR requires the bumping of minimum libMesh version to that corresponding to the libMesh PR.

The content here provides a new example that is run twice with the idea of demonstrating broad categories of solver configuration capabilities. The first run uses recursive Schur complement decomposition to solve the coupled problem, while the second run uses a multiplicative fieldsplit variant with GMG to precondition the velocity subblock, and GMG on the thermal convective/diffusive subblock.

Please let me know if there's anything to be improved upon!