### PR TITLE
Update cppunit.m4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -262,7 +262,7 @@ AC_ARG_ENABLE(cppunit,
               AS_HELP_STRING([--disable-cppunit],
                              [Build without cppunit C++ unit testing support]))
 AS_IF([test "x$enable_cppunit" != "xno"], [
-   AM_PATH_CPPUNIT([1.10.0],[enablecppunit=yes],[enablecppunit=no])
+   AM_PATH_CPPUNIT([enablecppunit=yes],[enablecppunit=no])
 ])
 
 AM_CONDITIONAL(GRINS_ENABLE_CPPUNIT, test x$enablecppunit = xyes)


### PR DESCRIPTION
Newer versions of CppUnit do not include the cppunit-config.
Libmesh is using macros that require one of these newer versions
anyway so I don't even bother checking for it anymore. Also
took out the version checks for simplicity. If we need to bifurcate
on version, we can do something about it later. But really, I'd
rather just move to catch2 one of these days.