### PR TITLE
Fix builds with recent --disable-deprecated and 64-bit libMesh

### DIFF
--- a/src/physics/src/overlapping_fluid_solid_map.C
+++ b/src/physics/src/overlapping_fluid_solid_map.C
@@ -64,8 +64,8 @@ namespace GRINS
   {
     const libMesh::MeshBase & mesh = system.get_mesh();
 
-    libMesh::UniquePtr<libMesh::DiffContext> raw_context = system.build_context();
-    libMesh::UniquePtr<libMesh::FEMContext>
+    std::unique_ptr<libMesh::DiffContext> raw_context = system.build_context();
+    std::unique_ptr<libMesh::FEMContext>
       fem_context( libMesh::cast_ptr<libMesh::FEMContext *>(raw_context.release()) );
 
     // Swap current_local_solution with old_local_nonlinear_solution

--- a/src/physics/src/spalart_allmaras.C
+++ b/src/physics/src/spalart_allmaras.C
@@ -78,7 +78,7 @@ namespace GRINS
     this->boundary_mesh.reset(new libMesh::SerialMesh(system->get_mesh().comm() , system->get_mesh().mesh_dimension()) );
 
     // Use the _wall_ids set to build the boundary mesh object
-    (system->get_mesh()).boundary_info->sync(_wall_ids, *boundary_mesh);
+    (system->get_mesh()).get_boundary_info().sync(_wall_ids, *boundary_mesh);
 
     //this->distance_function.reset(new DistanceFunction(system->get_equation_systems(), dynamic_cast<libMesh::UnstructuredMesh&>(system->get_mesh()) ));
     this->distance_function.reset(new DistanceFunction(system->get_equation_systems(), *boundary_mesh));

--- a/src/qoi/src/rayfire_mesh.C
+++ b/src/qoi/src/rayfire_mesh.C
@@ -1063,7 +1063,7 @@ namespace GRINS
 
     for (unsigned int n=0; n<first_order_elem->n_nodes(); ++n)
       {
-        libMesh::Node * node = new libMesh::Node(elem->node_ref(n));
+        libMesh::Node * node = new libMesh::Node(elem->point(n));
         first_order_elem->set_node(n) = node;
       }
 

--- a/src/utilities/src/distance_function.C
+++ b/src/utilities/src/distance_function.C
@@ -637,7 +637,7 @@ namespace GRINS {
     libMesh::System& sys = _equation_systems.get_system<libMesh::System>("distance_function");
     const libMesh::DofMap& dof_map = sys.get_dof_map();
 
-    std::vector<unsigned int> dof_ind;
+    std::vector<libMesh::dof_id_type> dof_ind;
     dof_map.dof_indices(elem, dof_ind);
 
     libMesh::DenseVector<libMesh::Real> nodal_dist;

--- a/test/regression/regression_testing_app.C
+++ b/test/regression/regression_testing_app.C
@@ -389,7 +389,7 @@ void test_convergence_iterations( libMesh::EquationSystems & eq_sys,
   // First run the solve to populate the Solver iteration info.
   GRINS::SimulationBuilder sb;
   GRINS::SimulationInitializer si;
-  libMesh::UniquePtr<GRINS::Simulation> sim;
+  std::unique_ptr<GRINS::Simulation> sim;
 
   std::cout << "==========================================================" << std::endl;
   command_line.print();


### PR DESCRIPTION
I'm still seeing test failures but at least the core code all compiles with those options again.