### PR TITLE
Require C++17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 GRINS
 =======
 
-General Reacting Incompressible Navier-Stokes (GRINS) was initiated                                                                                                                                                      
+General Reacting Incompressible Navier-Stokes (GRINS) was initiated
 to house common modeling work centered around using the incompressible
 and variable-density (low-Mach) Navier-Stokes equations
 utilizing the [libMesh](https://github.com/libMesh/libmesh.git) finite
 element library, including both MPI and MPI+threads parallelism,
-as provided by [libMesh](https://github.com/libMesh/libmesh.git). 
+as provided by [libMesh](https://github.com/libMesh/libmesh.git).
 GRINS has now become a tool for rapidly developing
 formulations and algorithms for the solution of complex multiphysics
-applications. 
+applications.
 GRINS originally lived within
 the [PECOS](http://pecos.ices.utexas.edu) center at the Institute for Computational
 Engineering and Sciences ([ICES](https://www.ices.utexas.edu))
@@ -44,7 +44,7 @@ an external chemistry library. Both [Cantera](http://code.google.com/p/cantera/)
 The current required minimum hash for using Antioch is libantioch/antioch@e17822d (libantioch/antioch#265).
 
 
-Building GRINS 
+Building GRINS
 ================
 
 GRINS uses an Autotools build system, so typical GNU build commands are used. We support, and encourage, out-of-source builds (so-called VPATH builds). However, in-source builds are supported.
@@ -78,7 +78,7 @@ not `METHODS`. For example
 is valid.
 
 The user can define
-their own CXXFLAGS variable by passing 
+their own CXXFLAGS variable by passing
 <pre><code>
 --disable-libmesh-flags CXXFLAGS="your flags here"
 </code>

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Dependencies
 Requirements
 ------------
 
-In addition to a C++11 compiler, GRINS requires an up-to-date installation of the [libMesh](https://github.com/libMesh/libmesh.git) finite element library. 
+In addition to a C++17 compiler, GRINS requires an up-to-date installation of the [libMesh](https://github.com/libMesh/libmesh.git) finite element library.
 
 libMesh
 -------
-GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is 943d5d0 [PR #2088](https://github.com/libMesh/libmesh/pull/2088), as of GRINS [PR #577](https://github.com/grinsfem/grins/pull/577).
+GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is f0def3f [PR #3168](https://github.com/libMesh/libmesh/pull/3168), as of GRINS [PR #611](https://github.com/grinsfem/grins/pull/611).
 GRINS release 0.5.0 can use libMesh versions as old as 0.9.4. Subsequent to
 the 0.5.0 release requires at least libMesh 1.0.0.
 

--- a/configure.ac
+++ b/configure.ac
@@ -86,26 +86,11 @@ fi
 dnl -Wall warnings, -Wall the time.
 AX_CXXFLAGS_WARN_ALL
 
-dnl--------------------------
-dnl Even if no dependency needed it,
-dnl C++11 makes our asserts nicer,
-dnl so let's try and enable it.
-dnl--------------------------
-AC_ARG_ENABLE(cxx11,
-              AC_HELP_STRING([--enable-cxx11],
-                             [build with C++11 support]),
-              [case "${enableval}" in
-                yes)  enablecxx11=yes ;;
-                 no)  enablecxx11=no ;;
-                  *)  AC_MSG_ERROR(bad value ${enableval} for --enable-cxx11) ;;
-               esac],
-               [enablecxx11=optional])
+dnl-------------------------------------------
+dnl libMesh is using c++17 now, so we will too
+dnl-------------------------------------------
+AX_CXX_COMPILE_STDCXX_17(noext, mandatory)
 
-if (test x$enablecxx11 = xyes); then
-  AX_CXX_COMPILE_STDCXX_11(noext, mandatory)
-elif (test x$enablecxx11 = xoptional); then
-  AX_CXX_COMPILE_STDCXX_11(noext, optional)
-fi
 
 dnl---------------------------------------------------------
 dnl Add libMesh flags manually if it's not a libtool build
@@ -131,34 +116,6 @@ dnl Check for GSL
 dnl----------------
 dnl### AX_PATH_GSL(1.10,AM_CONDITIONAL([UQBT_GSL], [test 'TRUE']),AC_MSG_ERROR([Could not find required GSL version.]))
 dnl AC_CACHE_SAVE
-
-
-dnl------------------------------------------
-dnl Check if libMesh detected std::shared_ptr
-dnl------------------------------------------
-AC_MSG_CHECKING([for C++11 std::shared_ptr support from libMesh])
-grins_save_CPPFLAGS=$CPPFLAGS
-CPPFLAGS="$LIBMESH_CPPFLAGS $CPPFLAGS"
-libmesh_have_cxx11_shared_ptr=no
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-                                      @%:@include <libmesh/libmesh_config.h>
-                                   ]],
-                                   [[
-                                      #if LIBMESH_HAVE_CXX11_SHARED_PTR
-                                      #else
-                                      #error "libMesh shared_ptr support not found!"
-                                      #endif
-                                   ]])
-                  ],
-                                   [
-                libmesh_have_cxx11_shared_ptr=yes
-                AC_MSG_RESULT(yes)
-            ],[
-                libmesh_have_cxx11_shared_ptr=no
-                AC_MSG_RESULT(no)
-])
-CPPFLAGS=$grins_save_CPPFLAGS
-
 
 dnl-----------------------
 dnl Check for Cantera 2.0+


### PR DESCRIPTION
libMesh requires c++17 as of libMesh/libmesh#3168 so we need to require it too.