### PR TITLE
Use GhostingFunctor::map_type rather than unordered_map

### DIFF
--- a/src/physics/include/grins/overlapping_fluid_solid_coupling_functor.h
+++ b/src/physics/include/grins/overlapping_fluid_solid_coupling_functor.h
@@ -56,7 +56,7 @@ namespace GRINS
     ( const libMesh::MeshBase::const_element_iterator & range_begin,
       const libMesh::MeshBase::const_element_iterator & range_end,
       libMesh::processor_id_type p,
-      std::unordered_map<const libMesh::Elem *,const libMesh::CouplingMatrix*> & coupled_elements ) override;
+      map_type & coupled_elements ) override;
 
   private:
 

--- a/src/physics/src/overlapping_fluid_solid_coupling_functor.C
+++ b/src/physics/src/overlapping_fluid_solid_coupling_functor.C
@@ -39,7 +39,7 @@ namespace GRINS
     ( const libMesh::MeshBase::const_element_iterator & range_begin,
       const libMesh::MeshBase::const_element_iterator & range_end,
       libMesh::processor_id_type p,
-      std::unordered_map<const libMesh::Elem *,const libMesh::CouplingMatrix*> & coupled_elements )
+      map_type & coupled_elements )
   {
     for( const auto & elem : libMesh::as_range(range_begin,range_end) )
       {


### PR DESCRIPTION
This captures the changes made upstream in libMesh in the API that were made for performance reasons in libMesh/libmesh#3431.