### PR TITLE
Update header, exact solution tols

### DIFF
--- a/src/qoi/src/absorption_coeff.C
+++ b/src/qoi/src/absorption_coeff.C
@@ -45,6 +45,7 @@
 #include "libmesh/fe.h"
 #include "libmesh/elem.h"
 #include "libmesh/fe_interface.h"
+#include "libmesh/libmesh_logging.h"
 
 namespace GRINS
 {

--- a/src/solver/src/simulation.C
+++ b/src/solver/src/simulation.C
@@ -45,6 +45,7 @@
 #include "libmesh/qoi_set.h"
 #include "libmesh/sensitivity_data.h"
 #include "libmesh/enum_xdr_mode.h"
+#include "libmesh/libmesh_logging.h"
 
 namespace GRINS
 {

--- a/src/solver/src/unsteady_mesh_adaptive_solver.C
+++ b/src/solver/src/unsteady_mesh_adaptive_solver.C
@@ -34,6 +34,7 @@
 // libMesh
 #include "libmesh/getpot.h"
 #include "libmesh/error_vector.h"
+#include "libmesh/libmesh_logging.h"
 
 namespace GRINS
 {

--- a/src/solver/src/unsteady_solver.C
+++ b/src/solver/src/unsteady_solver.C
@@ -45,6 +45,7 @@
 #include "libmesh/newmark_solver.h"
 #include "libmesh/function_base.h"
 #include "libmesh/zero_function.h"
+#include "libmesh/libmesh_logging.h"
 
 // C++
 #include <ctime>

--- a/test/exact_soln/convection_diffusion_steady_1d.sh
+++ b/test/exact_soln/convection_diffusion_steady_1d.sh
@@ -14,7 +14,7 @@ ${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app \
                  vars='u' \
                  norms='L2' \
                  tol='1.0e-10' \
-                 u_L2_error='4.1180937619033129e-04' \
+                 u_L2_error='4.862013076677351e-04' \
                  u_exact_soln='x-(1-exp(40*x))/(1-exp(40))' \
                  test_data=$TESTDATA
 

--- a/test/exact_soln/convection_diffusion_unsteady_2d.sh
+++ b/test/exact_soln/convection_diffusion_unsteady_2d.sh
@@ -15,7 +15,7 @@ ${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app \
                  vars='u' \
                  norms='L2' \
                  tol='1.0e-10' \
-                 u_L2_error='6.289317886708677e-03' \
+                 u_L2_error='6.360098052590270e-03' \
                  u_exact_soln='tf:=50*0.025;exp(-((x-0.8*tf-0.2)^2+(y-0.8*tf-0.2)^2)/(0.01*(4.0*tf+1.0)))/(4.0*tf+1.0)' \
                  test_data=$TESTDATA
 

--- a/test/exact_soln/convection_diffusion_unsteady_2d_petsc_diff.sh
+++ b/test/exact_soln/convection_diffusion_unsteady_2d_petsc_diff.sh
@@ -15,7 +15,7 @@ ${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app \
                  vars='u' \
                  norms='L2' \
                  tol='1.0e-10' \
-                 u_L2_error='6.289317886708677e-03' \
+                 u_L2_error='6.360098052654655e-03' \
                  u_exact_soln='tf:=50*0.025;exp(-((x-0.8*tf-0.2)^2+(y-0.8*tf-0.2)^2)/(0.01*(4.0*tf+1.0)))/(4.0*tf+1.0)' \
                  test_data=$TESTDATA
 

--- a/test/exact_soln/generic_exact_solution_testing_app.C
+++ b/test/exact_soln/generic_exact_solution_testing_app.C
@@ -253,6 +253,7 @@ int test_error_norm( libMesh::ExactSolution& exact_sol,
       return_flag = 1;
 
       std::cout << "Tolerance exceeded for generic regression test!" << std::endl
+	        << std::scientific << std::setprecision(15)
                 << "tolerance     = " << tol << std::endl
                 << "norm of error = " << error << std::endl
                 << "exact error   = " << exact_error << std::endl

--- a/test/exact_soln/poisson_periodic_2d_x.sh
+++ b/test/exact_soln/poisson_periodic_2d_x.sh
@@ -21,7 +21,7 @@ ${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app \
   Mesh/Generation/n_elems_x=20 \
   Mesh/Generation/n_elems_y=20 \
   vars='u' norms='L2' tol='1.0e-8' \
-  u_L2_error='0.00349104' u_exact_soln='sin(pi*y)*cos(2*pi*x)' \
+  u_L2_error='3.971781547627663e-03' u_exact_soln='sin(pi*y)*cos(2*pi*x)' \
   test_data=$TESTDATA
 
 # Now remove the test turd

--- a/test/exact_soln/poisson_periodic_2d_y.sh
+++ b/test/exact_soln/poisson_periodic_2d_y.sh
@@ -11,7 +11,7 @@ PETSC_OPTIONS="-ksp_type cg -pc_type bjacobi -sub_pc_type icc"
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT $PETSC_OPTIONS
 
 # Now run the test part to make sure we're getting the correct thing
-${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app --input $INPUT vars='u' norms='L2' tol='1.0e-8' u_L2_error='0.00349104' u_exact_soln='sin(pi*x)*cos(2*pi*y)' test_data=$TESTDATA
+${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app --input $INPUT vars='u' norms='L2' tol='1.0e-8' u_L2_error='3.971781547627699e-03' u_exact_soln='sin(pi*x)*cos(2*pi*y)' test_data=$TESTDATA
 
 # Now remove the test turd
 rm $TESTDATA

--- a/test/exact_soln/poisson_periodic_3d_xy.sh
+++ b/test/exact_soln/poisson_periodic_3d_xy.sh
@@ -11,7 +11,7 @@ PETSC_OPTIONS="-ksp_type cg -pc_type bjacobi -sub_pc_type icc"
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT $PETSC_OPTIONS
 
 # Now run the test part to make sure we're getting the correct thing
-${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app --input $INPUT vars='u' norms='L2' tol='1.0e-8' u_L2_error='0.0106696' u_exact_soln='sin(pi*z)*cos(2*pi*x)*cos(2*pi*y)' test_data=$TESTDATA
+${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app --input $INPUT vars='u' norms='L2' tol='1.0e-8' u_L2_error='1.300696876215465e-02' u_exact_soln='sin(pi*z)*cos(2*pi*x)*cos(2*pi*y)' test_data=$TESTDATA
 
 # Now remove the test turd
 rm $TESTDATA

--- a/test/exact_soln/poisson_periodic_3d_xz.sh
+++ b/test/exact_soln/poisson_periodic_3d_xz.sh
@@ -11,7 +11,7 @@ PETSC_OPTIONS="-ksp_type cg -pc_type bjacobi -sub_pc_type icc"
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT $PETSC_OPTIONS
 
 # Now run the test part to make sure we're getting the correct thing
-${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app --input $INPUT vars='u' norms='L2' tol='1.0e-8' u_L2_error='0.0106696' u_exact_soln='sin(pi*y)*cos(2*pi*x)*cos(2*pi*z)' test_data=$TESTDATA
+${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app --input $INPUT vars='u' norms='L2' tol='1.0e-8' u_L2_error='1.300696876215465e-02' u_exact_soln='sin(pi*y)*cos(2*pi*x)*cos(2*pi*z)' test_data=$TESTDATA
 
 # Now remove the test turd
 rm $TESTDATA

--- a/test/exact_soln/poisson_periodic_3d_yz.sh
+++ b/test/exact_soln/poisson_periodic_3d_yz.sh
@@ -11,7 +11,7 @@ PETSC_OPTIONS="-ksp_type cg -pc_type bjacobi -sub_pc_type icc"
 ${LIBMESH_RUN:-} ${GRINS_BUILDSRC_DIR}/grins $INPUT $PETSC_OPTIONS
 
 # Now run the test part to make sure we're getting the correct thing
-${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app --input $INPUT vars='u' norms='L2' tol='1.0e-8' u_L2_error='0.0106696' u_exact_soln='sin(pi*x)*cos(2*pi*z)*cos(2*pi*y)' test_data=$TESTDATA
+${LIBMESH_RUN:-} ${GRINS_TEST_DIR}/generic_exact_solution_testing_app --input $INPUT vars='u' norms='L2' tol='1.0e-8' u_L2_error='1.300696876215465e-02' u_exact_soln='sin(pi*x)*cos(2*pi*z)*cos(2*pi*y)' test_data=$TESTDATA
 
 # Now remove the test turd
 rm $TESTDATA


### PR DESCRIPTION
Some header cleanup upstream in libmesh we needed to account for in 7e3d4d51b25d43444bcb427eeb8fba21af8d80a2.

We also update some exact solution tolerances due to update libMesh/libmesh@e8cec186f9206db4318ae50315e695d3413c0d9c which updated the default quadrature order in the exact solution error estimation. (`git bisect run` is soooooo satisfying when it works)

This now gets us passing all tests except the turbulence one, which is known in #622.