### PR TITLE
Libmesh updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ In addition to a C++17 compiler, GRINS requires an up-to-date installation of th
 
 libMesh
 -------
-GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is f27eba2 [PR #3270](https://github.com/libMesh/libmesh/pull/3270), as of GRINS [PR #620](https://github.com/grinsfem/grins/pull/620).
+GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master.
+The current required libMesh master hash is
+f27eba2
+[PR #3270](https://github.com/libMesh/libmesh/pull/3270), as of GRINS
+[PR #620](https://github.com/grinsfem/grins/pull/620).
 GRINS release 0.5.0 can use libMesh versions as old as 0.9.4. Subsequent to
 the 0.5.0 release requires at least libMesh 1.0.0.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In addition to a C++17 compiler, GRINS requires an up-to-date installation of th
 
 libMesh
 -------
-GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is f0def3f [PR #3168](https://github.com/libMesh/libmesh/pull/3168), as of GRINS [PR #611](https://github.com/grinsfem/grins/pull/611).
+GRINS development both drives and is driven by libMesh development. Thus, the required minimum master hash of libMesh may change in GRINS master. The current required libMesh master hash is f27eba2 [PR #3270](https://github.com/libMesh/libmesh/pull/3270), as of GRINS [PR #620](https://github.com/grinsfem/grins/pull/620).
 GRINS release 0.5.0 can use libMesh versions as old as 0.9.4. Subsequent to
 the 0.5.0 release requires at least libMesh 1.0.0.
 

--- a/examples/elastic_sheet/displacement_continuation_solver.C
+++ b/examples/elastic_sheet/displacement_continuation_solver.C
@@ -139,7 +139,7 @@ namespace GRINS
     libMesh::DirichletBoundaries* d_vector = system.get_dof_map().get_dirichlet_boundaries();
 
     // Get the DirichletBoundary we want
-    libMesh::DirichletBoundary* dirichlet = (*d_vector)[_bc_index];
+    libMesh::DirichletBoundary & dirichlet = *(*d_vector)[_bc_index];
 
     // Kill the old FunctionBase object and put in our new one.
     libMesh::FunctionBase<libMesh::Real>* composite_func_ptr = new libMesh::CompositeFunction<libMesh::Real>;
@@ -149,7 +149,7 @@ namespace GRINS
     composite_func.attach_subfunction( libMesh::ConstFunction<libMesh::Real>(displacement), var_idx );
 
     // DirichletBoundary now takes ownership of the pointer
-    dirichlet->f.reset(composite_func_ptr);
+    dirichlet.f.reset(composite_func_ptr);
 
     // Need to reinit system
     equation_system.reinit();

--- a/src/physics/src/multiphysics_sys.C
+++ b/src/physics/src/multiphysics_sys.C
@@ -234,7 +234,7 @@ namespace GRINS
       physics.second->reinit(*this);
 
     // And now reinit the QoI
-    if (this->qoi.size() > 0)
+    if (this->n_qois() > 0)
       {
         libMesh::DifferentiableQoI* diff_qoi = this->get_qoi();
         CompositeQoI* qoi = libMesh::cast_ptr<CompositeQoI*>(diff_qoi);

--- a/src/qoi/include/grins/composite_qoi.h
+++ b/src/qoi/include/grins/composite_qoi.h
@@ -87,7 +87,7 @@ namespace GRINS
     /*!
      * Method to allow QoI to resize libMesh::System storage of QoI computations.
      */
-    virtual void init_qoi( std::vector<libMesh::Number>& sys_qoi ) override;
+    virtual void init_qoi_count( libMesh::System & sys ) override;
 
     virtual void init_context( libMesh::DiffContext& context ) override;
 

--- a/src/qoi/src/composite_qoi.C
+++ b/src/qoi/src/composite_qoi.C
@@ -78,9 +78,9 @@ namespace GRINS
     _qois.push_back(std::move(qoi));
   }
 
-  void CompositeQoI::init_qoi( std::vector<libMesh::Number>& sys_qoi )
+  void CompositeQoI::init_qoi_count( libMesh::System & sys )
   {
-    sys_qoi.resize(_qois.size(), 0.0);
+    sys.init_qois(_qois.size());
   }
 
   void CompositeQoI::init( const GetPot& input, const MultiphysicsSystem& system )

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -287,7 +287,7 @@ namespace GRINS
         std::cout << "Adjoint sensitivities:" << std::endl;
 
         for (unsigned int q=0;
-             q != this->_multiphysics_system->qoi.size(); ++q)
+             q != this->_multiphysics_system->n_qois(); ++q)
           {
             for (unsigned int p=0; p != params.size(); ++p)
               {
@@ -314,7 +314,7 @@ namespace GRINS
         std::cout << "Forward sensitivities:" << std::endl;
 
         for (unsigned int q=0;
-             q != this->_multiphysics_system->qoi.size(); ++q)
+             q != this->_multiphysics_system->n_qois(); ++q)
           {
             for (unsigned int p=0; p != params.size(); ++p)
               {

--- a/src/solver/src/steady_mesh_adaptive_solver.C
+++ b/src/solver/src/steady_mesh_adaptive_solver.C
@@ -116,7 +116,7 @@ namespace GRINS
 
         // Get the global error estimate if you can and are asked to
         if( _error_estimator_options.compute_qoi_error_estimate() )
-          for(unsigned int i = 0; i != context.system->qoi.size(); i++)
+          for(unsigned int i = 0; i != context.system->n_qois(); i++)
             {
               libMesh::AdjointRefinementEstimator* adjoint_ref_error_estimator = libMesh::cast_ptr<libMesh::AdjointRefinementEstimator*>( context.error_estimator.get() );
               std::cout<<"The error estimate for QoI("<<i<<") is: "<<adjoint_ref_error_estimator->get_global_QoI_error_estimate(i)<<std::endl;

--- a/src/solver/src/unsteady_solver.C
+++ b/src/solver/src/unsteady_solver.C
@@ -195,15 +195,15 @@ namespace GRINS
       for (libMesh::DirichletBoundaries::const_iterator
              it = db.begin(); it != db.end(); ++it)
         {
-          const libMesh::DirichletBoundary* bdy = *it;
+          const libMesh::DirichletBoundary & bdy = **it;
 
           // If we have a FEMFunctionBase, we assume nonlinearity
-          if (bdy->f_fem.get())
+          if (bdy.f_fem.get())
             have_nonlinear_dirichlet_bc = true;
 
           // Check for time-dependence of FunctionBase
-          if( bdy->f.get() )
-            if( bdy->f->is_time_dependent() )
+          if( bdy.f.get() )
+            if( bdy.f->is_time_dependent() )
               have_time_dependence = true;
 
           if( have_nonlinear_dirichlet_bc || have_time_dependence )

--- a/test/interface/spectroscopic_test_base.h
+++ b/test/interface/spectroscopic_test_base.h
@@ -46,6 +46,7 @@
 
 // libMesh
 #include "libmesh/getpot.h"
+#include "libmesh/numeric_vector.h"
 
 #include <tuple>
 

--- a/test/regression/generic_solution_regression.C
+++ b/test/regression/generic_solution_regression.C
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
       libMesh::Number gold_qoi = command_line("qois", libMesh::Number(0), n);
 
       libMesh::Number computed_qoi =
-        sim.get_multiphysics_system()->qoi[n];
+        sim.get_multiphysics_system()->get_qoi_value(n);
 
       double error = computed_qoi - gold_qoi;
 


### PR DESCRIPTION
This gets us building again with libMesh master.  Breaks us with old libMesh, though; I wish I had time to think of a smoother upgrade path on the deprecation of direct System::qoi access and the old init_qoi() virtual.