### PR TITLE
Include numeric_vector.h directly

### DIFF
--- a/src/qoi/src/spectroscopic_absorption.C
+++ b/src/qoi/src/spectroscopic_absorption.C
@@ -35,10 +35,11 @@
 #include "grins/single_variable.h"
 
 // libMesh
-#include "libmesh/getpot.h"
-#include "libmesh/fem_system.h"
-#include "libmesh/quadrature.h"
 #include "libmesh/fem_function_base.h"
+#include "libmesh/fem_system.h"
+#include "libmesh/getpot.h"
+#include "libmesh/numeric_vector.h"
+#include "libmesh/quadrature.h"
 
 namespace GRINS
 {

--- a/src/qoi/src/spectroscopic_transmission.C
+++ b/src/qoi/src/spectroscopic_transmission.C
@@ -35,10 +35,11 @@
 #include "grins/single_variable.h"
 
 // libMesh
-#include "libmesh/getpot.h"
-#include "libmesh/fem_system.h"
-#include "libmesh/quadrature.h"
 #include "libmesh/fem_function_base.h"
+#include "libmesh/fem_system.h"
+#include "libmesh/getpot.h"
+#include "libmesh/numeric_vector.h"
+#include "libmesh/quadrature.h"
 
 namespace GRINS
 {

--- a/src/visualization/src/steady_visualization.C
+++ b/src/visualization/src/steady_visualization.C
@@ -32,6 +32,7 @@
 
 // libMesh
 #include "libmesh/getpot.h"
+#include "libmesh/numeric_vector.h"
 #include "libmesh/parameter_vector.h"
 
 namespace GRINS

--- a/src/visualization/src/unsteady_visualization.C
+++ b/src/visualization/src/unsteady_visualization.C
@@ -32,6 +32,7 @@
 
 // libMesh
 #include "libmesh/getpot.h"
+#include "libmesh/numeric_vector.h"
 #include "libmesh/parameter_vector.h"
 #include "libmesh/steady_solver.h"
 

--- a/test/regression/test_turbulent_channel.C
+++ b/test/regression/test_turbulent_channel.C
@@ -35,21 +35,21 @@
 #include "grins/var_typedefs.h"
 
 //libMesh
+#include "libmesh/composite_function.h"
 #include "libmesh/dirichlet_boundaries.h"
 #include "libmesh/dof_map.h"
+#include "libmesh/edge_edge2.h"
+#include "libmesh/enum_xdr_mode.h"
+#include "libmesh/exact_solution.h"
 #include "libmesh/fe_base.h"
 #include "libmesh/fe_interface.h"
-#include "libmesh/mesh_function.h"
-#include "libmesh/serial_mesh.h"
-#include "libmesh/edge_edge2.h"
-#include "libmesh/mesh_generation.h"
-#include "libmesh/linear_implicit_system.h"
 #include "libmesh/gmv_io.h"
-#include "libmesh/exact_solution.h"
+#include "libmesh/linear_implicit_system.h"
+#include "libmesh/mesh_function.h"
+#include "libmesh/mesh_generation.h"
+#include "libmesh/numeric_vector.h"
+#include "libmesh/serial_mesh.h"
 #include "libmesh/zero_function.h"
-#include "libmesh/composite_function.h"
-#include "libmesh/zero_function.h"
-#include "libmesh/enum_xdr_mode.h"
 
 namespace GRINS
 {


### PR DESCRIPTION
Looks like we were previously getting this indirectly via time_solver.h
and subclasses, but the forward declarations in
https://github.com/libMesh/libmesh/pull/2647 mean we need to get things
ourselves now.