### PR TITLE
Prefer .xda.gz to .xdr in test cases

### DIFF
--- a/test/amr/convection_diffusion_unsteady_2d.sh
+++ b/test/amr/convection_diffusion_unsteady_2d.sh
@@ -34,4 +34,4 @@ ${GRINS_TEST_DIR}/generic_amr_testing_app \
 
 # Now remove the test turd
 rm -rf $LOCALTESTDIR
-rm ${TESTDATA}.*.xdr ${MESHDATA}.*.xda ${TESTDATA}.xdr ${MESHDATA}_mesh.xda
+rm ${TESTDATA}.*.xda.gz ${MESHDATA}.*.xda ${TESTDATA}.xda.gz ${MESHDATA}_mesh.xda

--- a/test/amr/convection_diffusion_unsteady_2d_petsc_diff.sh
+++ b/test/amr/convection_diffusion_unsteady_2d_petsc_diff.sh
@@ -36,4 +36,4 @@ ${GRINS_TEST_DIR}/generic_amr_testing_app \
 
 # Now remove the test turd
 rm -rf $LOCALTESTDIR
-rm ${TESTDATA}.*.xdr ${MESHDATA}.*.xda ${TESTDATA}.xdr ${MESHDATA}_mesh.xda
+rm ${TESTDATA}.*.xda.gz ${MESHDATA}.*.xda ${TESTDATA}.xda.gz ${MESHDATA}_mesh.xda

--- a/test/amr/generic_amr_testing_app.C
+++ b/test/amr/generic_amr_testing_app.C
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
 
       // This needs to match the read counter-part in GRINS::Simulation
       //FIXME: Need to support different input formats for restarts
-      std::string test_data = test_data_prefix+"."+step_string.str()+".xdr";
+      std::string test_data = test_data_prefix+"."+step_string.str()+".xda.gz";
 
       {
         std::ifstream i(test_data.c_str());
@@ -202,7 +202,7 @@ int main(int argc, char* argv[])
 
       libMesh::EquationSystems es(mesh);
       es.read(test_data,
-              GRINSEnums::DECODE,
+              GRINSEnums::READ,
               libMesh::EquationSystems::READ_HEADER |
               libMesh::EquationSystems::READ_DATA |
               libMesh::EquationSystems::READ_ADDITIONAL_DATA);

--- a/test/amr/input_files/convection_diffusion_unsteady_2d_amr.in
+++ b/test/amr/input_files/convection_diffusion_unsteady_2d_amr.in
@@ -92,7 +92,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'convection_diffusion_unsteady_2d_amr'
-   output_format = 'xdr mesh_only'
+   output_format = 'xda.gz mesh_only'
 []
 
 [screen-options]

--- a/test/exact_soln/README
+++ b/test/exact_soln/README
@@ -10,7 +10,7 @@ there are a couple of important points to implement.
    the integrity of the parallel builds, each restart file *must* be named uniquely.
    Thus, the rule here is to name the restart file the same as the test, e.g.
    if the test was named navier_stokes_2d.sh, then the restart should be named
-   navier_stokes_2d.xdr.
+   navier_stokes_2d.xda.gz.
 
 3. If you're exact solution is a time-dependent one, you must evaluate it at the time
    the restart is written. You can do this in the parsed function, e.g.:

--- a/test/exact_soln/axi_ns_con_cyl_flow.sh
+++ b/test/exact_soln/axi_ns_con_cyl_flow.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/axi_con_cyl_flow.in"
-TESTDATA="./axi_ns_con_cyl_flow.xdr"
+TESTDATA="./axi_ns_con_cyl_flow.xda.gz"
 
 # A MOAB preconditioner
 PETSC_OPTIONS="-pc_type asm -pc_asm_overlap 12 -sub_pc_type ilu -sub_pc_factor_mat_ordering_type 1wd -sub_pc_factor_levels 4 -sub_pc_factor_shift_type nonzero"

--- a/test/exact_soln/axi_ns_poiseuille_flow.sh
+++ b/test/exact_soln/axi_ns_poiseuille_flow.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/axi_poiseuille_flow_input.in"
-TESTDATA="./axi_ns_poiseuille_flow.xdr"
+TESTDATA="./axi_ns_poiseuille_flow.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.sh
+++ b/test/exact_soln/compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.in"
-TESTDATA="./compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.xdr"
+TESTDATA="./compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/convection_diffusion_steady_1d.sh
+++ b/test/exact_soln/convection_diffusion_steady_1d.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/convection_diffusion_steady_1d.in"
-TESTDATA="./convection_diffusion_steady_1d.xdr"
+TESTDATA="./convection_diffusion_steady_1d.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/convection_diffusion_unsteady_2d.sh
+++ b/test/exact_soln/convection_diffusion_unsteady_2d.sh
@@ -3,8 +3,8 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/convection_diffusion_unsteady_2d.in"
-TESTDATA_NOTUSED="./convection_diffusion_unsteady_2d.xdr"
-TESTDATA="./convection_diffusion_unsteady_2d.49.xdr"
+TESTDATA_NOTUSED="./convection_diffusion_unsteady_2d.xda.gz"
+TESTDATA="./convection_diffusion_unsteady_2d.49.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/convection_diffusion_unsteady_2d_petsc_diff.sh
+++ b/test/exact_soln/convection_diffusion_unsteady_2d_petsc_diff.sh
@@ -3,8 +3,8 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/convection_diffusion_unsteady_2d.in"
-TESTDATA_NOTUSED="./convection_diffusion_unsteady_2d_petsc_diff.xdr"
-TESTDATA="./convection_diffusion_unsteady_2d_petsc_diff.49.xdr"
+TESTDATA_NOTUSED="./convection_diffusion_unsteady_2d_petsc_diff.xda.gz"
+TESTDATA="./convection_diffusion_unsteady_2d_petsc_diff.49.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT linear-nonlinear-solver/type='libmesh_petsc_diff' vis-options/vis_output_file_prefix='convection_diffusion_unsteady_2d_petsc_diff'

--- a/test/exact_soln/elastic_cable_oned_displacement.sh
+++ b/test/exact_soln/elastic_cable_oned_displacement.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/elastic_cable_oned_displacement.in"
-TESTDATA="./elastic_cable_oned_displacement.xdr"
+TESTDATA="./elastic_cable_oned_displacement.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/elastic_cable_oned_newmark_rayleigh_damping.sh
+++ b/test/exact_soln/elastic_cable_oned_newmark_rayleigh_damping.sh
@@ -3,8 +3,8 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/elastic_cable_oned_newmark_rayleigh_damping.in"
-TESTDATA_NOTUSED="./elastic_cable_oned_newmark_rayleigh_damping.xdr"
-TESTDATA="./elastic_cable_oned_newmark_rayleigh_damping.99.xdr"
+TESTDATA_NOTUSED="./elastic_cable_oned_newmark_rayleigh_damping.xda.gz"
+TESTDATA="./elastic_cable_oned_newmark_rayleigh_damping.99.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/elastic_cable_twod_displacement.sh
+++ b/test/exact_soln/elastic_cable_twod_displacement.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/elastic_cable_twod_displacement.in"
-TESTDATA="./elastic_cable_twod_displacement.xdr"
+TESTDATA="./elastic_cable_twod_displacement.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/elastic_cable_twod_newmark_rayleigh_damping.sh
+++ b/test/exact_soln/elastic_cable_twod_newmark_rayleigh_damping.sh
@@ -3,8 +3,8 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/elastic_cable_twod_newmark_rayleigh_damping.in"
-TESTDATA_NOTUSED="./elastic_cable_twod_newmark_rayleigh_damping.xdr"
-TESTDATA="./elastic_cable_twod_newmark_rayleigh_damping.99.xdr"
+TESTDATA_NOTUSED="./elastic_cable_twod_newmark_rayleigh_damping.xda.gz"
+TESTDATA="./elastic_cable_twod_newmark_rayleigh_damping.99.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/heat_eqn_unsteady_2d_restart.sh
+++ b/test/exact_soln/heat_eqn_unsteady_2d_restart.sh
@@ -5,8 +5,8 @@ set -e
 INPUT_1="${GRINS_TEST_INPUT_DIR}/heat_eqn_unsteady_2d_restart_pt1.in"
 INPUT_2="${GRINS_TEST_INPUT_DIR}/heat_eqn_unsteady_2d_restart_pt2.in"
 
-TESTDATA_NOTUSED="./heat_eqn_unsteady_2d_restart_pt1.xdr ./heat_eqn_unsteady_2d_restart_pt2.xdr ./heat_eqn_unsteady_2d_restart_pt1_mesh.xda ./heat_eqn_unsteady_2d_restart_pt1.24.xdr ./heat_eqn_unsteady_2d_restart_pt1.24_mesh.xda"
-TESTDATA="./heat_eqn_unsteady_2d_restart_pt2.24.xdr"
+TESTDATA_NOTUSED="./heat_eqn_unsteady_2d_restart_pt1.xda.gz ./heat_eqn_unsteady_2d_restart_pt2.xda.gz ./heat_eqn_unsteady_2d_restart_pt1_mesh.xda ./heat_eqn_unsteady_2d_restart_pt1.24.xda.gz ./heat_eqn_unsteady_2d_restart_pt1.24_mesh.xda"
+TESTDATA="./heat_eqn_unsteady_2d_restart_pt2.24.xda.gz"
 
 # First run the case to generate the file to restart from
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT_1

--- a/test/exact_soln/incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.sh
+++ b/test/exact_soln/incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.in"
-TESTDATA="./incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.xdr"
+TESTDATA="./incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/ns_couette_flow_2d_x.sh
+++ b/test/exact_soln/ns_couette_flow_2d_x.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/couette_flow_input_2d_x.in"
-TESTDATA="./ns_couette_flow_2d_x.xdr"
+TESTDATA="./ns_couette_flow_2d_x.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/ns_couette_flow_2d_y.sh
+++ b/test/exact_soln/ns_couette_flow_2d_y.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/couette_flow_input_2d_y.in"
-TESTDATA="./ns_couette_flow_2d_y.xdr"
+TESTDATA="./ns_couette_flow_2d_y.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/plane_strain_compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.sh
+++ b/test/exact_soln/plane_strain_compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/plane_strain_compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.in"
-TESTDATA="./plane_strain_compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.xdr"
+TESTDATA="./plane_strain_compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/plane_strain_incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.sh
+++ b/test/exact_soln/plane_strain_incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/plane_strain_incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.in"
-TESTDATA="./plane_strain_incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.xdr"
+TESTDATA="./plane_strain_incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.xda.gz"
 
 # First run the case with grins
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT

--- a/test/exact_soln/stokes_poiseuille_flow.sh
+++ b/test/exact_soln/stokes_poiseuille_flow.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/stokes_poiseuille_flow_input.in"
-TESTDATA="./stokes_poiseuille_flow.xdr"
+TESTDATA="./stokes_poiseuille_flow.xda.gz"
 
 PETSC_OPTIONS="-pc_type asm -pc_asm_overlap 2 -sub_pc_type lu -sub_pc_factor_shift_type nonzero"
 

--- a/test/exact_soln/stokes_poiseuille_flow_parsed_viscosity.sh
+++ b/test/exact_soln/stokes_poiseuille_flow_parsed_viscosity.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/stokes_poiseuille_flow_parsed_viscosity_input.in"
-TESTDATA="./stokes_poiseuille_flow_parsed_viscosity.xdr"
+TESTDATA="./stokes_poiseuille_flow_parsed_viscosity.xda.gz"
 PETSC_OPTIONS="-pc_type asm -pc_asm_overlap 2 -sub_pc_factor_shift_type nonzero -sub_pc_factor_levels 4"
 
 # First run the case with grins

--- a/test/exact_soln/stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity.sh
+++ b/test/exact_soln/stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity.sh
@@ -3,7 +3,7 @@
 set -e
 
 INPUT="${GRINS_TEST_INPUT_DIR}/stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity_input.in"
-TESTDATA="./stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity.xdr"
+TESTDATA="./stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity.xda.gz"
 PETSC_OPTIONS="-pc_type asm -pc_asm_overlap 2 -sub_pc_factor_shift_type nonzero -sub_pc_factor_levels 4"
 
 # First run the case with grins

--- a/test/input_files/2d_fantrick.in
+++ b/test/input_files/2d_fantrick.in
@@ -119,7 +119,7 @@ vis_output_file_prefix = 'output/fantrick'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/2d_proptrick.in
+++ b/test/input_files/2d_proptrick.in
@@ -128,7 +128,7 @@ vis_output_file_prefix = 'output/proptrick'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/2d_pseudofan.in
+++ b/test/input_files/2d_pseudofan.in
@@ -103,7 +103,7 @@ vis_output_file_prefix = 'output/fan'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/2d_pseudoprop.in
+++ b/test/input_files/2d_pseudoprop.in
@@ -116,7 +116,7 @@ vis_output_file_prefix = 'output/prop'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/2d_vsource.in
+++ b/test/input_files/2d_vsource.in
@@ -109,7 +109,7 @@ vis_output_file_prefix = 'output/vsource'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/axi_con_cyl_flow.in
+++ b/test/input_files/axi_con_cyl_flow.in
@@ -23,7 +23,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'axi_ns_con_cyl_flow'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/axi_poiseuille_flow_input.in
+++ b/test/input_files/axi_poiseuille_flow_input.in
@@ -33,7 +33,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'axi_ns_poiseuille_flow'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/axi_thermally_driven_flow.in
+++ b/test/input_files/axi_thermally_driven_flow.in
@@ -27,7 +27,7 @@ relative_step_tolerance = 1.0e-11
 [vis-options]
 output_vis = 'false'
 vis_output_file_prefix = axi_thermally_driven
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/axisym_reacting_low_mach_antioch_cea_constant_regression.in
+++ b/test/input_files/axisym_reacting_low_mach_antioch_cea_constant_regression.in
@@ -158,7 +158,7 @@ vis_output_file_prefix = 'nitridation'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 []
 

--- a/test/input_files/backward_facing_step.in
+++ b/test/input_files/backward_facing_step.in
@@ -99,7 +99,7 @@ vis_output_file_prefix = 'step'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.in
+++ b/test/input_files/compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.in
@@ -127,7 +127,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/convection_diffusion_steady_1d.in
+++ b/test/input_files/convection_diffusion_steady_1d.in
@@ -72,7 +72,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'convection_diffusion_steady_1d'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/convection_diffusion_unsteady_2d.in
+++ b/test/input_files/convection_diffusion_unsteady_2d.in
@@ -77,7 +77,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'convection_diffusion_unsteady_2d'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
    timesteps_per_vis = '50'
 []
 

--- a/test/input_files/couette_flow_input_2d_x.in
+++ b/test/input_files/couette_flow_input_2d_x.in
@@ -25,7 +25,7 @@
 [vis-options]
    vis_output_file_prefix = 'ns_couette_flow_2d_x'
    output_vis = 'true'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/couette_flow_input_2d_y.in
+++ b/test/input_files/couette_flow_input_2d_y.in
@@ -21,7 +21,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'ns_couette_flow_2d_y'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/dirichlet_fem.in
+++ b/test/input_files/dirichlet_fem.in
@@ -32,7 +32,7 @@ relative_step_tolerance = 1.0e-10
 output_vis = false
 timesteps_per_vis = 1
 vis_output_file_prefix = 'dirichlet_fem'
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/dirichlet_nan.in
+++ b/test/input_files/dirichlet_nan.in
@@ -26,7 +26,7 @@ relative_step_tolerance = 1.0e-10
 [vis-options]
 output_vis = false
 vis_output_file_prefix = 'dirichlet_nan'
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/elastic_cable_oned_displacement.in
+++ b/test/input_files/elastic_cable_oned_displacement.in
@@ -72,7 +72,7 @@
    output_vis = 'true'
    vis_output_file_prefix = 'elastic_cable_oned_displacement'
    output_residual = 'false'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/elastic_cable_oned_newmark_rayleigh_damping.in
+++ b/test/input_files/elastic_cable_oned_newmark_rayleigh_damping.in
@@ -83,7 +83,7 @@
    output_vis = 'true'
    vis_output_file_prefix = 'elastic_cable_oned_newmark_rayleigh_damping'
    output_residual = 'false'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
    timesteps_per_vis = '100' 
 []
 

--- a/test/input_files/elastic_cable_twod_displacement.in
+++ b/test/input_files/elastic_cable_twod_displacement.in
@@ -77,7 +77,7 @@
    output_vis = 'true'
    vis_output_file_prefix = 'elastic_cable_twod_displacement'
    output_residual = 'false'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/elastic_cable_twod_newmark_rayleigh_damping.in
+++ b/test/input_files/elastic_cable_twod_newmark_rayleigh_damping.in
@@ -88,7 +88,7 @@
    output_vis = 'true'
    vis_output_file_prefix = 'elastic_cable_twod_newmark_rayleigh_damping'
    output_residual = 'false'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
    timesteps_per_vis = '100' 
 []
 

--- a/test/input_files/elastic_mooney_rivlin_circle_hookean_stiffeners_regression.in
+++ b/test/input_files/elastic_mooney_rivlin_circle_hookean_stiffeners_regression.in
@@ -98,7 +98,7 @@ vis_output_file_prefix = 'sheet'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 []
 
 ##### Options for print info to the screen #####

--- a/test/input_files/elastic_mooney_rivlin_sheet_regression.in
+++ b/test/input_files/elastic_mooney_rivlin_sheet_regression.in
@@ -90,7 +90,7 @@ vis_output_file_prefix = 'sheet'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_newmark_regression.in
+++ b/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_newmark_regression.in
@@ -109,7 +109,7 @@ vis_output_file_prefix = 'sheet'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 ##### Options for print info to the screen #####
 [screen-options]

--- a/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_rayleigh_damping_newmark_regression.in
+++ b/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_rayleigh_damping_newmark_regression.in
@@ -120,7 +120,7 @@ vis_output_file_prefix = 'sheet'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 ##### Options for print info to the screen #####
 [screen-options]

--- a/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_regression.in
+++ b/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_regression.in
@@ -116,7 +116,7 @@ vis_output_file_prefix = 'sheet'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 ##### Options for print info to the screen #####
 [screen-options]

--- a/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_unifref_regression.in
+++ b/test/input_files/elastic_mooney_rivlin_square_hookean_stiffeners_unifref_regression.in
@@ -120,7 +120,7 @@ vis_output_file_prefix = 'sheet'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 ##### Options for print info to the screen #####
 [screen-options]

--- a/test/input_files/heat_eqn_unsteady_2d_restart_pt1.in
+++ b/test/input_files/heat_eqn_unsteady_2d_restart_pt1.in
@@ -81,7 +81,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'heat_eqn_unsteady_2d_restart_pt1'
-   output_format = 'mesh_only xdr'
+   output_format = 'mesh_only xda.gz'
    timesteps_per_vis = '25'
 []
 

--- a/test/input_files/heat_eqn_unsteady_2d_restart_pt2.in
+++ b/test/input_files/heat_eqn_unsteady_2d_restart_pt2.in
@@ -69,7 +69,7 @@
 []
 
 [restart-options]
-   restart_file = './heat_eqn_unsteady_2d_restart_pt1.24.xdr'
+   restart_file = './heat_eqn_unsteady_2d_restart_pt1.24.xda.gz'
 []
 
 [linear-nonlinear-solver]
@@ -84,7 +84,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'heat_eqn_unsteady_2d_restart_pt2'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
    timesteps_per_vis = '25'
 []
 

--- a/test/input_files/incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.in
+++ b/test/input_files/incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.in
@@ -106,7 +106,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/laplace_parsed_source_regression.in
+++ b/test/input_files/laplace_parsed_source_regression.in
@@ -88,7 +88,7 @@
 [vis-options]
    output_vis = false
    vis_output_file_prefix = 'laplace'
-   output_format = 'ExodusII xdr'
+   output_format = 'ExodusII xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/locally_refine.in
+++ b/test/input_files/locally_refine.in
@@ -94,7 +94,7 @@ vis_output_file_prefix = 'refined_step'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/low_mach_cavity_benchmark_regression_input.in
+++ b/test/input_files/low_mach_cavity_benchmark_regression_input.in
@@ -162,7 +162,7 @@ vis_output_file_prefix = 'cavity'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 []
 
 [Output]

--- a/test/input_files/multigrid_poisson.in
+++ b/test/input_files/multigrid_poisson.in
@@ -90,7 +90,7 @@
   vis_output_file_prefix = 'multigrid_poisson'
   output_vis = true
   output_residual = 'false'
-  output_format = 'xdr'
+  output_format = 'xda.gz'
 []
 
 [screen-options]

--- a/test/input_files/multigrid_stokes.in
+++ b/test/input_files/multigrid_stokes.in
@@ -79,7 +79,7 @@
  output_vis = true
  vis_output_file_prefix = 'multigrid_stokes'
  output_residual = 'false'
- output_format = 'xdr'
+ output_format = 'xda.gz'
 []
 
 # Options for printing info to the screen

--- a/test/input_files/ozone_flame_antioch_constant_regression.in
+++ b/test/input_files/ozone_flame_antioch_constant_regression.in
@@ -161,7 +161,7 @@
    output_vis = 'false'
    vis_output_file_prefix = 'output_ozone_constant'
    output_residual = 'false'
-   output_format = 'ExodusII xdr'
+   output_format = 'ExodusII xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/ozone_flame_antioch_kinetics_theory_regression.in
+++ b/test/input_files/ozone_flame_antioch_kinetics_theory_regression.in
@@ -160,7 +160,7 @@
    output_vis = 'false'
    vis_output_file_prefix = 'output'
    output_residual = 'false'
-   output_format = 'ExodusII xdr'
+   output_format = 'ExodusII xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/penalty_poiseuille.in
+++ b/test/input_files/penalty_poiseuille.in
@@ -37,7 +37,7 @@ numerical_jacobian_h = 1.e-10
 [vis-options]
 output_vis = false
 vis_output_file_prefix = penalty_poiseuille
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/penalty_poiseuille_stab.in
+++ b/test/input_files/penalty_poiseuille_stab.in
@@ -33,7 +33,7 @@ use_numerical_jacobians_only = 'true'
 [vis-options]
 output_vis = false
 vis_output_file_prefix = penalty_poiseuille_stab
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/plane_strain_compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.in
+++ b/test/input_files/plane_strain_compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin.in
@@ -125,7 +125,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'plane_strain_compressible_hyperelasticity_uniaxial_tension_compressible_mooney_rivlin'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/plane_strain_incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.in
+++ b/test/input_files/plane_strain_incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin.in
@@ -97,7 +97,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'plane_strain_incompressible_hyperelasticity_uniaxial_tension_mooney_rivlin'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/poisson_weighted_flux_regression.in
+++ b/test/input_files/poisson_weighted_flux_regression.in
@@ -102,7 +102,7 @@ weights = 'y*(1-y)' # This 'fixes' the spill
    output_vis = 'false'
    output_adjoint = 'false'
    vis_output_file_prefix = 'poisson'
-   output_format = 'ExodusII xdr'
+   output_format = 'ExodusII xda.gz'
 []
 
 [Output]

--- a/test/input_files/reacting_low_mach_antioch_cea_constant_prandtl_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_cea_constant_prandtl_regression.in
@@ -153,7 +153,7 @@ vis_output_file_prefix = 'nitridation'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 #output_vars = 'rho_mix mole_fractions'
 

--- a/test/input_files/reacting_low_mach_antioch_cea_constant_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_cea_constant_regression.in
@@ -156,7 +156,7 @@ vis_output_file_prefix = 'nitridation'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 #output_vars = 'rho_mix mole_fractions'
 

--- a/test/input_files/reacting_low_mach_antioch_kinetics_theory_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_kinetics_theory_regression.in
@@ -149,7 +149,7 @@ vis_output_file_prefix = 'nitridation'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 #output_vars = 'rho_mix mole_fractions'
 

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_arrhenius_catalytic_wall_regression.in
@@ -173,7 +173,7 @@ vis_output_file_prefix = 'nitridation'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 #output_vars = 'rho_mix mole_fractions'
 

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_power_catalytic_wall_regression.in
@@ -163,7 +163,7 @@ vis_output_file_prefix = 'nitridation'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 #output_vars = 'rho_mix mole_fractions'
 

--- a/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_blottner_eucken_lewis_regression.in
@@ -151,7 +151,7 @@ vis_output_file_prefix = 'nitridation'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 #output_vars = 'rho_mix mole_fractions'
 

--- a/test/input_files/reacting_low_mach_antioch_statmech_constant_prandtl_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_constant_prandtl_regression.in
@@ -157,7 +157,7 @@ vis_output_file_prefix = 'nitridation'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 #output_vars = 'rho_mix mole_fractions'
 

--- a/test/input_files/reacting_low_mach_antioch_statmech_constant_regression.in
+++ b/test/input_files/reacting_low_mach_antioch_statmech_constant_regression.in
@@ -172,7 +172,7 @@ vis_output_file_prefix = 'nitridation'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 #output_vars = 'rho_mix mole_fractions'
 

--- a/test/input_files/redistribute.in
+++ b/test/input_files/redistribute.in
@@ -94,7 +94,7 @@ vis_output_file_prefix = 'redistributed_step'
 
 output_residual = 'false'
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/sa_2d_turbulent_channel_regression.in
+++ b/test/input_files/sa_2d_turbulent_channel_regression.in
@@ -33,7 +33,7 @@ use_numerical_jacobians_only = 'true'
 [vis-options]
 output_vis = 'false'
 vis_output_file_prefix = 'turbulent_channel'
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 [Materials]
   [./TestMaterial]

--- a/test/input_files/simple_ode.in
+++ b/test/input_files/simple_ode.in
@@ -33,7 +33,7 @@ minimum_linear_tolerance = 1.0e-6
 output_vis = false
 timesteps_per_vis = 1
 vis_output_file_prefix = 'simple_ode'
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/stokes_poiseuille_flow_input.in
+++ b/test/input_files/stokes_poiseuille_flow_input.in
@@ -20,7 +20,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'stokes_poiseuille_flow'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 [screen-options]

--- a/test/input_files/stokes_poiseuille_flow_parsed_viscosity_input.in
+++ b/test/input_files/stokes_poiseuille_flow_parsed_viscosity_input.in
@@ -20,7 +20,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'stokes_poiseuille_flow_parsed_viscosity'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 [screen-options]

--- a/test/input_files/stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity_input.in
+++ b/test/input_files/stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity_input.in
@@ -35,7 +35,7 @@
 [vis-options]
    output_vis = 'true'
    vis_output_file_prefix = 'stokes_poiseuille_flow_parsed_viscosity_parsed_conductivity'
-   output_format = 'xdr'
+   output_format = 'xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/suspended_cable_test.in
+++ b/test/input_files/suspended_cable_test.in
@@ -97,7 +97,7 @@ vis_output_file_prefix = 'cable'
 
 output_residual = 'false' 
 
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 []
 
 # Options for print info to the screen

--- a/test/input_files/thermally_driven_3d_flow.in
+++ b/test/input_files/thermally_driven_3d_flow.in
@@ -25,7 +25,7 @@ relative_step_tolerance = 1.0e-10
 [vis-options]
 output_vis = false
 vis_output_file_prefix = thermally_driven_3d_flow
-output_format = 'ExodusII xdr'
+output_format = 'ExodusII xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/input_files/velocity_penalty_drag.in
+++ b/test/input_files/velocity_penalty_drag.in
@@ -53,7 +53,7 @@ numerical_jacobian_h = 1.e-10
 [vis-options]
 output_vis = false
 vis_output_file_prefix = convection_cell
-output_format = 'xdr'
+output_format = 'xda.gz'
 
 # Options for print info to the screen
 [screen-options]

--- a/test/regression/multigrid_poisson.sh
+++ b/test/regression/multigrid_poisson.sh
@@ -21,7 +21,7 @@ GOLDDATA="${GRINS_TEST_DATA_DIR}/multigrid_poisson_gold.xdr"
 # Filename to be generated since were running directly through
 # regression_testing_app but want to maintain existing error checking
 # when running app under standard paradigm
-SOLNDATA="multigrid_poisson.xdr"
+SOLNDATA="multigrid_poisson.xda.gz"
 touch $SOLNDATA
 
 # Now run the test part to make sure we're getting the correct thing

--- a/test/regression/multigrid_stokes.sh
+++ b/test/regression/multigrid_stokes.sh
@@ -35,7 +35,7 @@ GOLDDATA="${GRINS_TEST_DATA_DIR}/multigrid_stokes_gold.xdr"
 # Filename to be generated since were running directly through
 # regression_testing_app but want to maintain existing error checking
 # when running app under standard paradigm
-SOLNDATA="multigrid_stokes.xdr"
+SOLNDATA="multigrid_stokes.xda.gz"
 touch $SOLNDATA
 
 # Now run the test part to make sure we're getting the correct thing


### PR DESCRIPTION
The goal of this was to make it easier to debug the many test run
failures I'm seeing ... but instead it looks like I've uncovered a
Heisenbug; this change brings my failure count from "dozens" down to "3"

I don't know if you want to merge this (xda.gz really is about as efficient as xdr and is easier to debug problems with, so it probably is a better choice for test outputs), but I figured it's definitely astonishing enough to point out.  I'm going to be very curious to find out exactly what regressed here, and how it affected so many GRINS tests without hitting failures in libMesh or MOOSE coverage.